### PR TITLE
refactor: remove duplicate lz-string URL encoding — consolidate on share.ts

### DIFF
--- a/src/__tests__/share.test.ts
+++ b/src/__tests__/share.test.ts
@@ -13,7 +13,7 @@ import {
   sharePayloadToDecision,
   compressionRatio,
 } from "@/lib/share";
-import { encodeDecisionToUrl } from "@/lib/utils";
+import { compressToEncodedURIComponent } from "lz-string";
 import type { Decision } from "@/lib/types";
 
 // ---------------------------------------------------------------------------
@@ -178,7 +178,7 @@ describe("encodeShareUrl / decodeShareUrl", () => {
 
   test("produces shorter URLs than raw encoding", () => {
     const compactEncoded = encodeShareUrl(sampleDecision);
-    const rawEncoded = encodeDecisionToUrl(sampleDecision);
+    const rawEncoded = compressToEncodedURIComponent(JSON.stringify(sampleDecision));
 
     expect(compactEncoded.length).toBeLessThan(rawEncoded.length);
   });
@@ -281,7 +281,7 @@ describe("buildShareLink", () => {
 
 describe("compressionRatio", () => {
   test("calculates savings correctly", () => {
-    const rawEncoded = encodeDecisionToUrl(sampleDecision);
+    const rawEncoded = compressToEncodedURIComponent(JSON.stringify(sampleDecision));
     const compactEncoded = encodeShareUrl(sampleDecision);
     const ratio = compressionRatio(rawEncoded, compactEncoded);
 

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -3,13 +3,8 @@
  */
 
 import { describe, it, expect } from "vitest";
-import {
-  generateId,
-  safeJsonParse,
-  encodeDecisionToUrl,
-  decodeDecisionFromUrl,
-  formatRelativeTime,
-} from "@/lib/utils";
+import { generateId, safeJsonParse, decodeDecisionFromUrl, formatRelativeTime } from "@/lib/utils";
+import { compressToEncodedURIComponent } from "lz-string";
 import { DEMO_DECISION } from "@/lib/demo-data";
 
 describe("generateId", () => {
@@ -39,9 +34,9 @@ describe("safeJsonParse", () => {
   });
 });
 
-describe("encodeDecisionToUrl / decodeDecisionFromUrl", () => {
-  it("round-trips a full decision object", () => {
-    const encoded = encodeDecisionToUrl(DEMO_DECISION);
+describe("decodeDecisionFromUrl (legacy format)", () => {
+  it("decodes a legacy lz-string encoded decision", () => {
+    const encoded = compressToEncodedURIComponent(JSON.stringify(DEMO_DECISION));
     expect(encoded.length).toBeGreaterThan(0);
     const decoded = decodeDecisionFromUrl(encoded, null);
     expect(decoded).toEqual(DEMO_DECISION);

--- a/src/components/DecisionProvider.tsx
+++ b/src/components/DecisionProvider.tsx
@@ -33,6 +33,7 @@ import { cloudSaveDecision } from "@/lib/cloud-storage";
 import { isCloudEnabled } from "@/lib/supabase";
 import { DEMO_DECISION } from "@/lib/demo-data";
 import { generateId, decodeDecisionFromUrl } from "@/lib/utils";
+import { decodeShareUrl } from "@/lib/share";
 import { isDecision } from "@/lib/validation";
 import { useAnnounce } from "@/components/Announcer";
 
@@ -89,20 +90,36 @@ export function useDecision() {
 }
 
 export function DecisionProvider({ children }: { children: ReactNode }) {
-  // Check URL hash for shared decision data
+  // Check URL hash for shared decision data (compact or legacy format)
   const sharedDecision = (() => {
     if (typeof window === "undefined") return null;
     const hash = window.location.hash;
-    if (!hash.startsWith("#data=")) return null;
-    const encoded = hash.slice("#data=".length);
-    if (!encoded) return null;
-    const decoded = decodeDecisionFromUrl<unknown>(encoded, null);
-    if (isDecision(decoded)) {
-      saveDecision(decoded);
-      // Clean the URL hash without triggering navigation
-      window.history.replaceState(null, "", window.location.pathname);
-      return decoded;
+
+    // Compact share format: /share#d=...
+    if (hash.startsWith("#d=")) {
+      const encoded = hash.slice("#d=".length);
+      if (!encoded) return null;
+      const decoded = decodeShareUrl(encoded);
+      if (decoded && isDecision(decoded)) {
+        saveDecision(decoded);
+        window.history.replaceState(null, "", window.location.pathname);
+        return decoded;
+      }
+      return null;
     }
+
+    // Legacy format: /#data=...
+    if (hash.startsWith("#data=")) {
+      const encoded = hash.slice("#data=".length);
+      if (!encoded) return null;
+      const decoded = decodeDecisionFromUrl<unknown>(encoded, null);
+      if (isDecision(decoded)) {
+        saveDecision(decoded);
+        window.history.replaceState(null, "", window.location.pathname);
+        return decoded;
+      }
+    }
+
     return null;
   })();
 

--- a/src/components/ResultsView.tsx
+++ b/src/components/ResultsView.tsx
@@ -18,7 +18,6 @@ import {
 } from "lucide-react";
 import { useState, lazy, Suspense } from "react";
 import { buildShareLink } from "@/lib/share";
-import { encodeDecisionToUrl } from "@/lib/utils";
 import { normalizeWeights } from "@/lib/scoring";
 import type { ValidationResult } from "@/hooks/useValidation";
 import type { CompletenessResult } from "@/lib/completeness";
@@ -110,7 +109,6 @@ export function ResultsView({ validation, completeness, onSwitchToBuilder }: Res
 
   const handleShareLink = async () => {
     try {
-      // Try compact share format first (shorter URLs)
       const shareUrl = buildShareLink(decision, window.location.origin);
       if (shareUrl) {
         await navigator.clipboard.writeText(shareUrl);
@@ -118,16 +116,8 @@ export function ResultsView({ validation, completeness, onSwitchToBuilder }: Res
         setTimeout(() => setShareStatus(""), 3000);
         return;
       }
-      // Fall back to legacy format for very large decisions
-      const encoded = encodeDecisionToUrl(decision);
-      const legacyUrl = `${window.location.origin}${window.location.pathname}#data=${encoded}`;
-      if (legacyUrl.length > 6000) {
-        setShareStatus("Decision too large for URL sharing. Use JSON export instead.");
-        return;
-      }
-      await navigator.clipboard.writeText(legacyUrl);
-      setShareStatus("Link copied to clipboard!");
-      setTimeout(() => setShareStatus(""), 3000);
+      // Compact URL too long — suggest JSON export instead
+      setShareStatus("Decision too large for URL sharing. Use JSON export instead.");
     } catch {
       setShareStatus("Failed to copy link.");
     }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -13,7 +13,7 @@ export function generateId(): string {
   return `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
 }
 
-import { compressToEncodedURIComponent, decompressFromEncodedURIComponent } from "lz-string";
+import { decompressFromEncodedURIComponent } from "lz-string";
 
 /**
  * Format a relative time string from an ISO timestamp (e.g. "2 hours ago").
@@ -53,19 +53,9 @@ export function safeJsonParse<T>(json: string, fallback: T): T {
 }
 
 /**
- * Compress decision state into a URL-safe string using lz-string.
- * Produces shorter URLs than raw base64 for typical decision payloads.
- */
-export function encodeDecisionToUrl(decision: object): string {
-  try {
-    const json = JSON.stringify(decision);
-    return compressToEncodedURIComponent(json);
-  } catch {
-    return "";
-  }
-}
-
-/**
+ * @deprecated Use `decodeShareUrl` from `@/lib/share` for compact share URLs.
+ * Retained for backward compatibility with legacy `#data=` share links.
+ *
  * Decode a decision from an lz-string compressed URL component.
  * Falls back to legacy base64 decoding for backward compatibility.
  */


### PR DESCRIPTION
## Summary

Implements Issue #63 — Remove duplicate lz-string URL encoding from utils.ts, consolidate on share.ts.

### Changes

**Removed:**
- `encodeDecisionToUrl()` from `utils.ts` — was duplicate of `share.ts` encoding
- Legacy fallback encoding path in `ResultsView.handleShareLink()`
- `compressToEncodedURIComponent` import from `utils.ts` (now unused)

**Updated:**
- `decodeDecisionFromUrl()` annotated with `@deprecated` JSDoc — retained for legacy `#data=` link backward compatibility
- `DecisionProvider.tsx` — now tries compact `#d=` format first via `decodeShareUrl()`, falls back to legacy `#data=` format via `decodeDecisionFromUrl()`
- `ResultsView.tsx` — share handler uses `buildShareLink()` only, shows "too large" message if it can't fit

**Tests:**
- Updated `utils.test.ts` and `share.test.ts` to use `lz-string` directly instead of removed function
- All 391 tests pass, ESLint clean, TypeScript strict, build clean

### Impact
- Single encoding path for all new share links (compact format, ~40-60% shorter URLs)
- Legacy share links (`#data=...`) still decode correctly
- Reduces code surface area and eliminates encoding strategy confusion

Closes #63