### PR TITLE
feat(ux): mobile-optimized score matrix with card layout and slider inputs

### DIFF
--- a/src/__tests__/components/MobileScoreCards.test.tsx
+++ b/src/__tests__/components/MobileScoreCards.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * MobileScoreCards & ScoreSlider — Unit Tests
+ *
+ * Covers:
+ *  - ScoreSlider rendering, value display, change handler
+ *  - MobileScoreCards accordion behavior
+ *  - Option card expand/collapse
+ *  - Score change propagation
+ *  - WCAG accessibility attributes
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ScoreSlider } from "@/components/ScoreSlider";
+import { MobileScoreCards } from "@/components/MobileScoreCards";
+import type { Decision } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// ScoreSlider
+// ---------------------------------------------------------------------------
+
+describe("ScoreSlider", () => {
+  it("renders a range input with correct attributes", () => {
+    render(<ScoreSlider value={5} onChange={vi.fn()} label="Test slider" />);
+
+    const slider = screen.getByRole("slider", { name: "Test slider" });
+    expect(slider).toBeInTheDocument();
+    expect(slider).toHaveAttribute("min", "0");
+    expect(slider).toHaveAttribute("max", "10");
+    expect(slider).toHaveAttribute("step", "1");
+    expect(slider).toHaveAttribute("aria-valuenow", "5");
+    expect(slider).toHaveAttribute("aria-valuemin", "0");
+    expect(slider).toHaveAttribute("aria-valuemax", "10");
+  });
+
+  it("displays the current value", () => {
+    render(<ScoreSlider value={7} onChange={vi.fn()} label="Test" />);
+    expect(screen.getByText("7")).toBeInTheDocument();
+  });
+
+  it("calls onChange when slider value changes", () => {
+    const onChange = vi.fn();
+    render(<ScoreSlider value={3} onChange={onChange} label="Test" />);
+
+    const slider = screen.getByRole("slider");
+    fireEvent.change(slider, { target: { value: "8" } });
+    expect(onChange).toHaveBeenCalledWith(8);
+  });
+
+  it("accepts custom min/max/step", () => {
+    render(<ScoreSlider value={2} onChange={vi.fn()} label="Custom" min={1} max={5} step={0.5} />);
+
+    const slider = screen.getByRole("slider");
+    expect(slider).toHaveAttribute("min", "1");
+    expect(slider).toHaveAttribute("max", "5");
+    expect(slider).toHaveAttribute("step", "0.5");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MobileScoreCards
+// ---------------------------------------------------------------------------
+
+function makeDecision(): Decision {
+  return {
+    id: "test-1",
+    title: "Test Decision",
+    description: "",
+    options: [
+      { id: "opt-a", name: "Option Alpha" },
+      { id: "opt-b", name: "Option Beta" },
+      { id: "opt-c", name: "Option Gamma" },
+    ],
+    criteria: [
+      { id: "c1", name: "Cost", weight: 40, type: "cost" },
+      { id: "c2", name: "Quality", weight: 60, type: "benefit", description: "Build quality" },
+    ],
+    scores: {
+      "opt-a": { c1: 3, c2: 8 },
+      "opt-b": { c1: 7, c2: 5 },
+      "opt-c": { c1: 5, c2: 6 },
+    },
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+describe("MobileScoreCards", () => {
+  let decision: Decision;
+  let updateScore: ReturnType<
+    typeof vi.fn<(optionId: string, criterionId: string, value: number) => void>
+  >;
+
+  beforeEach(() => {
+    decision = makeDecision();
+    updateScore = vi.fn<(optionId: string, criterionId: string, value: number) => void>();
+  });
+
+  it("renders a card for each option", () => {
+    render(<MobileScoreCards decision={decision} updateScore={updateScore} />);
+
+    expect(screen.getByText("Option Alpha")).toBeInTheDocument();
+    expect(screen.getByText("Option Beta")).toBeInTheDocument();
+    expect(screen.getByText("Option Gamma")).toBeInTheDocument();
+  });
+
+  it("renders option labels A, B, C", () => {
+    render(<MobileScoreCards decision={decision} updateScore={updateScore} />);
+
+    expect(screen.getByText("A")).toBeInTheDocument();
+    expect(screen.getByText("B")).toBeInTheDocument();
+    expect(screen.getByText("C")).toBeInTheDocument();
+  });
+
+  it("first option is expanded by default", () => {
+    render(<MobileScoreCards decision={decision} updateScore={updateScore} />);
+
+    const firstToggle = screen.getByRole("button", { name: /Option Alpha/i });
+    expect(firstToggle).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("other options are collapsed by default", () => {
+    render(<MobileScoreCards decision={decision} updateScore={updateScore} />);
+
+    const secondToggle = screen.getByRole("button", { name: /Option Beta/i });
+    const thirdToggle = screen.getByRole("button", { name: /Option Gamma/i });
+    expect(secondToggle).toHaveAttribute("aria-expanded", "false");
+    expect(thirdToggle).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("clicking a collapsed card expands it and collapses the other", () => {
+    render(<MobileScoreCards decision={decision} updateScore={updateScore} />);
+
+    // Click Beta
+    fireEvent.click(screen.getByRole("button", { name: /Option Beta/i }));
+
+    // Beta is now expanded, Alpha collapsed
+    expect(screen.getByRole("button", { name: /Option Beta/i })).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+    expect(screen.getByRole("button", { name: /Option Alpha/i })).toHaveAttribute(
+      "aria-expanded",
+      "false"
+    );
+  });
+
+  it("clicking the expanded card collapses it", () => {
+    render(<MobileScoreCards decision={decision} updateScore={updateScore} />);
+
+    // Click Alpha (already expanded) to collapse
+    fireEvent.click(screen.getByRole("button", { name: /Option Alpha/i }));
+    expect(screen.getByRole("button", { name: /Option Alpha/i })).toHaveAttribute(
+      "aria-expanded",
+      "false"
+    );
+  });
+
+  it("renders sliders for each criterion in the expanded card", () => {
+    render(<MobileScoreCards decision={decision} updateScore={updateScore} />);
+
+    // Alpha is expanded — should have sliders for Cost and Quality
+    const sliders = screen.getAllByRole("slider");
+    // At least 2 sliders visible for the expanded option
+    expect(sliders.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("displays criterion descriptions as hint text", () => {
+    render(<MobileScoreCards decision={decision} updateScore={updateScore} />);
+
+    // Quality has description "Build quality" — shown in all 3 cards
+    const hints = screen.getAllByText("Build quality");
+    expect(hints.length).toBe(3);
+  });
+
+  it("shows cost/benefit type labels", () => {
+    render(<MobileScoreCards decision={decision} updateScore={updateScore} />);
+
+    // Each card has both labels — 3 cards × 1 of each
+    expect(screen.getAllByText("↓ cost").length).toBe(3);
+    expect(screen.getAllByText("↑ benefit").length).toBe(3);
+  });
+
+  it("calls updateScore when a slider changes", () => {
+    render(<MobileScoreCards decision={decision} updateScore={updateScore} />);
+
+    // Find the first slider (Cost for Option Alpha)
+    const sliders = screen.getAllByRole("slider");
+    fireEvent.change(sliders[0], { target: { value: "9" } });
+
+    expect(updateScore).toHaveBeenCalledWith("opt-a", "c1", 9);
+  });
+
+  it("has aria-label for the cards container", () => {
+    const { container } = render(
+      <MobileScoreCards decision={decision} updateScore={updateScore} />
+    );
+
+    const section = container.querySelector('[aria-label="Scores matrix (mobile)"]');
+    expect(section).toBeInTheDocument();
+  });
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -112,6 +112,25 @@ input[type="range"]::-moz-range-track {
   border-radius: 3px;
 }
 
+/* Score slider — larger touch target (≥44px) for mobile WCAG 2.5.5 */
+.score-slider::-webkit-slider-thumb {
+  width: 28px;
+  height: 28px;
+}
+@media (max-width: 639px) {
+  .score-slider::-webkit-slider-thumb {
+    width: 44px;
+    height: 44px;
+  }
+  .score-slider::-moz-range-thumb {
+    width: 44px;
+    height: 44px;
+  }
+  .score-slider {
+    height: 8px;
+  }
+}
+
 /* Print styles */
 @media print {
   .no-print,

--- a/src/components/DecisionBuilder.tsx
+++ b/src/components/DecisionBuilder.tsx
@@ -28,6 +28,7 @@ import { WeightSlider } from "./WeightSlider";
 import { WeightDistributionBar } from "./WeightDistributionBar";
 import { BiasWarnings } from "./BiasWarnings";
 import { useBiasDetection } from "@/hooks/useBiasDetection";
+import { MobileScoreCards } from "./MobileScoreCards";
 
 interface DecisionBuilderProps {
   validation: ValidationResult;
@@ -553,7 +554,12 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
         <span id="score-range-desc" className="sr-only">
           Enter a value between 0 and 10
         </span>
-        <div className="overflow-x-auto">
+
+        {/* Mobile: Card-based scoring (< 640px) */}
+        <MobileScoreCards decision={decision} updateScore={updateScore} />
+
+        {/* Desktop: Table layout (≥ 640px) */}
+        <div className="hidden sm:block overflow-x-auto">
           <table
             ref={gridRef}
             className="min-w-full border-collapse"

--- a/src/components/MobileScoreCards.tsx
+++ b/src/components/MobileScoreCards.tsx
@@ -1,0 +1,140 @@
+/**
+ * MobileScoreCards — Accordion card layout for scoring on small screens.
+ *
+ * Renders one card per option with slider inputs for each criterion.
+ * Only one card is expanded at a time (accordion pattern).
+ * Shown on viewports < 640 px, hidden on sm: and above.
+ */
+
+"use client";
+
+import { useCallback, useState } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { ScoreSlider } from "./ScoreSlider";
+import type { Criterion, Decision, Option } from "@/lib/types";
+
+interface MobileScoreCardsProps {
+  decision: Decision;
+  updateScore: (optionId: string, criterionId: string, value: number) => void;
+}
+
+/** Letter label for option index (A, B, C, …) */
+function optionLabel(idx: number): string {
+  return String.fromCharCode(65 + idx);
+}
+
+/** Single option card (collapsible) */
+function OptionCard({
+  option,
+  index,
+  criteria,
+  scores,
+  expanded,
+  onToggle,
+  updateScore,
+}: {
+  option: Option;
+  index: number;
+  criteria: Criterion[];
+  scores: Record<string, number>;
+  expanded: boolean;
+  onToggle: () => void;
+  updateScore: (criterionId: string, value: number) => void;
+}) {
+  return (
+    <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 overflow-hidden">
+      {/* Header — always visible */}
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={expanded}
+        aria-controls={`mobile-scores-${option.id}`}
+        className="w-full flex items-center justify-between px-4 py-3 text-left bg-gray-50 dark:bg-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+      >
+        <span className="flex items-center gap-2">
+          <span className="inline-flex items-center justify-center h-6 w-6 rounded-full bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 text-xs font-bold">
+            {optionLabel(index)}
+          </span>
+          <span className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
+            {option.name}
+          </span>
+        </span>
+        {expanded ? (
+          <ChevronUp className="h-4 w-4 text-gray-400 shrink-0" />
+        ) : (
+          <ChevronDown className="h-4 w-4 text-gray-400 shrink-0" />
+        )}
+      </button>
+
+      {/* Collapsible body */}
+      <div
+        id={`mobile-scores-${option.id}`}
+        role="region"
+        aria-label={`Scores for ${option.name}`}
+        className={`transition-all duration-200 ease-in-out overflow-hidden ${
+          expanded ? "max-h-[2000px] opacity-100" : "max-h-0 opacity-0"
+        }`}
+      >
+        <div className="px-4 py-3 space-y-4 border-t border-gray-100 dark:border-gray-700">
+          {criteria.map((crit) => (
+            <div key={crit.id}>
+              <div className="flex items-center justify-between mb-1">
+                <label
+                  className="text-sm font-medium text-gray-700 dark:text-gray-300"
+                  htmlFor={`mobile-score-${option.id}-${crit.id}`}
+                >
+                  {crit.name}
+                  <span
+                    className={`ml-1.5 text-[10px] font-normal ${
+                      crit.type === "cost"
+                        ? "text-orange-600 dark:text-orange-400"
+                        : "text-green-600 dark:text-green-400"
+                    }`}
+                  >
+                    {crit.type === "cost" ? "↓ cost" : "↑ benefit"}
+                  </span>
+                </label>
+              </div>
+              {crit.description && (
+                <p className="text-xs text-gray-500 dark:text-gray-400 mb-1.5">
+                  {crit.description}
+                </p>
+              )}
+              <ScoreSlider
+                value={scores[crit.id] ?? 0}
+                onChange={(v) => updateScore(crit.id, v)}
+                label={`Score for ${option.name} on ${crit.name}`}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function MobileScoreCards({ decision, updateScore }: MobileScoreCardsProps) {
+  // Accordion: keep track of which option is expanded (first by default)
+  const [expandedId, setExpandedId] = useState<string | null>(decision.options[0]?.id ?? null);
+
+  const toggle = useCallback((optionId: string) => {
+    setExpandedId((prev) => (prev === optionId ? null : optionId));
+  }, []);
+
+  return (
+    <div className="space-y-3 sm:hidden" aria-label="Scores matrix (mobile)">
+      {decision.options.map((opt, idx) => (
+        <OptionCard
+          key={opt.id}
+          option={opt}
+          index={idx}
+          criteria={decision.criteria}
+          scores={decision.scores[opt.id] ?? {}}
+          expanded={expandedId === opt.id}
+          onToggle={() => toggle(opt.id)}
+          updateScore={(critId, v) => updateScore(opt.id, critId, v)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/ScoreSlider.tsx
+++ b/src/components/ScoreSlider.tsx
@@ -1,0 +1,78 @@
+/**
+ * ScoreSlider — Touch-optimized range slider for score input (0–10).
+ *
+ * Designed for mobile use with a ≥ 44 × 44 px touch target on the thumb.
+ * Shows the current value next to the slider with color coding (red→green).
+ */
+
+"use client";
+
+import { useCallback } from "react";
+
+interface ScoreSliderProps {
+  /** Current value (0–10) */
+  value: number;
+  /** Called on every change with the new integer value */
+  onChange: (value: number) => void;
+  /** Accessible label describing what this slider controls */
+  label: string;
+  /** Minimum value (default 0) */
+  min?: number;
+  /** Maximum value (default 10) */
+  max?: number;
+  /** Step increment (default 1) */
+  step?: number;
+}
+
+/** Map a 0–10 value to a Tailwind text-color class */
+function valueColor(v: number): string {
+  if (v <= 2) return "text-red-600 dark:text-red-400";
+  if (v <= 4) return "text-orange-600 dark:text-orange-400";
+  if (v <= 6) return "text-yellow-600 dark:text-yellow-400";
+  if (v <= 8) return "text-green-600 dark:text-green-400";
+  return "text-emerald-600 dark:text-emerald-400";
+}
+
+export function ScoreSlider({
+  value,
+  onChange,
+  label,
+  min = 0,
+  max = 10,
+  step = 1,
+}: ScoreSliderProps) {
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onChange(Number(e.target.value));
+    },
+    [onChange]
+  );
+
+  const pct = ((value - min) / (max - min)) * 100;
+
+  return (
+    <div className="flex items-center gap-3">
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={handleChange}
+        aria-label={label}
+        aria-valuemin={min}
+        aria-valuemax={max}
+        aria-valuenow={value}
+        className="score-slider flex-1 h-2 rounded-full appearance-none cursor-pointer accent-blue-600"
+        style={{
+          background: `linear-gradient(to right, #3b82f6 0%, #3b82f6 ${pct}%, #e5e7eb ${pct}%, #e5e7eb 100%)`,
+        }}
+      />
+      <span
+        className={`min-w-[2rem] text-right text-sm font-bold tabular-nums ${valueColor(value)}`}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Closes #74 — Mobile-optimized score matrix with card-based layout and touch-friendly slider inputs.

## Changes

### New Components
- **`ScoreSlider`** — Touch-optimized range input (0–10) with:
  - Color-coded value display (red → orange → yellow → green → emerald)
  - Inline gradient background tracking thumb position
  - 44px touch targets on mobile (WCAG 2.5.5), 28px on desktop
  - Full ARIA: `aria-label`, `aria-valuemin/max/now`

- **`MobileScoreCards`** — Accordion card layout (`sm:hidden`) with:
  - One card per option with letter labels (A, B, C…)
  - Expand/collapse toggle with `aria-expanded` + `aria-controls`
  - Smooth `max-h` CSS transition (200ms)
  - Criterion rows: label, cost/benefit type indicator, description, ScoreSlider
  - First option expanded by default

### Integration
- `DecisionBuilder` renders `<MobileScoreCards>` (visible < 640px) before the existing score table (now `hidden sm:block`)
- Responsive breakpoint at `sm` (640px) — no layout shift, no double rendering

### CSS
- `.score-slider` thumb overrides in `globals.css` — 28px desktop, 44px mobile with `@media (max-width: 639px)`

### Tests
- **15 new tests** covering ScoreSlider attributes/interaction, MobileScoreCards accordion behavior, criterion descriptions, cost/benefit labels, updateScore propagation

## Verification
- TSC clean
- ESLint zero warnings
- 448 tests pass (433 existing + 15 new)
- Production build succeeds