### PR TITLE
perf(mc): move Monte Carlo simulation to Web Worker with progress bar and cancellation

### DIFF
--- a/src/__tests__/mc-worker.test.ts
+++ b/src/__tests__/mc-worker.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Monte Carlo Web Worker — Unit Tests
+ *
+ * Covers:
+ *  - Progress callback integration in runMonteCarloSimulation
+ *  - AbortSignal cancellation support
+ *  - PROGRESS_BATCH_SIZE constant
+ *  - Worker message type exports
+ *  - useMonteCarloWorker hook (fallback mode, since jsdom lacks real Workers)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { runMonteCarloSimulation, PROGRESS_BATCH_SIZE } from "@/lib/monte-carlo";
+import type { Decision } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Test decision fixture
+// ---------------------------------------------------------------------------
+
+function makeDecision(): Decision {
+  return {
+    id: "mc-worker-test",
+    title: "Worker Test Decision",
+    description: "",
+    options: [
+      { id: "opt-a", name: "Option A" },
+      { id: "opt-b", name: "Option B" },
+    ],
+    criteria: [
+      { id: "c1", name: "Cost", weight: 50, type: "cost" },
+      { id: "c2", name: "Quality", weight: 50, type: "benefit" },
+    ],
+    scores: {
+      "opt-a": { c1: 3, c2: 8 },
+      "opt-b": { c1: 7, c2: 5 },
+    },
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// PROGRESS_BATCH_SIZE
+// ---------------------------------------------------------------------------
+
+describe("PROGRESS_BATCH_SIZE", () => {
+  it("is exported and equals 1000", () => {
+    expect(PROGRESS_BATCH_SIZE).toBe(1_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Progress callback integration
+// ---------------------------------------------------------------------------
+
+describe("runMonteCarloSimulation with callbacks", () => {
+  let decision: Decision;
+
+  beforeEach(() => {
+    decision = makeDecision();
+  });
+
+  it("calls onProgress every PROGRESS_BATCH_SIZE iterations", () => {
+    const onProgress = vi.fn();
+    const numSimulations = 5_000;
+
+    runMonteCarloSimulation(decision, { numSimulations, seed: 42 }, { onProgress });
+
+    // Should be called at 1000, 2000, 3000, 4000, 5000
+    expect(onProgress).toHaveBeenCalledTimes(5);
+    expect(onProgress).toHaveBeenNthCalledWith(1, 1000, 5000);
+    expect(onProgress).toHaveBeenNthCalledWith(2, 2000, 5000);
+    expect(onProgress).toHaveBeenNthCalledWith(3, 3000, 5000);
+    expect(onProgress).toHaveBeenNthCalledWith(4, 4000, 5000);
+    expect(onProgress).toHaveBeenNthCalledWith(5, 5000, 5000);
+  });
+
+  it("calls onProgress with final count even when not at batch boundary", () => {
+    const onProgress = vi.fn();
+
+    runMonteCarloSimulation(decision, { numSimulations: 2_500, seed: 42 }, { onProgress });
+
+    // Batch reports at 1000, 2000, then final at 2500
+    expect(onProgress).toHaveBeenCalledTimes(3);
+    expect(onProgress).toHaveBeenLastCalledWith(2500, 2500);
+  });
+
+  it("works without callbacks (backward compatible)", () => {
+    const result = runMonteCarloSimulation(decision, {
+      numSimulations: 1_000,
+      seed: 42,
+    });
+
+    expect(result.options).toHaveLength(2);
+    expect(result.options[0].winProbability).toBeGreaterThanOrEqual(0);
+  });
+
+  it("produces identical results with and without callbacks", () => {
+    const onProgress = vi.fn();
+
+    const withCallbacks = runMonteCarloSimulation(
+      decision,
+      { numSimulations: 2_000, seed: 99 },
+      { onProgress }
+    );
+
+    const withoutCallbacks = runMonteCarloSimulation(decision, {
+      numSimulations: 2_000,
+      seed: 99,
+    });
+
+    // Scores should be bit-identical since same seed and same algorithm
+    expect(withCallbacks.options.map((o) => o.meanScore)).toEqual(
+      withoutCallbacks.options.map((o) => o.meanScore)
+    );
+    expect(withCallbacks.options.map((o) => o.winProbability)).toEqual(
+      withoutCallbacks.options.map((o) => o.winProbability)
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AbortSignal cancellation
+// ---------------------------------------------------------------------------
+
+describe("runMonteCarloSimulation with AbortSignal", () => {
+  let decision: Decision;
+
+  beforeEach(() => {
+    decision = makeDecision();
+  });
+
+  it("stops early when signal is already aborted", () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const onProgress = vi.fn();
+    const result = runMonteCarloSimulation(
+      decision,
+      { numSimulations: 10_000, seed: 42 },
+      { signal: controller.signal, onProgress }
+    );
+
+    // Should have run 0 iterations — signal was aborted before start
+    expect(result.options).toHaveLength(2);
+    // All win counts should be 0
+    for (const opt of result.options) {
+      expect(opt.winCount).toBe(0);
+    }
+    // Progress should not have been called at batch boundaries
+    // but will be called once with the final count (0)
+    // The "final progress report" runs for completedSims > 0, so 0 sims = no call
+    expect(onProgress).not.toHaveBeenCalled();
+  });
+
+  it("stops at the first iteration when signal is pre-aborted", () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = runMonteCarloSimulation(
+      decision,
+      { numSimulations: 5_000, seed: 42 },
+      { signal: controller.signal }
+    );
+
+    // Summary should mention cancelled
+    expect(result.summary).toContain("cancelled");
+  });
+
+  it("runs all iterations when signal is never aborted", () => {
+    const controller = new AbortController();
+    const onProgress = vi.fn();
+
+    const result = runMonteCarloSimulation(
+      decision,
+      { numSimulations: 2_000, seed: 42 },
+      { signal: controller.signal, onProgress }
+    );
+
+    // Should complete all 2000
+    const totalWins = result.options.reduce((s, o) => s + o.winCount, 0);
+    expect(totalWins).toBe(2_000);
+    expect(result.summary).not.toContain("cancelled");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Worker message types (compile-time check)
+// ---------------------------------------------------------------------------
+
+describe("Worker message types", () => {
+  it("exports WorkerRunMessage, WorkerOutMessage types", async () => {
+    // This test verifies the type exports exist and are importable
+    const mod = await import("@/workers/monte-carlo.worker");
+    expect(mod).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useMonteCarloWorker (fallback mode in jsdom)
+// ---------------------------------------------------------------------------
+
+describe("useMonteCarloWorker hook types", () => {
+  it("exports the hook and state types", async () => {
+    const mod = await import("@/hooks/useMonteCarloWorker");
+    expect(mod.useMonteCarloWorker).toBeTypeOf("function");
+  });
+});

--- a/src/components/MonteCarloView.tsx
+++ b/src/components/MonteCarloView.tsx
@@ -8,7 +8,7 @@
 
 "use client";
 
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo } from "react";
 import { useDecision } from "./DecisionProvider";
 import {
   Dices,
@@ -19,11 +19,13 @@ import {
   Info,
   ChevronDown,
   ChevronUp,
+  X,
+  AlertTriangle,
 } from "lucide-react";
-import { runMonteCarloSimulation, DEFAULT_CONFIG } from "@/lib/monte-carlo";
+import { DEFAULT_CONFIG } from "@/lib/monte-carlo";
+import { useMonteCarloWorker } from "@/hooks/useMonteCarloWorker";
 import type {
   MonteCarloConfig,
-  MonteCarloResults,
   MonteCarloOptionResult,
   PerturbationDistribution,
 } from "@/lib/types";
@@ -104,9 +106,8 @@ export function MonteCarloView() {
   const [seed, setSeed] = useState(DEFAULT_CONFIG.seed);
   const [showAdvanced, setShowAdvanced] = useState(false);
 
-  // Results state
-  const [mcResults, setMcResults] = useState<MonteCarloResults | null>(null);
-  const [isRunning, setIsRunning] = useState(false);
+  // Worker hook
+  const worker = useMonteCarloWorker();
 
   const hasOptions = results.optionResults.length >= 2;
 
@@ -115,15 +116,12 @@ export function MonteCarloView() {
     [numSimulations, perturbationRange, distribution, seed]
   );
 
-  const runSimulation = useCallback(() => {
-    setIsRunning(true);
-    // Use a microtask so the UI updates before blocking on compute
-    requestAnimationFrame(() => {
-      const result = runMonteCarloSimulation(decision, config);
-      setMcResults(result);
-      setIsRunning(false);
-    });
-  }, [decision, config]);
+  const runSimulation = () => {
+    worker.run(decision, config);
+  };
+
+  const mcResults = worker.results;
+  const isRunning = worker.status === "running";
 
   // Empty state
   if (!hasOptions) {
@@ -202,24 +200,25 @@ export function MonteCarloView() {
               </div>
             </div>
 
-            {/* Run button */}
-            <button
-              onClick={runSimulation}
-              disabled={isRunning}
-              className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg bg-indigo-600 text-white font-medium shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-            >
-              {isRunning ? (
-                <>
-                  <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
-                  Running…
-                </>
-              ) : (
-                <>
-                  <Play className="h-4 w-4" />
-                  Run Simulation
-                </>
-              )}
-            </button>
+            {/* Run / Cancel button */}
+            {isRunning ? (
+              <button
+                onClick={() => worker.cancel()}
+                className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg bg-red-600 text-white font-medium shadow-sm hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition-colors"
+              >
+                <X className="h-4 w-4" />
+                Cancel
+              </button>
+            ) : (
+              <button
+                onClick={runSimulation}
+                disabled={isRunning}
+                className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg bg-indigo-600 text-white font-medium shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                <Play className="h-4 w-4" />
+                Run Simulation
+              </button>
+            )}
           </div>
 
           {/* Advanced settings (collapsible) */}
@@ -280,6 +279,76 @@ export function MonteCarloView() {
           </div>
         </div>
       </section>
+
+      {/* ── Progress Bar (during simulation) ─────────────────── */}
+      {isRunning && (
+        <section
+          className="rounded-lg border border-indigo-200 bg-indigo-50 dark:border-indigo-800 dark:bg-indigo-900/30 p-4"
+          role="progressbar"
+          aria-valuenow={Math.round(worker.progress * 100)}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label="Simulation progress"
+        >
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-sm font-medium text-indigo-800 dark:text-indigo-300">
+              Running simulation…
+            </span>
+            <span className="text-sm tabular-nums text-indigo-700 dark:text-indigo-400">
+              {Math.round(worker.progress * 100)}% — {worker.completed.toLocaleString()} /{" "}
+              {worker.total.toLocaleString()}
+            </span>
+          </div>
+          <div className="h-3 bg-indigo-200 dark:bg-indigo-800 rounded-full overflow-hidden">
+            <div
+              className="h-full bg-indigo-600 dark:bg-indigo-400 rounded-full transition-all duration-300 ease-out"
+              style={{ width: `${Math.max(worker.progress * 100, 1)}%` }}
+            />
+          </div>
+          {!worker.workerSupported && (
+            <p className="mt-2 text-xs text-amber-700 dark:text-amber-400 flex items-center gap-1">
+              <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+              Running on main thread — UI may be temporarily unresponsive
+            </p>
+          )}
+        </section>
+      )}
+
+      {/* ── Cancelled state ──────────────────────────────────── */}
+      {worker.status === "cancelled" && (
+        <section className="rounded-lg border border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-900/30 p-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5 text-amber-600 shrink-0" />
+              <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
+                Simulation cancelled
+              </p>
+            </div>
+            <button
+              onClick={runSimulation}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium bg-amber-600 text-white hover:bg-amber-700 transition-colors"
+            >
+              <Play className="h-3.5 w-3.5" />
+              Restart
+            </button>
+          </div>
+        </section>
+      )}
+
+      {/* ── Error state ──────────────────────────────────────── */}
+      {worker.status === "error" && (
+        <section className="rounded-lg border border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-900/30 p-4">
+          <div className="flex items-start gap-2">
+            <AlertTriangle className="h-5 w-5 text-red-600 shrink-0 mt-0.5" />
+            <div>
+              <p className="text-sm font-medium text-red-800 dark:text-red-300">
+                Simulation failed
+              </p>
+              <p className="text-sm text-red-700 dark:text-red-400">{worker.error}</p>
+            </div>
+          </div>
+        </section>
+      )}
 
       {/* ── Results Section ──────────────────────────────────── */}
       {mcResults && (

--- a/src/hooks/useMonteCarloWorker.ts
+++ b/src/hooks/useMonteCarloWorker.ts
@@ -1,0 +1,220 @@
+/**
+ * useMonteCarloWorker — Custom hook for running Monte Carlo simulations
+ * in a Web Worker with progress tracking & cancellation.
+ *
+ * Falls back to main-thread execution when Workers are unavailable.
+ */
+
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { runMonteCarloSimulation } from "@/lib/monte-carlo";
+import type { Decision, MonteCarloConfig, MonteCarloResults } from "@/lib/types";
+import type { WorkerOutMessage, WorkerRunMessage } from "@/workers/monte-carlo.worker";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SimulationStatus = "idle" | "running" | "complete" | "cancelled" | "error";
+
+export interface MonteCarloWorkerState {
+  /** Current lifecycle status */
+  status: SimulationStatus;
+  /** 0-1 progress fraction during a run */
+  progress: number;
+  /** Completed iteration count */
+  completed: number;
+  /** Total iteration count */
+  total: number;
+  /** Results on completion (null otherwise) */
+  results: MonteCarloResults | null;
+  /** Error message if status === "error" */
+  error: string | null;
+  /** Whether Web Workers are supported */
+  workerSupported: boolean;
+}
+
+export interface MonteCarloWorkerAPI {
+  /** Kick off a simulation. Terminates any in-flight run. */
+  run: (decision: Decision, config: Partial<MonteCarloConfig>) => void;
+  /** Cancel the current run. */
+  cancel: () => void;
+  /** Reset state to idle. */
+  reset: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+const INITIAL_STATE: MonteCarloWorkerState = {
+  status: "idle",
+  progress: 0,
+  completed: 0,
+  total: 0,
+  results: null,
+  error: null,
+  workerSupported: false,
+};
+
+export function useMonteCarloWorker(): MonteCarloWorkerState & MonteCarloWorkerAPI {
+  const [state, setState] = useState<MonteCarloWorkerState>(INITIAL_STATE);
+  const workerRef = useRef<Worker | null>(null);
+  const supportedRef = useRef(false);
+
+  // Detect Worker support once on mount
+  useEffect(() => {
+    const supported = typeof Worker !== "undefined";
+    supportedRef.current = supported;
+    setState((s) => ({ ...s, workerSupported: supported }));
+  }, []);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      workerRef.current?.terminate();
+      workerRef.current = null;
+    };
+  }, []);
+
+  // ── Terminate any existing worker ──────────────────────────
+  const terminateWorker = useCallback(() => {
+    if (workerRef.current) {
+      workerRef.current.terminate();
+      workerRef.current = null;
+    }
+  }, []);
+
+  // ── Run ──────────────────────────────────────────────────────
+  const run = useCallback(
+    (decision: Decision, config: Partial<MonteCarloConfig>) => {
+      // Kill any in-flight worker
+      terminateWorker();
+
+      const total = config.numSimulations ?? 10_000;
+
+      setState({
+        status: "running",
+        progress: 0,
+        completed: 0,
+        total,
+        results: null,
+        error: null,
+        workerSupported: supportedRef.current,
+      });
+
+      // ── Web Worker path ──
+      if (supportedRef.current) {
+        try {
+          const worker = new Worker(new URL("../workers/monte-carlo.worker.ts", import.meta.url));
+          workerRef.current = worker;
+
+          worker.onmessage = (e: MessageEvent<WorkerOutMessage>) => {
+            const msg = e.data;
+
+            switch (msg.type) {
+              case "progress":
+                setState((s) => ({
+                  ...s,
+                  completed: msg.completed,
+                  total: msg.total,
+                  progress: msg.completed / msg.total,
+                }));
+                break;
+
+              case "complete":
+                setState((s) => ({
+                  ...s,
+                  status: "complete",
+                  progress: 1,
+                  completed: msg.results.config.numSimulations,
+                  total: msg.results.config.numSimulations,
+                  results: msg.results,
+                }));
+                terminateWorker();
+                break;
+
+              case "error":
+                setState((s) => ({
+                  ...s,
+                  status: "error",
+                  error: msg.message,
+                }));
+                terminateWorker();
+                break;
+            }
+          };
+
+          worker.onerror = (ev) => {
+            setState((s) => ({
+              ...s,
+              status: "error",
+              error: ev.message ?? "Worker error",
+            }));
+            terminateWorker();
+          };
+
+          const message: WorkerRunMessage = { type: "run", decision, config };
+          worker.postMessage(message);
+          return;
+        } catch {
+          // Worker creation failed — fall through to main-thread
+          supportedRef.current = false;
+        }
+      }
+
+      // ── Main-thread fallback ──
+      // Use requestAnimationFrame to allow UI to update "Running" state first.
+      requestAnimationFrame(() => {
+        try {
+          const results = runMonteCarloSimulation(decision, config, {
+            onProgress: (completed, tot) => {
+              setState((s) => ({
+                ...s,
+                completed,
+                total: tot,
+                progress: completed / tot,
+              }));
+            },
+          });
+
+          setState((s) => ({
+            ...s,
+            status: "complete",
+            progress: 1,
+            completed: results.config.numSimulations,
+            total: results.config.numSimulations,
+            results,
+            workerSupported: false,
+          }));
+        } catch (err) {
+          setState((s) => ({
+            ...s,
+            status: "error",
+            error: err instanceof Error ? err.message : String(err),
+            workerSupported: false,
+          }));
+        }
+      });
+    },
+    [terminateWorker]
+  );
+
+  // ── Cancel ──────────────────────────────────────────────────
+  const cancel = useCallback(() => {
+    terminateWorker();
+    setState((s) => ({
+      ...s,
+      status: "cancelled",
+    }));
+  }, [terminateWorker]);
+
+  // ── Reset ───────────────────────────────────────────────────
+  const reset = useCallback(() => {
+    terminateWorker();
+    setState({ ...INITIAL_STATE, workerSupported: supportedRef.current });
+  }, [terminateWorker]);
+
+  return { ...state, run, cancel, reset };
+}

--- a/src/lib/monte-carlo.ts
+++ b/src/lib/monte-carlo.ts
@@ -30,6 +30,20 @@ import type {
 import { computeResults, roundDisplay } from "./scoring";
 
 // ---------------------------------------------------------------------------
+// Callback interface for progress reporting & cancellation
+// ---------------------------------------------------------------------------
+
+export interface SimulationCallbacks {
+  /** Called periodically with (completed, total) iteration counts. */
+  onProgress?: (completed: number, total: number) => void;
+  /** When aborted, the simulation stops at the next batch boundary. */
+  signal?: AbortSignal;
+}
+
+/** Batch size for progress reporting (every N iterations). */
+export const PROGRESS_BATCH_SIZE = 1_000;
+
+// ---------------------------------------------------------------------------
 // Defaults
 // ---------------------------------------------------------------------------
 
@@ -216,7 +230,8 @@ export function percentile(sorted: number[], p: number): number {
  */
 export function runMonteCarloSimulation(
   decision: Decision,
-  config: Partial<MonteCarloConfig> = {}
+  config: Partial<MonteCarloConfig> = {},
+  callbacks?: SimulationCallbacks
 ): MonteCarloResults {
   const cfg: MonteCarloConfig = { ...DEFAULT_CONFIG, ...config };
   const { numSimulations, perturbationRange, distribution, seed } = cfg;
@@ -253,7 +268,15 @@ export function runMonteCarloSimulation(
 
   // Run simulations -------------------------------------------------------
 
+  let completedSims = 0;
+
   for (let sim = 0; sim < numSimulations; sim++) {
+    // Check for cancellation at batch boundaries
+    if (callbacks?.signal?.aborted) {
+      completedSims = sim;
+      break;
+    }
+
     // Perturb weights
     const perturbedWeights = perturbWeights(baseWeights, rand, perturbationRange, distribution);
 
@@ -281,22 +304,37 @@ export function runMonteCarloSimulation(
         winCounts[winnerIdx]++;
       }
     }
+
+    completedSims = sim + 1;
+
+    // Report progress at batch boundaries
+    if (callbacks?.onProgress && completedSims % PROGRESS_BATCH_SIZE === 0) {
+      callbacks.onProgress(completedSims, numSimulations);
+    }
   }
+
+  // Final progress report (only if not already reported at a batch boundary)
+  if (callbacks?.onProgress && completedSims > 0 && completedSims % PROGRESS_BATCH_SIZE !== 0) {
+    callbacks.onProgress(completedSims, numSimulations);
+  }
+
+  // If cancelled, adjust array slices to only include completed sims
+  const effectiveSims = completedSims;
 
   // Build option results --------------------------------------------------
 
   const mcOptions: MonteCarloOptionResult[] = options.map((opt, idx) => {
-    const scores = Array.from(allScores[idx]);
+    const scores = Array.from(allScores[idx].subarray(0, effectiveSims));
     scores.sort((a, b) => a - b);
 
-    const mean = scores.reduce((s, v) => s + v, 0) / numSimulations;
-    const variance = scores.reduce((s, v) => s + (v - mean) ** 2, 0) / numSimulations;
+    const mean = scores.reduce((s, v) => s + v, 0) / (effectiveSims || 1);
+    const variance = scores.reduce((s, v) => s + (v - mean) ** 2, 0) / (effectiveSims || 1);
     const stdDev = Math.sqrt(variance);
 
     return {
       optionId: opt.id,
       optionName: opt.name,
-      winProbability: roundDisplay(winCounts[idx] / numSimulations),
+      winProbability: roundDisplay(winCounts[idx] / (effectiveSims || 1)),
       winCount: winCounts[idx],
       meanScore: roundDisplay(mean),
       stdDev: roundDisplay(stdDev),
@@ -313,13 +351,15 @@ export function runMonteCarloSimulation(
   mcOptions.sort((a, b) => b.winProbability - a.winProbability || b.meanScore - a.meanScore);
 
   const elapsedMs = roundDisplay(performance.now() - t0);
+  const cancelled = callbacks?.signal?.aborted ?? false;
 
   // Summary text
   const topOption = mcOptions[0];
+  const cancelNote = cancelled ? ` (cancelled after ${effectiveSims.toLocaleString()})` : "";
   const summary = topOption
     ? `"${topOption.optionName}" wins ${roundDisplay(topOption.winProbability * 100)}% of simulations ` +
       `(mean score ${topOption.meanScore}, 90% CI [${topOption.p5}–${topOption.p95}]). ` +
-      `${numSimulations.toLocaleString()} simulations completed in ${elapsedMs} ms.`
+      `${effectiveSims.toLocaleString()} simulations completed in ${elapsedMs} ms${cancelNote}.`
     : "No results.";
 
   return {

--- a/src/workers/monte-carlo.worker.ts
+++ b/src/workers/monte-carlo.worker.ts
@@ -1,0 +1,74 @@
+/**
+ * Monte Carlo Simulation Web Worker
+ *
+ * Runs the MC simulation off the main thread so the UI stays fully
+ * interactive during long-running computation.
+ *
+ * Message protocol (incoming):
+ *   { type: "run", decision, config }
+ *
+ * Message protocol (outgoing):
+ *   { type: "progress", completed, total }
+ *   { type: "complete", results }
+ *   { type: "error", message }
+ *
+ * Cancellation: the host calls `worker.terminate()`.
+ */
+
+import { runMonteCarloSimulation } from "@/lib/monte-carlo";
+import type { Decision, MonteCarloConfig, MonteCarloResults } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Worker message types
+// ---------------------------------------------------------------------------
+
+export interface WorkerRunMessage {
+  type: "run";
+  decision: Decision;
+  config: Partial<MonteCarloConfig>;
+}
+
+export interface WorkerProgressMessage {
+  type: "progress";
+  completed: number;
+  total: number;
+}
+
+export interface WorkerCompleteMessage {
+  type: "complete";
+  results: MonteCarloResults;
+}
+
+export interface WorkerErrorMessage {
+  type: "error";
+  message: string;
+}
+
+export type WorkerOutMessage = WorkerProgressMessage | WorkerCompleteMessage | WorkerErrorMessage;
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+self.onmessage = (e: MessageEvent<WorkerRunMessage>) => {
+  if (e.data.type !== "run") return;
+
+  const { decision, config } = e.data;
+
+  try {
+    const results = runMonteCarloSimulation(decision, config, {
+      onProgress: (completed: number, total: number) => {
+        self.postMessage({ type: "progress", completed, total } satisfies WorkerProgressMessage);
+      },
+      // No AbortSignal here — cancellation is via worker.terminate()
+    });
+
+    self.postMessage({ type: "complete", results } satisfies WorkerCompleteMessage);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    self.postMessage({ type: "error", message } satisfies WorkerErrorMessage);
+  }
+};
+
+// Signal that the worker is ready
+export {};


### PR DESCRIPTION
# Move Monte Carlo Simulation to Web Worker

Closes #73

## Summary

Moves the Monte Carlo simulation engine off the main thread into a dedicated Web Worker, eliminating UI freezing during long-running computations. Adds a real progress bar with percentage/iteration count and a cancel button.

## Changes

### `src/lib/monte-carlo.ts`
- Added `SimulationCallbacks` interface with `onProgress` callback and `AbortSignal` support
- Exported `PROGRESS_BATCH_SIZE` constant (1,000 iterations per progress report)
- `runMonteCarloSimulation()` now accepts optional 3rd param `callbacks?: SimulationCallbacks`
- Progress reported every 1,000 iterations via `onProgress(completed, total)`
- Abort signal checked at each iteration; early termination with partial results
- Summary text includes "(cancelled after N)" when aborted
- **100% backward compatible** — omitting `callbacks` produces identical behavior

### `src/workers/monte-carlo.worker.ts` (NEW)
- Dedicated Web Worker running simulation off main thread
- Message protocol: `{ type: "run" }` → `{ type: "progress" }` / `{ type: "complete" }` / `{ type: "error" }`
- Cancellation via `worker.terminate()` (hard kill)

### `src/hooks/useMonteCarloWorker.ts` (NEW)
- Custom hook: `useMonteCarloWorker()` returns `{ run, cancel, reset, status, progress, results, ... }`
- Status lifecycle: `idle` → `running` → `complete` | `cancelled` | `error`
- Automatic Worker lifecycle management (terminate on unmount, terminate before re-run)
- Falls back to main-thread `requestAnimationFrame` execution when Workers unavailable
- Shows warning when using main-thread fallback

### `src/components/MonteCarloView.tsx`
- Replaced synchronous `requestAnimationFrame` + `runMonteCarloSimulation` with `useMonteCarloWorker` hook
- Added real progress bar with percentage, iteration count, smooth CSS transition
- Added Cancel button (red, terminates worker)
- Added cancelled state banner with Restart button
- Added error state banner
- Added main-thread fallback warning
- Multiple rapid "Run" clicks safely terminate previous worker first

### `src/__tests__/mc-worker.test.ts` (NEW — 10 tests)
- `PROGRESS_BATCH_SIZE` export validation
- Progress callback: batch boundaries, final report, backward compat, identical results with/without callbacks
- AbortSignal: pre-aborted, never-aborted, cancelled summary text
- Worker and hook module export validation

## Verification
- [x] TSC clean
- [x] ESLint clean (0 warnings)
- [x] All 433 tests pass (423 existing + 10 new)
- [x] Production build succeeds (Turbopack bundles worker correctly)
- [x] Prettier formatted