### PR TITLE
feat(ux): first-run onboarding flow — auto-navigate to Results, 3-step coachmark tour

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -10,6 +10,10 @@ import AxeBuilder from "@axe-core/playwright";
 
 test.describe("Accessibility — axe-core scans", () => {
   test.beforeEach(async ({ page }) => {
+    // Set onboarding flag before navigating so the tour doesn't interfere with tests
+    await page.addInitScript(() => {
+      localStorage.setItem("decisionos:onboarded", "true");
+    });
     await page.goto("/");
     // Wait for the app to fully hydrate
     await expect(page.getByRole("heading", { name: "Decision OS" })).toBeVisible();

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -6,6 +6,10 @@ import { test, expect } from "@playwright/test";
 
 test.describe("Decision OS — Smoke Tests", () => {
   test.beforeEach(async ({ page }) => {
+    // Set onboarding flag before navigating so the tour doesn't interfere with tests
+    await page.addInitScript(() => {
+      localStorage.setItem("decisionos:onboarded", "true");
+    });
     await page.goto("/");
     // Wait for hydration
     await page.waitForSelector('h1:has-text("Decision OS")');

--- a/e2e/visual.spec.ts
+++ b/e2e/visual.spec.ts
@@ -17,6 +17,10 @@ test.describe("Visual Regression", () => {
   test.skip(({ browserName }) => browserName !== "chromium", "Visual tests run only on Chromium");
 
   test.beforeEach(async ({ page }) => {
+    // Set onboarding flag before navigating so the tour doesn't interfere with tests
+    await page.addInitScript(() => {
+      localStorage.setItem("decisionos:onboarded", "true");
+    });
     await page.goto("/");
     // Wait for hydration + content to stabilize
     await page.waitForSelector('h1:has-text("Decision OS")');

--- a/src/__tests__/onboarding.test.tsx
+++ b/src/__tests__/onboarding.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * Tests for the onboarding hook and CoachmarkOverlay component.
+ *
+ * Covers: state machine transitions, localStorage persistence, dismiss/restart,
+ * share URL skip, coachmark rendering, keyboard dismiss, focus trap.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useOnboarding } from "@/hooks/useOnboarding";
+import { CoachmarkOverlay } from "@/components/CoachmarkOverlay";
+
+const ONBOARDED_KEY = "decisionos:onboarded";
+
+beforeEach(() => {
+  localStorage.clear();
+  // Reset URL to / (no ?share params)
+  window.history.replaceState({}, "", "/");
+});
+
+// ─── useOnboarding hook ──────────────────────────────────────────
+
+describe("useOnboarding", () => {
+  it("starts on step1 for first-time visitors", () => {
+    const { result } = renderHook(() => useOnboarding());
+    expect(result.current.step).toBe("step1");
+    expect(result.current.isOnboarded).toBe(false);
+  });
+
+  it("starts idle for returning users", () => {
+    localStorage.setItem(ONBOARDED_KEY, "true");
+    const { result } = renderHook(() => useOnboarding());
+    expect(result.current.step).toBe("idle");
+    expect(result.current.isOnboarded).toBe(true);
+  });
+
+  it("advances step1 → step2 → step3 → idle", () => {
+    const { result } = renderHook(() => useOnboarding());
+    expect(result.current.step).toBe("step1");
+
+    act(() => result.current.next());
+    expect(result.current.step).toBe("step2");
+
+    act(() => result.current.next());
+    expect(result.current.step).toBe("step3");
+
+    act(() => result.current.next());
+    expect(result.current.step).toBe("idle");
+    expect(result.current.isOnboarded).toBe(true);
+  });
+
+  it("sets localStorage on completion", () => {
+    const { result } = renderHook(() => useOnboarding());
+    act(() => result.current.next()); // → step2
+    act(() => result.current.next()); // → step3
+    act(() => result.current.next()); // → idle
+    expect(localStorage.getItem(ONBOARDED_KEY)).toBe("true");
+  });
+
+  it("dismiss() sets idle and persists", () => {
+    const { result } = renderHook(() => useOnboarding());
+    expect(result.current.step).toBe("step1");
+
+    act(() => result.current.dismiss());
+    expect(result.current.step).toBe("idle");
+    expect(result.current.isOnboarded).toBe(true);
+    expect(localStorage.getItem(ONBOARDED_KEY)).toBe("true");
+  });
+
+  it("restart() re-triggers from step1", () => {
+    localStorage.setItem(ONBOARDED_KEY, "true");
+    const { result } = renderHook(() => useOnboarding());
+    expect(result.current.step).toBe("idle");
+
+    act(() => result.current.restart());
+    expect(result.current.step).toBe("step1");
+  });
+
+  it("skips onboarding when ?share= is in URL", () => {
+    window.history.replaceState({}, "", "/?share=abc123");
+    const { result } = renderHook(() => useOnboarding());
+    expect(result.current.step).toBe("idle");
+  });
+});
+
+// ─── CoachmarkOverlay component ──────────────────────────────────
+
+describe("CoachmarkOverlay", () => {
+  // Create mock target elements for positioning
+  beforeEach(() => {
+    // Add tab buttons that the coachmark targets
+    for (const id of ["tab-results", "tab-builder", "tab-sensitivity"]) {
+      const el = document.createElement("button");
+      el.id = id;
+      el.getBoundingClientRect = () =>
+        ({
+          top: 50,
+          bottom: 90,
+          left: 100,
+          right: 200,
+          width: 100,
+          height: 40,
+          x: 100,
+          y: 50,
+          toJSON: () => {},
+        }) as DOMRect;
+      document.body.appendChild(el);
+    }
+    // Add panel elements
+    for (const id of ["panel-results", "panel-builder", "panel-sensitivity"]) {
+      const el = document.createElement("div");
+      el.id = id;
+      document.body.appendChild(el);
+    }
+  });
+
+  it("renders nothing when step is idle", () => {
+    const { container } = render(
+      <CoachmarkOverlay step="idle" onNext={vi.fn()} onDismiss={vi.fn()} />
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders step 1 with correct content", () => {
+    render(<CoachmarkOverlay step="step1" onNext={vi.fn()} onDismiss={vi.fn()} />);
+    expect(screen.getByText("See Your Decision, Ranked")).toBeInTheDocument();
+    expect(screen.getByTestId("onboarding-step-1")).toBeInTheDocument();
+  });
+
+  it("renders step 2 with correct content", () => {
+    render(<CoachmarkOverlay step="step2" onNext={vi.fn()} onDismiss={vi.fn()} />);
+    expect(screen.getByText("Define Your Decision")).toBeInTheDocument();
+    expect(screen.getByTestId("onboarding-step-2")).toBeInTheDocument();
+  });
+
+  it("renders step 3 with correct content", () => {
+    render(<CoachmarkOverlay step="step3" onNext={vi.fn()} onDismiss={vi.fn()} />);
+    expect(screen.getByText(/Test Your Decision/)).toBeInTheDocument();
+    expect(screen.getByTestId("onboarding-step-3")).toBeInTheDocument();
+  });
+
+  it("calls onNext when Next button is clicked", () => {
+    const onNext = vi.fn();
+    render(<CoachmarkOverlay step="step1" onNext={onNext} onDismiss={vi.fn()} />);
+    fireEvent.click(screen.getByText("Next →"));
+    expect(onNext).toHaveBeenCalledOnce();
+  });
+
+  it('calls onNext with "Get Started!" on step 3', () => {
+    const onNext = vi.fn();
+    render(<CoachmarkOverlay step="step3" onNext={onNext} onDismiss={vi.fn()} />);
+    fireEvent.click(screen.getByText("Get Started! ✓"));
+    expect(onNext).toHaveBeenCalledOnce();
+  });
+
+  it("calls onDismiss when Skip tour is clicked", () => {
+    const onDismiss = vi.fn();
+    render(<CoachmarkOverlay step="step1" onNext={vi.fn()} onDismiss={onDismiss} />);
+    // There are two skip elements (X button + text link)
+    const skipButtons = screen.getAllByText("Skip tour");
+    fireEvent.click(skipButtons[0]);
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("calls onDismiss when backdrop is clicked", () => {
+    const onDismiss = vi.fn();
+    render(<CoachmarkOverlay step="step1" onNext={vi.fn()} onDismiss={onDismiss} />);
+    fireEvent.click(screen.getByTestId("coachmark-backdrop"));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("calls onDismiss when Escape is pressed", async () => {
+    const onDismiss = vi.fn();
+    render(<CoachmarkOverlay step="step1" onNext={vi.fn()} onDismiss={onDismiss} />);
+    // Wait for the card to render (position computed asynchronously)
+    await waitFor(() => expect(screen.getByText("See Your Decision, Ranked")).toBeInTheDocument());
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("has correct ARIA attributes", () => {
+    render(<CoachmarkOverlay step="step1" onNext={vi.fn()} onDismiss={vi.fn()} />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAttribute("aria-label", expect.stringContaining("step 1 of 3"));
+  });
+
+  it("shows step dots with correct count", () => {
+    render(<CoachmarkOverlay step="step2" onNext={vi.fn()} onDismiss={vi.fn()} />);
+    expect(screen.getByText("Step 2 of 3")).toBeInTheDocument();
+  });
+
+  it('renders "Get Started! ✓" button on final step', () => {
+    render(<CoachmarkOverlay step="step3" onNext={vi.fn()} onDismiss={vi.fn()} />);
+    expect(screen.getByText("Get Started! ✓")).toBeInTheDocument();
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,7 +19,9 @@ import { MigrationBanner } from "@/components/MigrationBanner";
 import { DecisionSkeleton } from "@/components/DecisionSkeleton";
 import { ImportModal } from "@/components/ImportModal";
 import { useValidation } from "@/hooks/useValidation";
+import { useOnboarding } from "@/hooks/useOnboarding";
 import { computeCompleteness } from "@/lib/completeness";
+import { CoachmarkOverlay } from "@/components/CoachmarkOverlay";
 import {
   Settings2,
   BarChart3,
@@ -29,6 +31,7 @@ import {
   Keyboard,
   X,
   Upload,
+  HelpCircle,
 } from "lucide-react";
 import { ToastProvider, showToast } from "@/components/Toast";
 import { validateFile, readFileAsText, importFromJson } from "@/lib/import";
@@ -58,7 +61,11 @@ const tabLabels: Record<Tab, string> = {
 const TAB_IDS: Tab[] = ["builder", "results", "sensitivity", "compare", "montecarlo"];
 
 function AppContent() {
-  const [activeTab, setActiveTab] = useState<Tab>("builder");
+  const onboarding = useOnboarding();
+  // First-time visitors start on Results tab (onboarding step 1)
+  const [activeTab, setActiveTab] = useState<Tab>(
+    onboarding.step === "step1" ? "results" : "builder"
+  );
   const [showShortcuts, setShowShortcuts] = useState(false);
   const shortcutTriggerRef = useRef<HTMLButtonElement>(null);
   const modalRef = useRef<HTMLDivElement>(null);
@@ -67,6 +74,21 @@ function AppContent() {
   const validation = useValidation(decision);
   const completeness = useMemo(() => computeCompleteness(decision), [decision]);
   const auth = useAuth();
+
+  // ── Onboarding: tab switching handled in callbacks (no effect) ──
+  const handleOnboardingNext = useCallback(() => {
+    const currentStep = onboarding.step;
+    onboarding.next();
+    // Advance tab to match the next step
+    if (currentStep === "step1") setActiveTab("builder");
+    else if (currentStep === "step2") setActiveTab("sensitivity");
+    else if (currentStep === "step3") setActiveTab("builder"); // end of tour
+  }, [onboarding]);
+
+  const handleOnboardingDismiss = useCallback(() => {
+    onboarding.dismiss();
+    setActiveTab("builder");
+  }, [onboarding]);
 
   // ── Global drag-and-drop for file import ──────────────────
   const [showDropOverlay, setShowDropOverlay] = useState(false);
@@ -416,19 +438,38 @@ function AppContent() {
 
       {/* Footer */}
       <footer className="border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 mt-12 transition-colors">
-        <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8 py-4 text-center text-xs text-gray-500 dark:text-gray-400">
-          Decision OS v{pkg.version} — Open source structured decision-making tool.{" "}
-          <a
-            href="https://github.com/ericsocrat/decision-os"
-            className="text-blue-600 underline hover:no-underline dark:text-blue-400"
-            target="_blank"
-            rel="noopener noreferrer"
+        <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8 py-4 flex items-center justify-center gap-3 text-xs text-gray-500 dark:text-gray-400">
+          <span>
+            Decision OS v{pkg.version} — Open source structured decision-making tool.{" "}
+            <a
+              href="https://github.com/ericsocrat/decision-os"
+              className="text-blue-600 underline hover:no-underline dark:text-blue-400"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              GitHub
+            </a>{" "}
+            | MIT License
+          </span>
+          <button
+            onClick={onboarding.restart}
+            className="inline-flex items-center justify-center h-6 w-6 rounded-full text-gray-400 hover:text-blue-600 hover:bg-gray-100 dark:hover:text-blue-400 dark:hover:bg-gray-700 transition-colors"
+            aria-label="Replay onboarding tour"
+            title="Replay tour"
           >
-            GitHub
-          </a>{" "}
-          | MIT License
+            <HelpCircle className="h-4 w-4" />
+          </button>
         </div>
       </footer>
+
+      {/* Onboarding coachmark overlay */}
+      {onboarding.step !== "idle" && (
+        <CoachmarkOverlay
+          step={onboarding.step}
+          onNext={handleOnboardingNext}
+          onDismiss={handleOnboardingDismiss}
+        />
+      )}
 
       {/* Keyboard Shortcuts Modal */}
       {showShortcuts && (

--- a/src/components/CoachmarkOverlay.tsx
+++ b/src/components/CoachmarkOverlay.tsx
@@ -1,0 +1,245 @@
+/**
+ * CoachmarkOverlay — 3-step onboarding tour with positioned coachmarks.
+ *
+ * Each step highlights a target element and shows a tooltip with an arrow.
+ * Features: focus trap, Escape/outside-click to dismiss, dark mode, responsive.
+ */
+
+"use client";
+
+import { useEffect, useRef, useState, useCallback } from "react";
+import { Target, Pencil, FlaskConical, X } from "lucide-react";
+import type { OnboardingStep } from "@/hooks/useOnboarding";
+
+interface CoachmarkOverlayProps {
+  step: OnboardingStep;
+  onNext: () => void;
+  onDismiss: () => void;
+}
+
+interface StepConfig {
+  targetSelector: string;
+  icon: React.ReactNode;
+  title: string;
+  body: string;
+  button: string;
+}
+
+const STEPS: Record<Exclude<OnboardingStep, "idle">, StepConfig> = {
+  step1: {
+    targetSelector: "#panel-results",
+    icon: <Target className="h-5 w-5 text-blue-500" />,
+    title: "See Your Decision, Ranked",
+    body: "Decision OS scores and ranks your options based on the criteria and weights you define. This demo compares job offers.",
+    button: "Next →",
+  },
+  step2: {
+    targetSelector: "#panel-builder",
+    icon: <Pencil className="h-5 w-5 text-blue-500" />,
+    title: "Define Your Decision",
+    body: "Add options, set criteria, assign weights, and score each option. Try changing a score and watch the results update instantly.",
+    button: "Next →",
+  },
+  step3: {
+    targetSelector: "#panel-sensitivity",
+    icon: <FlaskConical className="h-5 w-5 text-blue-500" />,
+    title: "Test Your Decision\u2019s Robustness",
+    body: "Sensitivity analysis and Monte Carlo simulation show if your top choice holds up under uncertainty.",
+    button: "Get Started! ✓",
+  },
+};
+
+interface Position {
+  top: number;
+  left: number;
+  arrowLeft: number;
+}
+
+export function CoachmarkOverlay({ step, onNext, onDismiss }: CoachmarkOverlayProps) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const [position, setPosition] = useState<Position | null>(null);
+
+  if (step === "idle") return null;
+
+  const config = STEPS[step];
+  const stepNum = step === "step1" ? 1 : step === "step2" ? 2 : 3;
+
+  // Position the coachmark relative to the target element's tab button
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const updatePosition = useCallback(() => {
+    // Position relative to the corresponding tab button
+    const tabId =
+      step === "step1" ? "tab-results" : step === "step2" ? "tab-builder" : "tab-sensitivity";
+    const tabEl = document.getElementById(tabId);
+    if (!tabEl) {
+      setPosition(null);
+      return;
+    }
+
+    const rect = tabEl.getBoundingClientRect();
+    const cardWidth = Math.min(360, window.innerWidth - 32);
+
+    // Position below the tab button
+    let left = rect.left + rect.width / 2 - cardWidth / 2;
+    // Clamp to viewport
+    left = Math.max(16, Math.min(left, window.innerWidth - cardWidth - 16));
+
+    const arrowLeft = rect.left + rect.width / 2 - left;
+
+    setPosition({
+      top: rect.bottom + 12 + window.scrollY,
+      left,
+      arrowLeft: Math.max(20, Math.min(arrowLeft, cardWidth - 20)),
+    });
+  }, [step]);
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  useEffect(() => {
+    updatePosition();
+    window.addEventListener("resize", updatePosition);
+    window.addEventListener("scroll", updatePosition, true);
+    return () => {
+      window.removeEventListener("resize", updatePosition);
+      window.removeEventListener("scroll", updatePosition, true);
+    };
+  }, [updatePosition]);
+
+  // Escape key handler — always active while overlay is visible
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onDismiss();
+      }
+    };
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [onDismiss]);
+
+  // Focus trap: focus the card when it appears and trap Tab
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  useEffect(() => {
+    const card = cardRef.current;
+    if (!card) return;
+
+    // Focus the primary action button
+    const btn = card.querySelector<HTMLElement>("[data-coachmark-next]");
+    btn?.focus();
+
+    const handleTrap = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+      const focusable = card.querySelectorAll<HTMLElement>(
+        'button, [href], [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleTrap);
+    return () => document.removeEventListener("keydown", handleTrap);
+  }, [step, position]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50"
+      data-testid={`onboarding-step-${stepNum}`}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Onboarding step ${stepNum} of 3: ${config.title}`}
+    >
+      {/* Semi-transparent backdrop */}
+      <div
+        className="absolute inset-0 bg-black/40 backdrop-blur-[2px]"
+        onClick={onDismiss}
+        data-testid="coachmark-backdrop"
+      />
+
+      {/* Coachmark card */}
+      {position && (
+        <div
+          ref={cardRef}
+          className="absolute w-[calc(100vw-2rem)] max-w-[360px] rounded-xl bg-white dark:bg-gray-800 shadow-2xl border border-gray-200 dark:border-gray-700 p-5 animate-in fade-in slide-in-from-top-2 duration-200"
+          style={{
+            top: position.top,
+            left: position.left,
+          }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* Arrow pointer */}
+          <div
+            className="absolute -top-2 w-4 h-4 rotate-45 bg-white dark:bg-gray-800 border-l border-t border-gray-200 dark:border-gray-700"
+            style={{ left: position.arrowLeft - 8 }}
+          />
+
+          {/* Close button (Skip tour) top-right */}
+          <button
+            onClick={onDismiss}
+            className="absolute top-3 right-3 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+            aria-label="Skip tour"
+          >
+            <X className="h-4 w-4" />
+          </button>
+
+          {/* Content */}
+          <div className="flex items-start gap-3 mb-3">
+            <div className="mt-0.5 shrink-0">{config.icon}</div>
+            <div>
+              <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                {config.title}
+              </h3>
+            </div>
+          </div>
+
+          <p className="text-sm text-gray-600 dark:text-gray-300 leading-relaxed mb-4 pl-8">
+            {config.body}
+          </p>
+
+          {/* Footer: step indicator + actions */}
+          <div className="flex items-center justify-between pl-8">
+            {/* Step dots */}
+            <div className="flex items-center gap-1.5" aria-hidden="true">
+              {[1, 2, 3].map((n) => (
+                <div
+                  key={n}
+                  className={`h-1.5 rounded-full transition-all duration-200 ${
+                    n === stepNum
+                      ? "w-4 bg-blue-600 dark:bg-blue-400"
+                      : n < stepNum
+                        ? "w-1.5 bg-blue-300 dark:bg-blue-600"
+                        : "w-1.5 bg-gray-300 dark:bg-gray-600"
+                  }`}
+                />
+              ))}
+              <span className="sr-only">Step {stepNum} of 3</span>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <button
+                onClick={onDismiss}
+                className="text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+              >
+                Skip tour
+              </button>
+              <button
+                data-coachmark-next
+                onClick={onNext}
+                className="px-4 py-1.5 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
+              >
+                {config.button}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useOnboarding.ts
+++ b/src/hooks/useOnboarding.ts
@@ -1,0 +1,96 @@
+/**
+ * Onboarding state machine hook.
+ *
+ * States: idle | step1 | step2 | step3
+ * On first visit (no localStorage flag), auto-triggers step1.
+ * Persists completion to localStorage so returning users skip the tour.
+ */
+
+import { useState, useCallback } from "react";
+
+const ONBOARDED_KEY = "decisionos:onboarded";
+
+export type OnboardingStep = "idle" | "step1" | "step2" | "step3";
+
+export interface OnboardingState {
+  /** Current step of the tour (idle = not showing) */
+  step: OnboardingStep;
+  /** Whether the user has been previously onboarded */
+  isOnboarded: boolean;
+  /** Advance to the next step; from step3 → dismiss */
+  next: () => void;
+  /** Dismiss the tour entirely */
+  dismiss: () => void;
+  /** Re-trigger the tour from step1 */
+  restart: () => void;
+}
+
+/**
+ * Check if the user has been onboarded (safe for SSR).
+ */
+function getOnboarded(): boolean {
+  if (typeof window === "undefined") return true; // SSR: assume onboarded
+  try {
+    return localStorage.getItem(ONBOARDED_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+/** Check if this is a shared link (skip onboarding). */
+function isShareLink(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return new URLSearchParams(window.location.search).has("share");
+  } catch {
+    return false;
+  }
+}
+
+function setOnboarded(): void {
+  try {
+    localStorage.setItem(ONBOARDED_KEY, "true");
+  } catch {
+    // Storage may be full or blocked
+  }
+}
+
+/** Compute initial onboarding state (lazy initializer for useState). */
+function initOnboarding(): { step: OnboardingStep; isOnboarded: boolean } {
+  const onboarded = getOnboarded();
+  if (onboarded || isShareLink()) {
+    return { step: "idle", isOnboarded: onboarded };
+  }
+  return { step: "step1", isOnboarded: false };
+}
+
+export function useOnboarding(): OnboardingState {
+  const [state, setState] = useState(initOnboarding);
+
+  const next = useCallback(() => {
+    setState((prev) => {
+      switch (prev.step) {
+        case "step1":
+          return { ...prev, step: "step2" as const };
+        case "step2":
+          return { ...prev, step: "step3" as const };
+        case "step3":
+          setOnboarded();
+          return { step: "idle" as const, isOnboarded: true };
+        default:
+          return prev;
+      }
+    });
+  }, []);
+
+  const dismiss = useCallback(() => {
+    setOnboarded();
+    setState({ step: "idle", isOnboarded: true });
+  }, []);
+
+  const restart = useCallback(() => {
+    setState((prev) => ({ ...prev, step: "step1" as const }));
+  }, []);
+
+  return { step: state.step, isOnboarded: state.isOnboarded, next, dismiss, restart };
+}


### PR DESCRIPTION
First-run onboarding: auto-navigate to Results tab, 3-step coachmark tour (Results/Builder/Sensitivity), help button to replay tour, localStorage persistence, E2E test setup updated. 19 new tests, 321 total. Closes #68