### PR TITLE
feat(ux): add decision completeness indicator — progress ring, tab badge, and results warning

### DIFF
--- a/src/__tests__/completeness.test.ts
+++ b/src/__tests__/completeness.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for the completeness calculation utility.
+ */
+
+import { describe, it, expect } from "vitest";
+import { computeCompleteness } from "@/lib/completeness";
+import type { Decision } from "@/lib/types";
+
+function makeDecision(
+  optionCount: number,
+  criterionCount: number,
+  filledScores: Record<string, Record<string, number>> = {}
+): Decision {
+  const options = Array.from({ length: optionCount }, (_, i) => ({
+    id: `opt-${i}`,
+    name: `Option ${i}`,
+  }));
+  const criteria = Array.from({ length: criterionCount }, (_, i) => ({
+    id: `crit-${i}`,
+    name: `Criterion ${i}`,
+    weight: Math.round(100 / Math.max(criterionCount, 1)),
+    type: "benefit" as const,
+  }));
+  return {
+    id: "test",
+    title: "Test Decision",
+    options,
+    criteria,
+    scores: filledScores,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+describe("computeCompleteness", () => {
+  it("returns 100% blue when no options or criteria", () => {
+    const result = computeCompleteness(makeDecision(0, 0));
+    expect(result).toEqual({
+      filled: 0,
+      total: 0,
+      ratio: 1,
+      percent: 100,
+      tier: "blue",
+    });
+  });
+
+  it("returns 0% red when all scores are 0", () => {
+    const result = computeCompleteness(makeDecision(2, 3));
+    expect(result.filled).toBe(0);
+    expect(result.total).toBe(6);
+    expect(result.ratio).toBe(0);
+    expect(result.percent).toBe(0);
+    expect(result.tier).toBe("red");
+  });
+
+  it("returns 100% blue when all scores are > 0", () => {
+    const scores: Record<string, Record<string, number>> = {
+      "opt-0": { "crit-0": 5, "crit-1": 3 },
+      "opt-1": { "crit-0": 7, "crit-1": 2 },
+    };
+    const result = computeCompleteness(makeDecision(2, 2, scores));
+    expect(result.filled).toBe(4);
+    expect(result.total).toBe(4);
+    expect(result.ratio).toBe(1);
+    expect(result.percent).toBe(100);
+    expect(result.tier).toBe("blue");
+  });
+
+  it("returns correct ratio for partial completion", () => {
+    const scores: Record<string, Record<string, number>> = {
+      "opt-0": { "crit-0": 5 },
+      // opt-1 scores all missing → 0
+    };
+    const result = computeCompleteness(makeDecision(2, 2, scores));
+    expect(result.filled).toBe(1);
+    expect(result.total).toBe(4);
+    expect(result.ratio).toBe(0.25);
+    expect(result.percent).toBe(25);
+    expect(result.tier).toBe("red");
+  });
+
+  it("assigns tier 'red' when ratio < 0.3", () => {
+    // 1/4 = 0.25
+    const scores = { "opt-0": { "crit-0": 1 } };
+    const result = computeCompleteness(makeDecision(2, 2, scores));
+    expect(result.tier).toBe("red");
+  });
+
+  it("assigns tier 'yellow' when ratio >= 0.3 and <= 0.7", () => {
+    // 2/4 = 0.5
+    const scores = { "opt-0": { "crit-0": 1, "crit-1": 2 } };
+    const result = computeCompleteness(makeDecision(2, 2, scores));
+    expect(result.tier).toBe("yellow");
+  });
+
+  it("assigns tier 'green' when ratio > 0.7 and < 1", () => {
+    // 3/4 = 0.75
+    const scores = {
+      "opt-0": { "crit-0": 1, "crit-1": 2 },
+      "opt-1": { "crit-0": 3 },
+    };
+    const result = computeCompleteness(makeDecision(2, 2, scores));
+    expect(result.tier).toBe("green");
+  });
+
+  it("assigns tier 'blue' when ratio = 1", () => {
+    const scores = {
+      "opt-0": { "crit-0": 1, "crit-1": 2 },
+      "opt-1": { "crit-0": 3, "crit-1": 4 },
+    };
+    const result = computeCompleteness(makeDecision(2, 2, scores));
+    expect(result.tier).toBe("blue");
+  });
+
+  it("handles missing option rows in scores gracefully", () => {
+    // scores object has no entries at all
+    const result = computeCompleteness(makeDecision(3, 3));
+    expect(result.filled).toBe(0);
+    expect(result.total).toBe(9);
+  });
+
+  it("rounds percent to nearest integer", () => {
+    // 1/3 = 0.333... → 33%
+    const scores = { "opt-0": { "crit-0": 5 } };
+    const result = computeCompleteness(makeDecision(1, 3, scores));
+    expect(result.percent).toBe(33);
+  });
+
+  it("treats score of exactly 0 as unfilled", () => {
+    const scores = { "opt-0": { "crit-0": 0 } };
+    const result = computeCompleteness(makeDecision(1, 1, scores));
+    expect(result.filled).toBe(0);
+  });
+
+  it("treats score > 0 as filled", () => {
+    const scores = { "opt-0": { "crit-0": 1 } };
+    const result = computeCompleteness(makeDecision(1, 1, scores));
+    expect(result.filled).toBe(1);
+  });
+});

--- a/src/__tests__/components/ResultsView.test.tsx
+++ b/src/__tests__/components/ResultsView.test.tsx
@@ -7,6 +7,7 @@ import { screen } from "@testing-library/react";
 import { renderWithProviders } from "../test-utils";
 import { ResultsView } from "@/components/ResultsView";
 import type { ValidationResult } from "@/hooks/useValidation";
+import type { CompletenessResult } from "@/lib/completeness";
 
 // Mock lazy-loaded ScoreChart
 vi.mock("@/components/ScoreChart", () => ({
@@ -33,6 +34,15 @@ const invalidResult: ValidationResult = {
 
 const onSwitchToBuilder = vi.fn();
 
+/** Default full-completion result for tests (demo data has non-zero scores). */
+const fullCompleteness: CompletenessResult = {
+  filled: 20,
+  total: 20,
+  ratio: 1,
+  percent: 100,
+  tier: "blue",
+};
+
 beforeEach(() => {
   localStorage.clear();
   onSwitchToBuilder.mockClear();
@@ -41,14 +51,22 @@ beforeEach(() => {
 describe("ResultsView", () => {
   it("renders rankings section", () => {
     renderWithProviders(
-      <ResultsView validation={validResult} onSwitchToBuilder={onSwitchToBuilder} />
+      <ResultsView
+        validation={validResult}
+        completeness={fullCompleteness}
+        onSwitchToBuilder={onSwitchToBuilder}
+      />
     );
     expect(screen.getByText("Rankings")).toBeInTheDocument();
   });
 
   it("renders ranked option cards", () => {
     renderWithProviders(
-      <ResultsView validation={validResult} onSwitchToBuilder={onSwitchToBuilder} />
+      <ResultsView
+        validation={validResult}
+        completeness={fullCompleteness}
+        onSwitchToBuilder={onSwitchToBuilder}
+      />
     );
     // Demo data should produce ranked results; the #1 option should have "Winner" badge
     expect(screen.getByText("Winner")).toBeInTheDocument();
@@ -56,28 +74,44 @@ describe("ResultsView", () => {
 
   it("renders export JSON button", () => {
     renderWithProviders(
-      <ResultsView validation={validResult} onSwitchToBuilder={onSwitchToBuilder} />
+      <ResultsView
+        validation={validResult}
+        completeness={fullCompleteness}
+        onSwitchToBuilder={onSwitchToBuilder}
+      />
     );
     expect(screen.getByRole("button", { name: /export.*json/i })).toBeInTheDocument();
   });
 
   it("renders share link button", () => {
     renderWithProviders(
-      <ResultsView validation={validResult} onSwitchToBuilder={onSwitchToBuilder} />
+      <ResultsView
+        validation={validResult}
+        completeness={fullCompleteness}
+        onSwitchToBuilder={onSwitchToBuilder}
+      />
     );
     expect(screen.getByRole("button", { name: /copy share link/i })).toBeInTheDocument();
   });
 
   it("renders Top Drivers section", () => {
     renderWithProviders(
-      <ResultsView validation={validResult} onSwitchToBuilder={onSwitchToBuilder} />
+      <ResultsView
+        validation={validResult}
+        completeness={fullCompleteness}
+        onSwitchToBuilder={onSwitchToBuilder}
+      />
     );
     expect(screen.getByText("Top Drivers")).toBeInTheDocument();
   });
 
   it("renders Explain This Result section", () => {
     renderWithProviders(
-      <ResultsView validation={validResult} onSwitchToBuilder={onSwitchToBuilder} />
+      <ResultsView
+        validation={validResult}
+        completeness={fullCompleteness}
+        onSwitchToBuilder={onSwitchToBuilder}
+      />
     );
     expect(screen.getByText("Explain This Result")).toBeInTheDocument();
     expect(screen.getByText(/how scoring works/i)).toBeInTheDocument();
@@ -85,7 +119,11 @@ describe("ResultsView", () => {
 
   it("shows validation guard when invalid", () => {
     renderWithProviders(
-      <ResultsView validation={invalidResult} onSwitchToBuilder={onSwitchToBuilder} />
+      <ResultsView
+        validation={invalidResult}
+        completeness={fullCompleteness}
+        onSwitchToBuilder={onSwitchToBuilder}
+      />
     );
     expect(screen.getByText(/fix these issues/i)).toBeInTheDocument();
     expect(screen.getByText("Decision title is required")).toBeInTheDocument();
@@ -94,7 +132,11 @@ describe("ResultsView", () => {
 
   it("Go to Builder button fires callback", async () => {
     const { user } = renderWithProviders(
-      <ResultsView validation={invalidResult} onSwitchToBuilder={onSwitchToBuilder} />
+      <ResultsView
+        validation={invalidResult}
+        completeness={fullCompleteness}
+        onSwitchToBuilder={onSwitchToBuilder}
+      />
     );
     await user.click(screen.getByRole("button", { name: /go to builder/i }));
     expect(onSwitchToBuilder).toHaveBeenCalledTimes(1);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@
 
 "use client";
 
-import { useState, useEffect, useCallback, useRef, useSyncExternalStore } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef, useSyncExternalStore } from "react";
 import { AnnouncerProvider, useAnnounce } from "@/components/Announcer";
 import { DecisionProvider, useDecision } from "@/components/DecisionProvider";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
@@ -19,6 +19,7 @@ import { MigrationBanner } from "@/components/MigrationBanner";
 import { DecisionSkeleton } from "@/components/DecisionSkeleton";
 import { ImportModal } from "@/components/ImportModal";
 import { useValidation } from "@/hooks/useValidation";
+import { computeCompleteness } from "@/lib/completeness";
 import {
   Settings2,
   BarChart3,
@@ -64,6 +65,7 @@ function AppContent() {
   const announce = useAnnounce();
   const { decision, isLoading, undo, redo, loadDecision } = useDecision();
   const validation = useValidation(decision);
+  const completeness = useMemo(() => computeCompleteness(decision), [decision]);
   const auth = useAuth();
 
   // ── Global drag-and-drop for file import ──────────────────
@@ -330,6 +332,23 @@ function AppContent() {
                     {validation.errorCount}
                   </span>
                 )}
+                {tab.id === "results" &&
+                  completeness.total > 0 &&
+                  (completeness.percent === 100 ? (
+                    <span
+                      className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-blue-500 text-[10px] font-bold text-white px-1"
+                      title="All scores filled"
+                    >
+                      ✓
+                    </span>
+                  ) : completeness.percent < 50 ? (
+                    <span
+                      className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-amber-500 text-[10px] font-bold text-white px-1"
+                      title={`${completeness.percent}% of scores filled`}
+                    >
+                      ⚠
+                    </span>
+                  ) : null)}
               </button>
             ))}
           </nav>
@@ -363,7 +382,11 @@ function AppContent() {
           aria-labelledby="tab-results"
           className={activeTab === "results" ? "" : "hidden"}
         >
-          <ResultsView validation={validation} onSwitchToBuilder={() => setActiveTab("builder")} />
+          <ResultsView
+            validation={validation}
+            completeness={completeness}
+            onSwitchToBuilder={() => setActiveTab("builder")}
+          />
         </div>
         <div
           id="panel-sensitivity"

--- a/src/components/CompletionRing.tsx
+++ b/src/components/CompletionRing.tsx
@@ -1,0 +1,91 @@
+/**
+ * CompletionRing — SVG circular progress indicator showing score-matrix
+ * completeness as a fraction, percentage, and colour-coded ring.
+ *
+ * Pure presentational component — all data comes via props.
+ *
+ * The ring is animated with a CSS transition on `stroke-dashoffset`.
+ */
+
+"use client";
+
+import { memo } from "react";
+import type { CompletenessResult } from "@/lib/completeness";
+import { tierStrokeColour, tierTextColour } from "@/lib/completeness";
+
+interface CompletionRingProps {
+  completeness: CompletenessResult;
+  /** Diameter of the ring in pixels. @default 80 */
+  size?: number;
+}
+
+export const CompletionRing = memo(function CompletionRing({
+  completeness,
+  size = 80,
+}: CompletionRingProps) {
+  const { filled, total, percent, tier } = completeness;
+
+  const strokeWidth = 6;
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference * (1 - completeness.ratio);
+
+  return (
+    <div className="flex items-center gap-4">
+      {/* SVG ring */}
+      <div className="relative flex-shrink-0" style={{ width: size, height: size }}>
+        <svg
+          width={size}
+          height={size}
+          viewBox={`0 0 ${size} ${size}`}
+          className="-rotate-90"
+          aria-hidden="true"
+        >
+          {/* Background track */}
+          <circle
+            cx={size / 2}
+            cy={size / 2}
+            r={radius}
+            fill="none"
+            strokeWidth={strokeWidth}
+            className="stroke-gray-200 dark:stroke-gray-700"
+          />
+          {/* Progress arc */}
+          <circle
+            cx={size / 2}
+            cy={size / 2}
+            r={radius}
+            fill="none"
+            strokeWidth={strokeWidth}
+            strokeLinecap="round"
+            strokeDasharray={circumference}
+            strokeDashoffset={offset}
+            className={`${tierStrokeColour[tier]} transition-[stroke-dashoffset] duration-500 ease-out`}
+          />
+        </svg>
+        {/* Centred percentage */}
+        <span
+          className={`absolute inset-0 flex items-center justify-center text-sm font-semibold ${tierTextColour[tier]}`}
+        >
+          {percent}%
+        </span>
+      </div>
+
+      {/* Label text */}
+      <div>
+        <p
+          className={`text-sm font-medium ${tierTextColour[tier]}`}
+          role="status"
+          aria-live="polite"
+        >
+          {filled}/{total} scores filled
+        </p>
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          {percent === 100
+            ? "All scores filled — results are fully informed"
+            : "Fill all scores for the most accurate results"}
+        </p>
+      </div>
+    </div>
+  );
+});

--- a/src/components/DecisionBuilder.tsx
+++ b/src/components/DecisionBuilder.tsx
@@ -10,7 +10,9 @@ import { showToast } from "./Toast";
 import { formatRelativeTime } from "@/lib/utils";
 import type { CriterionType } from "@/lib/types";
 import type { ValidationResult } from "@/hooks/useValidation";
-import { useCallback, useRef } from "react";
+import { useCallback, useMemo, useRef } from "react";
+import { computeCompleteness } from "@/lib/completeness";
+import { CompletionRing } from "./CompletionRing";
 
 interface DecisionBuilderProps {
   validation: ValidationResult;
@@ -35,6 +37,7 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
   } = useDecision();
 
   const gridRef = useRef<HTMLTableElement>(null);
+  const completeness = useMemo(() => computeCompleteness(decision), [decision]);
 
   /** Arrow-key navigation within the score matrix (WAI-ARIA grid pattern) */
   const handleGridKeyDown = useCallback(
@@ -467,6 +470,13 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
             </tbody>
           </table>
         </div>
+
+        {/* Completion progress ring */}
+        {completeness.total > 0 && (
+          <div className="mt-4">
+            <CompletionRing completeness={completeness} />
+          </div>
+        )}
       </section>
     </div>
   );

--- a/src/components/ResultsView.tsx
+++ b/src/components/ResultsView.tsx
@@ -14,23 +14,27 @@ import {
   FileText,
   AlertCircle,
   AlertTriangle,
+  X,
 } from "lucide-react";
 import { useState, lazy, Suspense } from "react";
 import { buildShareLink } from "@/lib/share";
 import { encodeDecisionToUrl } from "@/lib/utils";
 import { normalizeWeights } from "@/lib/scoring";
 import type { ValidationResult } from "@/hooks/useValidation";
+import type { CompletenessResult } from "@/lib/completeness";
 
 const ScoreChart = lazy(() => import("./ScoreChart").then((m) => ({ default: m.ScoreChart })));
 
 interface ResultsViewProps {
   validation: ValidationResult;
+  completeness: CompletenessResult;
   onSwitchToBuilder: () => void;
 }
 
-export function ResultsView({ validation, onSwitchToBuilder }: ResultsViewProps) {
+export function ResultsView({ validation, completeness, onSwitchToBuilder }: ResultsViewProps) {
   const { decision, results } = useDecision();
   const [shareStatus, setShareStatus] = useState<string>("");
+  const [bannerDismissed, setBannerDismissed] = useState(false);
 
   if (results.optionResults.length === 0) {
     return (
@@ -69,6 +73,9 @@ export function ResultsView({ validation, onSwitchToBuilder }: ResultsViewProps)
   }
 
   const maxScore = Math.max(...results.optionResults.map((r) => r.totalScore));
+
+  const defaultCount = completeness.total - completeness.filled;
+  const showIncompleteBanner = defaultCount > 0 && !bannerDismissed;
 
   const handleExportJson = () => {
     const data = {
@@ -138,6 +145,36 @@ export function ResultsView({ validation, onSwitchToBuilder }: ResultsViewProps)
               <span className="font-medium">Warning:</span>{" "}
               {validation.warnings.map((w) => w.message).join(". ")}.
             </div>
+          </div>
+        </div>
+      )}
+
+      {/* Incomplete scores banner */}
+      {showIncompleteBanner && (
+        <div className="rounded-lg border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 px-4 py-3">
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex items-start gap-2">
+              <AlertTriangle className="h-4 w-4 text-amber-600 shrink-0 mt-0.5" />
+              <div className="text-sm text-amber-700 dark:text-amber-300">
+                <span className="font-medium">
+                  {defaultCount} of {completeness.total} scores are at the default value (0).
+                </span>{" "}
+                Results may not reflect your actual evaluation.
+                <button
+                  onClick={onSwitchToBuilder}
+                  className="ml-2 inline-flex items-center gap-1 text-sm font-medium text-amber-800 dark:text-amber-200 underline hover:no-underline focus:outline-none focus:ring-2 focus:ring-amber-500 rounded"
+                >
+                  Fill remaining scores &rarr;
+                </button>
+              </div>
+            </div>
+            <button
+              onClick={() => setBannerDismissed(true)}
+              className="flex-shrink-0 rounded p-1 text-amber-600 hover:bg-amber-100 dark:hover:bg-amber-800/30 focus:outline-none focus:ring-2 focus:ring-amber-500"
+              aria-label="Dismiss incomplete scores warning"
+            >
+              <X className="h-4 w-4" />
+            </button>
           </div>
         </div>
       )}

--- a/src/lib/completeness.ts
+++ b/src/lib/completeness.ts
@@ -1,0 +1,101 @@
+/**
+ * Completeness calculation — pure functions to determine how "complete"
+ * a decision's score matrix is.
+ *
+ * A cell is considered "filled" when its value is > 0.
+ * (Future: when per-score confidence / null-score (#76) is implemented,
+ * the definition can change to "explicitly set".)
+ */
+
+import type { Decision } from "./types";
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
+export interface CompletenessResult {
+  /** Number of score cells that have been filled (> 0). */
+  filled: number;
+  /** Total number of score cells (options × criteria). */
+  total: number;
+  /** Fraction 0–1 representing  filled / total. 1 when total is 0. */
+  ratio: number;
+  /** Integer percentage 0–100. */
+  percent: number;
+  /** Colour tier based on completion ratio. */
+  tier: "red" | "yellow" | "green" | "blue";
+}
+
+/* ------------------------------------------------------------------ */
+/*  Tier thresholds                                                    */
+/* ------------------------------------------------------------------ */
+
+function tierFromRatio(ratio: number): CompletenessResult["tier"] {
+  if (ratio >= 1) return "blue";
+  if (ratio > 0.7) return "green";
+  if (ratio >= 0.3) return "yellow";
+  return "red";
+}
+
+/* ------------------------------------------------------------------ */
+/*  Core computation                                                   */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Compute the score-matrix completeness for a decision.
+ *
+ * Edge cases:
+ * - 0 options or 0 criteria → total = 0, ratio = 1, tier = blue (nothing to fill)
+ * - All scores 0 → ratio = 0, tier = red
+ */
+export function computeCompleteness(decision: Decision): CompletenessResult {
+  const { options, criteria, scores } = decision;
+  const total = options.length * criteria.length;
+
+  if (total === 0) {
+    return { filled: 0, total: 0, ratio: 1, percent: 100, tier: "blue" };
+  }
+
+  let filled = 0;
+  for (const opt of options) {
+    const row = scores[opt.id];
+    if (!row) continue;
+    for (const crit of criteria) {
+      if ((row[crit.id] ?? 0) > 0) filled++;
+    }
+  }
+
+  const ratio = filled / total;
+  const percent = Math.round(ratio * 100);
+  const tier = tierFromRatio(ratio);
+
+  return { filled, total, ratio, percent, tier };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Tier → Tailwind colour maps (used by UI components)                */
+/* ------------------------------------------------------------------ */
+
+/** Stroke colour for the SVG progress ring. */
+export const tierStrokeColour: Record<CompletenessResult["tier"], string> = {
+  red: "stroke-red-500",
+  yellow: "stroke-amber-400",
+  green: "stroke-green-500",
+  blue: "stroke-blue-500",
+};
+
+/** Text colour matching the tier. */
+export const tierTextColour: Record<CompletenessResult["tier"], string> = {
+  red: "text-red-600 dark:text-red-400",
+  yellow: "text-amber-600 dark:text-amber-400",
+  green: "text-green-600 dark:text-green-400",
+  blue: "text-blue-600 dark:text-blue-400",
+};
+
+/** Background colour for badges. */
+export const tierBadgeBg: Record<CompletenessResult["tier"], string> = {
+  red: "bg-red-500",
+  yellow: "bg-amber-500",
+  green: "bg-green-500",
+  blue: "bg-blue-500",
+};


### PR DESCRIPTION
## Summary
Adds visual feedback showing how complete a decision's score matrix is, preventing users from relying on mostly-default results.

## Changes Made
| File | Change |
|------|--------|
| \src/lib/completeness.ts\ | **New** — Pure completeness calculator with colour tiers |
| \src/components/CompletionRing.tsx\ | **New** — SVG circular progress ring with animated transitions |
| \src/components/DecisionBuilder.tsx\ | **Modified** — Added CompletionRing below score matrix |
| \src/app/page.tsx\ | **Modified** — Added completeness badge on Results tab (⚠/✓) |
| \src/components/ResultsView.tsx\ | **Modified** — Added dismissible incomplete-scores banner |
| \src/__tests__/completeness.test.ts\ | **New** — 12 unit tests for computeCompleteness |
| \src/__tests__/components/ResultsView.test.tsx\ | **Modified** — Added completeness prop |

## Features
1. **Builder tab**: Progress ring below score matrix showing X/Y scores filled with % and colour
2. **Results tab badge**: ⚠ when < 50% scores filled, ✓ when 100% filled
3. **Results banner**: Dismissible warning with fill count and link back to Builder
4. **Colour tiers**: red (< 30%) → yellow (30-70%) → green (> 70%) → blue (100%)

## Testing
- 12 new unit tests covering all tiers, edge cases, rounding, zero-handling
- 302 total tests passing (up from 290)
- TypeScript: zero errors
- ESLint: zero errors
- Build: clean production build

Closes #65