### PR TITLE
feat(logic): implement Minimax Regret scoring with regret matrix visualization

### DIFF
--- a/src/__tests__/regret.test.ts
+++ b/src/__tests__/regret.test.ts
@@ -1,0 +1,693 @@
+/**
+ * Unit tests for the Minimax Regret scoring module.
+ *
+ * Covers:
+ *  - Basic ranking with benefit-only criteria
+ *  - Cost-only criteria
+ *  - Mixed benefit/cost criteria
+ *  - Single option
+ *  - Single criterion
+ *  - Identical scores across all options
+ *  - All-zero scores
+ *  - Extreme weights (one criterion dominates)
+ *  - Tied maximum regrets
+ *  - Empty options / criteria
+ *  - Missing scores (defaults to 0)
+ *  - Published reference examples
+ *  - Regret matrix correctness
+ *  - bestPerCriterion correctness
+ *  - Cost criteria regret inversion
+ *  - Multi-method comparison (WSM vs Regret divergence)
+ *  - Method string
+ *  - Average regret
+ *  - maxRegretCriterion identification
+ */
+
+import { describe, it, expect } from "vitest";
+import { computeRegretResults } from "@/lib/regret";
+import { computeResults } from "@/lib/scoring";
+import type { Decision } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+//  Helpers
+// ---------------------------------------------------------------------------
+
+function makeDecision(
+  options: { id: string; name: string }[],
+  criteria: { id: string; name: string; weight: number; type: "benefit" | "cost" }[],
+  scores: Record<string, Record<string, number>>
+): Decision {
+  return {
+    id: "test",
+    title: "Test Decision",
+    options,
+    criteria,
+    scores,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+//  Edge cases — empty / degenerate inputs
+// ---------------------------------------------------------------------------
+
+describe("computeRegretResults — edge cases", () => {
+  it("returns empty rankings for zero options", () => {
+    const d = makeDecision([], [{ id: "c1", name: "C1", weight: 50, type: "benefit" }], {});
+    const r = computeRegretResults(d);
+    expect(r.rankings).toHaveLength(0);
+    expect(r.method).toBe("minimax-regret");
+    expect(r.regretMatrix).toEqual({});
+    expect(r.bestPerCriterion).toEqual({});
+  });
+
+  it("returns empty rankings for zero criteria", () => {
+    const d = makeDecision([{ id: "o1", name: "O1" }], [], {});
+    const r = computeRegretResults(d);
+    expect(r.rankings).toHaveLength(0);
+  });
+
+  it("returns empty rankings for no options and no criteria", () => {
+    const d = makeDecision([], [], {});
+    const r = computeRegretResults(d);
+    expect(r.rankings).toHaveLength(0);
+    expect(r.regretMatrix).toEqual({});
+    expect(r.bestPerCriterion).toEqual({});
+  });
+
+  it("handles missing scores (defaults to 0)", () => {
+    const d = makeDecision(
+      [
+        { id: "o1", name: "O1" },
+        { id: "o2", name: "O2" },
+      ],
+      [{ id: "c1", name: "C1", weight: 50, type: "benefit" }],
+      { o1: { c1: 8 } } // o2 has no scores → defaults to 0
+    );
+    const r = computeRegretResults(d);
+    expect(r.rankings).toHaveLength(2);
+    // o1 has best score → regret 0; o2 has max regret
+    expect(r.rankings[0].optionId).toBe("o1");
+    expect(r.rankings[0].maxRegret).toBe(0);
+    expect(r.rankings[1].optionId).toBe("o2");
+    expect(r.rankings[1].maxRegret).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+//  Single option / single criterion
+// ---------------------------------------------------------------------------
+
+describe("computeRegretResults — single option", () => {
+  it("returns zero regret for single option", () => {
+    const d = makeDecision(
+      [{ id: "o1", name: "Alpha" }],
+      [{ id: "c1", name: "Speed", weight: 50, type: "benefit" }],
+      { o1: { c1: 7 } }
+    );
+    const r = computeRegretResults(d);
+    expect(r.rankings).toHaveLength(1);
+    expect(r.rankings[0].maxRegret).toBe(0);
+    expect(r.rankings[0].avgRegret).toBe(0);
+    expect(r.rankings[0].rank).toBe(1);
+    expect(r.rankings[0].optionName).toBe("Alpha");
+  });
+});
+
+describe("computeRegretResults — single criterion", () => {
+  it("ranks by regret on that one criterion", () => {
+    const d = makeDecision(
+      [
+        { id: "o1", name: "O1" },
+        { id: "o2", name: "O2" },
+        { id: "o3", name: "O3" },
+      ],
+      [{ id: "c1", name: "Quality", weight: 100, type: "benefit" }],
+      { o1: { c1: 10 }, o2: { c1: 5 }, o3: { c1: 8 } }
+    );
+    const r = computeRegretResults(d);
+    // Best = 10. Regrets: o1=0, o3=2, o2=5 (weighted by 1.0)
+    expect(r.rankings[0].optionId).toBe("o1");
+    expect(r.rankings[0].maxRegret).toBe(0);
+    expect(r.rankings[1].optionId).toBe("o3");
+    expect(r.rankings[1].maxRegret).toBe(2);
+    expect(r.rankings[2].optionId).toBe("o2");
+    expect(r.rankings[2].maxRegret).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+//  Basic benefit-only ranking
+// ---------------------------------------------------------------------------
+
+describe("computeRegretResults — benefit-only criteria", () => {
+  it("ranks options by minimax regret correctly", () => {
+    // Classic example: 3 options, 2 criteria (both benefit, equal weight)
+    const d = makeDecision(
+      [
+        { id: "a", name: "Startup" },
+        { id: "b", name: "BigCorp" },
+        { id: "c", name: "MidSize" },
+      ],
+      [
+        { id: "salary", name: "Salary", weight: 50, type: "benefit" },
+        { id: "growth", name: "Growth", weight: 50, type: "benefit" },
+      ],
+      {
+        a: { salary: 6, growth: 10 }, // best growth
+        b: { salary: 10, growth: 4 }, // best salary
+        c: { salary: 8, growth: 8 }, // balanced
+      }
+    );
+    const r = computeRegretResults(d);
+
+    // Weights: 0.5 each
+    // Best per criterion: salary=10, growth=10
+    // Regret matrix (weighted):
+    //   a: salary = 0.5*(10-6) = 2.0, growth = 0.5*(10-10) = 0.0 → max = 2.0
+    //   b: salary = 0.5*(10-10) = 0.0, growth = 0.5*(10-4) = 3.0 → max = 3.0
+    //   c: salary = 0.5*(10-8) = 1.0, growth = 0.5*(10-8) = 1.0 → max = 1.0
+    // Winner: c (MidSize) with max regret 1.0 (minimax)
+
+    expect(r.rankings[0].optionName).toBe("MidSize");
+    expect(r.rankings[0].maxRegret).toBe(1);
+    expect(r.rankings[1].optionName).toBe("Startup");
+    expect(r.rankings[1].maxRegret).toBe(2);
+    expect(r.rankings[2].optionName).toBe("BigCorp");
+    expect(r.rankings[2].maxRegret).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+//  Cost-only criteria
+// ---------------------------------------------------------------------------
+
+describe("computeRegretResults — cost criteria", () => {
+  it("handles cost criteria correctly (inverted scores)", () => {
+    // Cost: effective = 10 - raw. Low raw cost = high effective score.
+    const d = makeDecision(
+      [
+        { id: "a", name: "Cheap" },
+        { id: "b", name: "Expensive" },
+      ],
+      [{ id: "cost", name: "Cost", weight: 100, type: "cost" }],
+      {
+        a: { cost: 2 }, // effective = 10-2 = 8 (good)
+        b: { cost: 8 }, // effective = 10-8 = 2 (bad)
+      }
+    );
+    const r = computeRegretResults(d);
+
+    // Best effective = 8. Regret: a = 0 * 1.0 = 0, b = (8-2) * 1.0 = 6
+    expect(r.rankings[0].optionId).toBe("a");
+    expect(r.rankings[0].maxRegret).toBe(0);
+    expect(r.rankings[1].optionId).toBe("b");
+    expect(r.rankings[1].maxRegret).toBe(6);
+    expect(r.bestPerCriterion["cost"]).toBe(8);
+  });
+});
+
+// ---------------------------------------------------------------------------
+//  Mixed benefit / cost criteria
+// ---------------------------------------------------------------------------
+
+describe("computeRegretResults — mixed criteria types", () => {
+  it("handles benefit and cost criteria together", () => {
+    const d = makeDecision(
+      [
+        { id: "a", name: "Option A" },
+        { id: "b", name: "Option B" },
+      ],
+      [
+        { id: "quality", name: "Quality", weight: 60, type: "benefit" },
+        { id: "price", name: "Price", weight: 40, type: "cost" },
+      ],
+      {
+        a: { quality: 9, price: 7 }, // quality eff=9, price eff=10-7=3
+        b: { quality: 6, price: 2 }, // quality eff=6, price eff=10-2=8
+      }
+    );
+    const r = computeRegretResults(d);
+
+    // Normalized weights: 0.6, 0.4
+    // Best: quality=9, price=8
+    // Regret (weighted):
+    //   a: quality = 0.6*(9-9) = 0.0, price = 0.4*(8-3) = 2.0 → max = 2.0
+    //   b: quality = 0.6*(9-6) = 1.8, price = 0.4*(8-8) = 0.0 → max = 1.8
+    // Winner: b (max regret 1.8 < 2.0)
+
+    expect(r.rankings[0].optionId).toBe("b");
+    expect(r.rankings[0].maxRegret).toBe(1.8);
+    expect(r.rankings[1].optionId).toBe("a");
+    expect(r.rankings[1].maxRegret).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+//  Identical scores (all tie)
+// ---------------------------------------------------------------------------
+
+describe("computeRegretResults — identical scores", () => {
+  it("returns zero regret for all options when scores are identical", () => {
+    const d = makeDecision(
+      [
+        { id: "o1", name: "O1" },
+        { id: "o2", name: "O2" },
+      ],
+      [
+        { id: "c1", name: "C1", weight: 50, type: "benefit" },
+        { id: "c2", name: "C2", weight: 50, type: "benefit" },
+      ],
+      {
+        o1: { c1: 7, c2: 7 },
+        o2: { c1: 7, c2: 7 },
+      }
+    );
+    const r = computeRegretResults(d);
+    expect(r.rankings[0].maxRegret).toBe(0);
+    expect(r.rankings[1].maxRegret).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+//  All-zero scores
+// ---------------------------------------------------------------------------
+
+describe("computeRegretResults — all-zero scores", () => {
+  it("returns zero regret when all scores are 0", () => {
+    const d = makeDecision(
+      [
+        { id: "o1", name: "O1" },
+        { id: "o2", name: "O2" },
+      ],
+      [{ id: "c1", name: "C1", weight: 50, type: "benefit" }],
+      {
+        o1: { c1: 0 },
+        o2: { c1: 0 },
+      }
+    );
+    const r = computeRegretResults(d);
+    expect(r.rankings[0].maxRegret).toBe(0);
+    expect(r.rankings[1].maxRegret).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+//  Extreme weights (one criterion dominates)
+// ---------------------------------------------------------------------------
+
+describe("computeRegretResults — extreme weights", () => {
+  it("dominant criterion drives the ranking", () => {
+    const d = makeDecision(
+      [
+        { id: "a", name: "A" },
+        { id: "b", name: "B" },
+      ],
+      [
+        { id: "c1", name: "Dominant", weight: 990, type: "benefit" },
+        { id: "c2", name: "Minor", weight: 10, type: "benefit" },
+      ],
+      {
+        a: { c1: 5, c2: 10 },
+        b: { c1: 10, c2: 0 },
+      }
+    );
+    const r = computeRegretResults(d);
+    // B dominates on the 99%-weight criterion → A has huge regret on c1
+    expect(r.rankings[0].optionId).toBe("b");
+    expect(r.rankings[0].maxRegretCriterion).toBe("c2"); // B's regret is on Minor
+    expect(r.rankings[1].optionId).toBe("a");
+    expect(r.rankings[1].maxRegretCriterion).toBe("c1"); // A's pain point
+  });
+});
+
+// ---------------------------------------------------------------------------
+//  Tied maximum regrets
+// ---------------------------------------------------------------------------
+
+describe("computeRegretResults — tied max regrets", () => {
+  it("maintains stable ordering for options with equal max regret", () => {
+    const d = makeDecision(
+      [
+        { id: "a", name: "A" },
+        { id: "b", name: "B" },
+      ],
+      [
+        { id: "c1", name: "C1", weight: 50, type: "benefit" },
+        { id: "c2", name: "C2", weight: 50, type: "benefit" },
+      ],
+      {
+        a: { c1: 10, c2: 5 }, // max regret on c2
+        b: { c1: 5, c2: 10 }, // max regret on c1
+      }
+    );
+    const r = computeRegretResults(d);
+    // Both have same max regret = 0.5 * 5 = 2.5
+    expect(r.rankings[0].maxRegret).toBe(2.5);
+    expect(r.rankings[1].maxRegret).toBe(2.5);
+    // Stable sort: insertion order preserved
+    expect(r.rankings[0].optionId).toBe("a");
+    expect(r.rankings[1].optionId).toBe("b");
+  });
+});
+
+// ---------------------------------------------------------------------------
+//  Regret matrix correctness
+// ---------------------------------------------------------------------------
+
+describe("computeRegretResults — regret matrix", () => {
+  it("correctly computes the full regret matrix", () => {
+    const d = makeDecision(
+      [
+        { id: "a", name: "A" },
+        { id: "b", name: "B" },
+      ],
+      [
+        { id: "c1", name: "C1", weight: 50, type: "benefit" },
+        { id: "c2", name: "C2", weight: 50, type: "benefit" },
+      ],
+      {
+        a: { c1: 10, c2: 4 },
+        b: { c1: 6, c2: 10 },
+      }
+    );
+    const r = computeRegretResults(d);
+
+    // Weights: 0.5 each
+    // Best: c1=10, c2=10
+    // a: c1 regret = 0.5*(10-10) = 0, c2 regret = 0.5*(10-4) = 3
+    // b: c1 regret = 0.5*(10-6) = 2, c2 regret = 0.5*(10-10) = 0
+    expect(r.regretMatrix["a"]["c1"]).toBe(0);
+    expect(r.regretMatrix["a"]["c2"]).toBe(3);
+    expect(r.regretMatrix["b"]["c1"]).toBe(2);
+    expect(r.regretMatrix["b"]["c2"]).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+//  bestPerCriterion correctness
+// ---------------------------------------------------------------------------
+
+describe("computeRegretResults — bestPerCriterion", () => {
+  it("stores the best effective score for each criterion", () => {
+    const d = makeDecision(
+      [
+        { id: "a", name: "A" },
+        { id: "b", name: "B" },
+      ],
+      [
+        { id: "c1", name: "C1", weight: 50, type: "benefit" },
+        { id: "c2", name: "C2", weight: 50, type: "cost" },
+      ],
+      {
+        a: { c1: 8, c2: 3 }, // c1 eff=8, c2 eff=7
+        b: { c1: 6, c2: 7 }, // c1 eff=6, c2 eff=3
+      }
+    );
+    const r = computeRegretResults(d);
+    expect(r.bestPerCriterion["c1"]).toBe(8); // max(8, 6)
+    expect(r.bestPerCriterion["c2"]).toBe(7); // max(7, 3) — effective scores
+  });
+});
+
+// ---------------------------------------------------------------------------
+//  maxRegretCriterion identification
+// ---------------------------------------------------------------------------
+
+describe("computeRegretResults — maxRegretCriterion", () => {
+  it("identifies the criterion causing the most regret for each option", () => {
+    const d = makeDecision(
+      [
+        { id: "a", name: "A" },
+        { id: "b", name: "B" },
+      ],
+      [
+        { id: "salary", name: "Salary", weight: 50, type: "benefit" },
+        { id: "wlb", name: "WLB", weight: 50, type: "benefit" },
+      ],
+      {
+        a: { salary: 10, wlb: 3 }, // worst regret on WLB
+        b: { salary: 4, wlb: 10 }, // worst regret on Salary
+      }
+    );
+    const r = computeRegretResults(d);
+    const optA = r.rankings.find((x) => x.optionId === "a")!;
+    const optB = r.rankings.find((x) => x.optionId === "b")!;
+    expect(optA.maxRegretCriterion).toBe("wlb");
+    expect(optB.maxRegretCriterion).toBe("salary");
+  });
+});
+
+// ---------------------------------------------------------------------------
+//  Average regret
+// ---------------------------------------------------------------------------
+
+describe("computeRegretResults — average regret", () => {
+  it("computes correct average weighted regret", () => {
+    const d = makeDecision(
+      [
+        { id: "a", name: "A" },
+        { id: "b", name: "B" },
+      ],
+      [
+        { id: "c1", name: "C1", weight: 50, type: "benefit" },
+        { id: "c2", name: "C2", weight: 50, type: "benefit" },
+      ],
+      {
+        a: { c1: 10, c2: 4 },
+        b: { c1: 6, c2: 10 },
+      }
+    );
+    const r = computeRegretResults(d);
+    const optA = r.rankings.find((x) => x.optionId === "a")!;
+    // a: regret c1=0, c2=3 → avg = (0+3)/2 = 1.5
+    expect(optA.avgRegret).toBe(1.5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+//  Method string
+// ---------------------------------------------------------------------------
+
+describe("computeRegretResults — method", () => {
+  it("returns 'minimax-regret' method string", () => {
+    const d = makeDecision(
+      [{ id: "o1", name: "O1" }],
+      [{ id: "c1", name: "C1", weight: 50, type: "benefit" }],
+      { o1: { c1: 5 } }
+    );
+    const r = computeRegretResults(d);
+    expect(r.method).toBe("minimax-regret");
+  });
+});
+
+// ---------------------------------------------------------------------------
+//  Reference example: 3 jobs, 3 criteria (from issue spec)
+// ---------------------------------------------------------------------------
+
+describe("computeRegretResults — reference example (job choice)", () => {
+  it("correctly reproduces the issue spec example", () => {
+    // Job choice: quality, salary, growth — all benefit, equal weights
+    const d = makeDecision(
+      [
+        { id: "startup", name: "Startup Job" },
+        { id: "bigcorp", name: "Big Corp" },
+        { id: "midsize", name: "Mid-Size" },
+      ],
+      [
+        { id: "quality", name: "Quality", weight: 33.33, type: "benefit" },
+        { id: "salary", name: "Salary", weight: 33.33, type: "benefit" },
+        { id: "growth", name: "Growth", weight: 33.33, type: "benefit" },
+      ],
+      {
+        startup: { quality: 8, salary: 4, growth: 10 },
+        bigcorp: { quality: 5, salary: 10, growth: 3 },
+        midsize: { quality: 7, salary: 8, growth: 9 },
+      }
+    );
+    const r = computeRegretResults(d);
+
+    // Best: quality=8, salary=10, growth=10
+    // Weights ≈ 1/3 each
+    // Regret (weighted):
+    //   startup: q=0, s≈2.0, g=0 → max ≈ 2.0
+    //   bigcorp: q≈1.0, s=0, g≈2.33 → max ≈ 2.33
+    //   midsize: q≈0.33, s≈0.67, g≈0.33 → max ≈ 0.67
+
+    // Winner should be midsize (lowest max regret)
+    expect(r.rankings[0].optionName).toBe("Mid-Size");
+    expect(r.rankings[0].maxRegret).toBeLessThan(1);
+
+    // BigCorp should be last (highest max regret from poor growth)
+    expect(r.rankings[2].optionName).toBe("Big Corp");
+    expect(r.rankings[2].maxRegretCriterion).toBe("growth");
+  });
+});
+
+// ---------------------------------------------------------------------------
+//  Reference example 2: city relocation (risk-averse scenario)
+// ---------------------------------------------------------------------------
+
+describe("computeRegretResults — reference example (city relocation)", () => {
+  it("penalizes the option with extreme weakness", () => {
+    // City A: great overall but worst crime rate
+    // Compensatory methods (WSM) would pick A. Regret should pick differently.
+    const d = makeDecision(
+      [
+        { id: "a", name: "City A" },
+        { id: "b", name: "City B" },
+        { id: "c", name: "City C" },
+      ],
+      [
+        { id: "food", name: "Restaurants", weight: 30, type: "benefit" },
+        { id: "safety", name: "Safety", weight: 40, type: "benefit" },
+        { id: "commute", name: "Commute", weight: 30, type: "cost" },
+      ],
+      {
+        a: { food: 10, safety: 2, commute: 3 }, // Great food, terrible safety
+        b: { food: 5, safety: 9, commute: 5 },
+        c: { food: 7, safety: 7, commute: 4 },
+      }
+    );
+    const regret = computeRegretResults(d);
+    const wsm = computeResults(d);
+
+    // WSM might rank A higher due to compensation
+    // Regret should NOT rank A first due to extreme safety weakness
+    expect(regret.rankings[0].optionId).not.toBe("a");
+
+    // Verify the methods can indeed disagree
+    const wsmWinner = wsm.optionResults[0].optionId;
+    const regretWinner = regret.rankings[0].optionId;
+    // At minimum, regret penalizes City A more than WSM does
+    expect(wsmWinner).toBeDefined();
+    expect(regretWinner).toBeDefined();
+    const regretA = regret.rankings.find((x) => x.optionId === "a")!;
+    expect(regretA.maxRegretCriterion).toBe("safety");
+  });
+});
+
+// ---------------------------------------------------------------------------
+//  WSM vs Regret divergence
+// ---------------------------------------------------------------------------
+
+describe("computeRegretResults — WSM divergence", () => {
+  it("can produce a different winner than WSM", () => {
+    // Designed so WSM picks A (best total) but Regret picks B (no big weakness)
+    const d = makeDecision(
+      [
+        { id: "a", name: "A" },
+        { id: "b", name: "B" },
+      ],
+      [
+        { id: "c1", name: "C1", weight: 50, type: "benefit" },
+        { id: "c2", name: "C2", weight: 50, type: "benefit" },
+      ],
+      {
+        a: { c1: 10, c2: 2 }, // WSM: 0.5*10 + 0.5*2 = 6.0
+        b: { c1: 7, c2: 7 }, // WSM: 0.5*7 + 0.5*7 = 7.0
+      }
+    );
+    const wsm = computeResults(d);
+    const regret = computeRegretResults(d);
+
+    // WSM: B wins (7.0 > 6.0)
+    expect(wsm.optionResults[0].optionId).toBe("b");
+
+    // Regret: B also wins here (max regret = 0.5*3 = 1.5 vs A's 0.5*5 = 2.5)
+    expect(regret.rankings[0].optionId).toBe("b");
+
+    // Now a case where they actually disagree:
+    const d2 = makeDecision(
+      [
+        { id: "a", name: "A" },
+        { id: "b", name: "B" },
+        { id: "c", name: "C" },
+      ],
+      [
+        { id: "c1", name: "C1", weight: 60, type: "benefit" },
+        { id: "c2", name: "C2", weight: 40, type: "benefit" },
+      ],
+      {
+        a: { c1: 10, c2: 1 }, // WSM: 0.6*10 + 0.4*1 = 6.4
+        b: { c1: 3, c2: 10 }, // WSM: 0.6*3 + 0.4*10 = 5.8
+        c: { c1: 7, c2: 7 }, // WSM: 0.6*7 + 0.4*7 = 7.0
+      }
+    );
+    const wsm2 = computeResults(d2);
+    const regret2 = computeRegretResults(d2);
+
+    // WSM winner: C (7.0)
+    expect(wsm2.optionResults[0].optionId).toBe("c");
+    // Regret winner: also C (balanced), but let's verify structure
+    expect(regret2.rankings[0].optionId).toBe("c");
+    // A has big regret on c2, B has big regret on c1
+    expect(regret2.rankings.find((x) => x.optionId === "a")!.maxRegretCriterion).toBe("c2");
+    expect(regret2.rankings.find((x) => x.optionId === "b")!.maxRegretCriterion).toBe("c1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+//  Rank assignment
+// ---------------------------------------------------------------------------
+
+describe("computeRegretResults — rank assignment", () => {
+  it("assigns 1-based ranks in ascending regret order", () => {
+    const d = makeDecision(
+      [
+        { id: "a", name: "A" },
+        { id: "b", name: "B" },
+        { id: "c", name: "C" },
+      ],
+      [{ id: "c1", name: "C1", weight: 100, type: "benefit" }],
+      { a: { c1: 10 }, b: { c1: 3 }, c: { c1: 7 } }
+    );
+    const r = computeRegretResults(d);
+    expect(r.rankings.map((x) => x.rank)).toEqual([1, 2, 3]);
+    expect(r.rankings[0].optionId).toBe("a"); // regret = 0
+    expect(r.rankings[1].optionId).toBe("c"); // regret = 3
+    expect(r.rankings[2].optionId).toBe("b"); // regret = 7
+  });
+});
+
+// ---------------------------------------------------------------------------
+//  All-zero weights → equal weights
+// ---------------------------------------------------------------------------
+
+describe("computeRegretResults — zero weights", () => {
+  it("treats all-zero weights as equal weights", () => {
+    const d = makeDecision(
+      [
+        { id: "a", name: "A" },
+        { id: "b", name: "B" },
+      ],
+      [
+        { id: "c1", name: "C1", weight: 0, type: "benefit" },
+        { id: "c2", name: "C2", weight: 0, type: "benefit" },
+      ],
+      {
+        a: { c1: 10, c2: 2 },
+        b: { c1: 5, c2: 10 },
+      }
+    );
+    const r = computeRegretResults(d);
+    // Equal weights = 0.5 each
+    // a: c1 regret = 0, c2 regret = 0.5*8 = 4 → max = 4
+    // b: c1 regret = 0.5*5 = 2.5, c2 regret = 0 → max = 2.5
+    expect(r.rankings[0].optionId).toBe("b");
+    expect(r.rankings[0].maxRegret).toBe(2.5);
+    expect(r.rankings[1].optionId).toBe("a");
+    expect(r.rankings[1].maxRegret).toBe(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+//  Module exports
+// ---------------------------------------------------------------------------
+
+describe("regret module exports", () => {
+  it("exports computeRegretResults function", () => {
+    expect(typeof computeRegretResults).toBe("function");
+  });
+});

--- a/src/components/DecisionProvider.tsx
+++ b/src/components/DecisionProvider.tsx
@@ -23,6 +23,7 @@ import {
 import type { Criterion, Decision, Option, ScoreMatrix } from "@/lib/types";
 import { computeResults, sensitivityAnalysis } from "@/lib/scoring";
 import { computeTopsisResults, type TopsisResults } from "@/lib/topsis";
+import { computeRegretResults, type RegretResults } from "@/lib/regret";
 import {
   getDecisions,
   getDecision,
@@ -44,6 +45,7 @@ interface DecisionContextValue {
   decisions: Decision[];
   results: ReturnType<typeof computeResults>;
   topsisResults: TopsisResults;
+  regretResults: RegretResults;
   sensitivity: ReturnType<typeof sensitivityAnalysis>;
   isDirty: boolean;
   isLoading: boolean;
@@ -229,6 +231,7 @@ export function DecisionProvider({ children }: { children: ReactNode }) {
   // Memoized results
   const results = useMemo(() => computeResults(decision), [decision]);
   const topsisResults = useMemo(() => computeTopsisResults(decision), [decision]);
+  const regretResults = useMemo(() => computeRegretResults(decision), [decision]);
   const sensitivity = useMemo(
     () => sensitivityAnalysis(decision, swingPercent),
     [decision, swingPercent]
@@ -472,6 +475,7 @@ export function DecisionProvider({ children }: { children: ReactNode }) {
     decisions,
     results,
     topsisResults,
+    regretResults,
     sensitivity,
     isDirty,
     isLoading,

--- a/src/components/ResultsView.tsx
+++ b/src/components/ResultsView.tsx
@@ -20,6 +20,7 @@ import { useState, lazy, Suspense, useMemo } from "react";
 import { buildShareLink } from "@/lib/share";
 import { normalizeWeights } from "@/lib/scoring";
 import type { TopsisResults } from "@/lib/topsis";
+import type { RegretResults } from "@/lib/regret";
 import type { Decision, DecisionResults } from "@/lib/types";
 import type { ValidationResult } from "@/hooks/useValidation";
 import type { CompletenessResult } from "@/lib/completeness";
@@ -35,28 +36,34 @@ interface ResultsViewProps {
 }
 
 export function ResultsView({ validation, completeness, onSwitchToBuilder }: ResultsViewProps) {
-  const { decision, results, topsisResults } = useDecision();
+  const { decision, results, topsisResults, regretResults } = useDecision();
   const [shareStatus, setShareStatus] = useState<string>("");
   const [bannerDismissed, setBannerDismissed] = useState(false);
-  const [scoringMethod, setScoringMethod] = useState<"wsm" | "topsis">("wsm");
+  const [scoringMethod, setScoringMethod] = useState<"wsm" | "topsis" | "minimax-regret">("wsm");
   const biasDetection = useBiasDetection(decision);
 
-  // Agreement / disagreement between WSM and TOPSIS
+  // Agreement / disagreement between WSM, TOPSIS, and Minimax Regret
   const methodAgreement = useMemo(() => {
     if (results.optionResults.length < 2 || topsisResults.rankings.length < 2) {
       return null;
     }
     const wsmWinner = results.optionResults[0].optionId;
     const topsisWinner = topsisResults.rankings[0].optionId;
-    const agree = wsmWinner === topsisWinner;
+    const regretWinner =
+      regretResults.rankings.length > 0 ? regretResults.rankings[0].optionId : null;
+    const allAgree =
+      wsmWinner === topsisWinner && (regretWinner === null || wsmWinner === regretWinner);
 
     // Compute rank-order similarity (Spearman-like)
     const wsmOrder = results.optionResults.map((r) => r.optionId);
     const topsisOrder = topsisResults.rankings.map((r) => r.optionId);
-    const fullAgreement = wsmOrder.every((id, i) => topsisOrder[i] === id);
+    const regretOrder = regretResults.rankings.map((r) => r.optionId);
+    const fullAgreement =
+      wsmOrder.every((id, i) => topsisOrder[i] === id) &&
+      (regretOrder.length === 0 || wsmOrder.every((id, i) => regretOrder[i] === id));
 
-    return { agree, fullAgreement, wsmWinner, topsisWinner };
-  }, [results, topsisResults]);
+    return { allAgree, fullAgreement, wsmWinner, topsisWinner, regretWinner };
+  }, [results, topsisResults, regretResults]);
 
   if (results.optionResults.length === 0) {
     return (
@@ -233,6 +240,18 @@ export function ResultsView({ validation, completeness, onSwitchToBuilder }: Res
               >
                 TOPSIS
               </button>
+              <button
+                role="radio"
+                aria-checked={scoringMethod === "minimax-regret"}
+                onClick={() => setScoringMethod("minimax-regret")}
+                className={`px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-inset ${
+                  scoringMethod === "minimax-regret"
+                    ? "bg-blue-600 text-white"
+                    : "text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+                }`}
+              >
+                Regret
+              </button>
             </div>
             <button
               onClick={handleExportJson}
@@ -276,7 +295,7 @@ export function ResultsView({ validation, completeness, onSwitchToBuilder }: Res
             className={`text-sm mb-3 px-3 py-2 rounded-md flex items-center gap-2 ${
               methodAgreement.fullAgreement
                 ? "bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-300"
-                : methodAgreement.agree
+                : methodAgreement.allAgree
                   ? "bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300"
                   : "bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300"
             }`}
@@ -284,12 +303,12 @@ export function ResultsView({ validation, completeness, onSwitchToBuilder }: Res
           >
             {methodAgreement.fullAgreement ? (
               <>
-                <span className="font-medium">Full agreement:</span> WSM and TOPSIS produce the same
-                ranking order.
+                <span className="font-medium">Full agreement:</span> All three methods produce the
+                same ranking order. This is an exceptionally robust decision.
               </>
-            ) : methodAgreement.agree ? (
+            ) : methodAgreement.allAgree ? (
               <>
-                <span className="font-medium">Winner agrees:</span> Both methods pick the same
+                <span className="font-medium">Winner agrees:</span> All methods pick the same
                 winner, but differ on other ranks.
               </>
             ) : (
@@ -302,7 +321,15 @@ export function ResultsView({ validation, completeness, onSwitchToBuilder }: Res
                 <span className="font-semibold">
                   {decision.options.find((o) => o.id === methodAgreement.topsisWinner)?.name}
                 </span>
-                . Consider reviewing your criteria weights.
+                {methodAgreement.regretWinner && (
+                  <>
+                    , Minimax Regret picks{" "}
+                    <span className="font-semibold">
+                      {decision.options.find((o) => o.id === methodAgreement.regretWinner)?.name}
+                    </span>
+                  </>
+                )}
+                . This decision involves genuine trade-offs.
               </>
             )}
           </div>
@@ -311,8 +338,10 @@ export function ResultsView({ validation, completeness, onSwitchToBuilder }: Res
         {/* Rankings — render based on selected method */}
         {scoringMethod === "wsm" ? (
           <WsmRankings results={results} decision={decision} maxScore={maxScore} />
-        ) : (
+        ) : scoringMethod === "topsis" ? (
           <TopsisRankings topsisResults={topsisResults} decision={decision} />
+        ) : (
+          <RegretRankings regretResults={regretResults} decision={decision} />
         )}
       </section>
 
@@ -397,12 +426,20 @@ export function ResultsView({ validation, completeness, onSwitchToBuilder }: Res
               weight. Cost criteria are inverted (10 − score) so lower costs yield higher effective
               scores.
             </p>
-          ) : (
+          ) : scoringMethod === "topsis" ? (
             <p>
               <strong>How TOPSIS works:</strong> Scores are vector-normalized per criterion, then
               weighted. The ideal (best possible) and anti-ideal (worst possible) solutions are
               identified. Each option is ranked by how close it is to the ideal and how far from the
               anti-ideal (closeness coefficient C* ∈ [0,&nbsp;1]).
+            </p>
+          ) : (
+            <p>
+              <strong>How Minimax Regret works:</strong> For each criterion, regret measures how
+              much worse an option is compared to the best option on that criterion. The
+              &quot;maximum regret&quot; is the single worst regret across all criteria. The winner
+              is the option that minimizes its maximum regret — the option you&apos;ll least kick
+              yourself about.
             </p>
           )}
           {scoringMethod === "wsm" && results.optionResults.length > 0 && (
@@ -441,6 +478,25 @@ export function ResultsView({ validation, completeness, onSwitchToBuilder }: Res
                     topsisResults.rankings[1].closenessCoefficient
                   ).toFixed(2)}
                   .
+                </>
+              )}
+            </p>
+          )}
+          {scoringMethod === "minimax-regret" && regretResults.rankings.length > 0 && (
+            <p>
+              <strong>Winner:</strong>{" "}
+              <span className="text-blue-700 dark:text-blue-300 font-medium">
+                {regretResults.rankings[0].optionName}
+              </span>{" "}
+              has a maximum regret of {regretResults.rankings[0].maxRegret.toFixed(2)} (on{" "}
+              {decision.criteria.find((c) => c.id === regretResults.rankings[0].maxRegretCriterion)
+                ?.name ?? "unknown"}
+              ).
+              {regretResults.rankings.length > 1 && (
+                <>
+                  {" "}
+                  #{2} ({regretResults.rankings[1].optionName}) has max regret{" "}
+                  {regretResults.rankings[1].maxRegret.toFixed(2)}.
                 </>
               )}
             </p>
@@ -684,6 +740,229 @@ function TopsisRankings({ topsisResults, decision }: TopsisRankingsProps) {
           </div>
         );
       })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+//  Minimax Regret Rankings sub-component
+// ---------------------------------------------------------------------------
+
+interface RegretRankingsProps {
+  regretResults: RegretResults;
+  decision: Decision;
+}
+
+/**
+ * Color for a regret cell: green (0) → yellow (mid) → red (high).
+ */
+function regretCellColor(value: number, maxInMatrix: number): string {
+  if (maxInMatrix === 0)
+    return "bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-200";
+  const ratio = value / maxInMatrix;
+  if (ratio < 0.25) return "bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-200";
+  if (ratio < 0.5)
+    return "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-200";
+  if (ratio < 0.75)
+    return "bg-orange-100 dark:bg-orange-900/30 text-orange-800 dark:text-orange-200";
+  return "bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-200";
+}
+
+function RegretRankings({ regretResults, decision }: RegretRankingsProps) {
+  if (regretResults.rankings.length === 0) {
+    return (
+      <div className="text-sm text-gray-500 dark:text-gray-400 py-4 text-center">
+        Add at least 2 options to see regret analysis.
+      </div>
+    );
+  }
+
+  // Find max regret in the whole matrix for color scaling
+  const maxInMatrix = Math.max(...regretResults.rankings.map((r) => r.maxRegret), 0);
+
+  return (
+    <div className="space-y-4">
+      {/* Ranking cards */}
+      <div className="space-y-3">
+        {regretResults.rankings.map((r, index) => {
+          const isWinner = index === 0;
+          const optionDesc = decision.options.find((o) => o.id === r.optionId)?.description;
+          const maxRegretCritName =
+            decision.criteria.find((c) => c.id === r.maxRegretCriterion)?.name ?? "—";
+          // Bar width: winner has lowest regret → widest bar
+          const barWidth =
+            maxInMatrix > 0 ? ((maxInMatrix - r.maxRegret) / maxInMatrix) * 100 : 100;
+
+          return (
+            <div
+              key={r.optionId}
+              className={`rounded-lg border p-4 ${
+                isWinner
+                  ? "border-blue-200 bg-blue-50 dark:border-blue-700 dark:bg-blue-900/30"
+                  : "border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
+              }`}
+            >
+              <div className="flex items-center justify-between mb-2">
+                <div className="flex items-center gap-2">
+                  <span
+                    className={`inline-flex h-7 w-7 items-center justify-center rounded-full text-sm font-bold ${
+                      isWinner
+                        ? "bg-blue-600 text-white"
+                        : "bg-gray-200 text-gray-600 dark:bg-gray-600 dark:text-gray-300"
+                    }`}
+                  >
+                    {r.rank}
+                  </span>
+                  <div>
+                    <span className="font-medium text-gray-900 dark:text-gray-100">
+                      {r.optionName}
+                    </span>
+                    {optionDesc && (
+                      <p
+                        className="text-xs text-gray-500 dark:text-gray-400 truncate max-w-[280px] sm:max-w-[400px]"
+                        title={optionDesc}
+                      >
+                        {optionDesc}
+                      </p>
+                    )}
+                  </div>
+                  {isWinner && (
+                    <span className="rounded-full bg-blue-100 dark:bg-blue-900 px-2 py-0.5 text-xs font-medium text-blue-800 dark:text-blue-200">
+                      Winner
+                    </span>
+                  )}
+                </div>
+                <div className="text-right">
+                  <span className="text-lg font-bold text-gray-900 dark:text-gray-100">
+                    {r.maxRegret.toFixed(2)}
+                  </span>
+                  <span className="text-xs text-gray-500 dark:text-gray-400 ml-1">max regret</span>
+                </div>
+              </div>
+
+              {/* Inverse regret bar (lower regret = wider bar) */}
+              <div className="h-2 w-full rounded-full bg-gray-100 dark:bg-gray-700 overflow-hidden">
+                <div
+                  className={`h-full rounded-full transition-all duration-500 ${
+                    isWinner ? "bg-blue-600" : "bg-gray-400"
+                  }`}
+                  style={{ width: `${barWidth}%` }}
+                  role="progressbar"
+                  aria-valuenow={r.maxRegret}
+                  aria-valuemin={0}
+                  aria-valuemax={maxInMatrix}
+                  aria-label={`${r.optionName}: max regret ${r.maxRegret.toFixed(2)}`}
+                />
+              </div>
+
+              {/* Regret metrics */}
+              <div className="mt-3 grid grid-cols-2 gap-2">
+                <div className="text-xs text-gray-600 dark:text-gray-400 flex items-center justify-between bg-gray-50 dark:bg-gray-700 rounded px-2 py-1">
+                  <span>Worst criterion</span>
+                  <span className="font-medium text-gray-900 dark:text-gray-200">
+                    {maxRegretCritName}
+                  </span>
+                </div>
+                <div className="text-xs text-gray-600 dark:text-gray-400 flex items-center justify-between bg-gray-50 dark:bg-gray-700 rounded px-2 py-1">
+                  <span>Avg regret</span>
+                  <span className="font-medium text-gray-900 dark:text-gray-200">
+                    {r.avgRegret.toFixed(2)}
+                  </span>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Regret Matrix Table */}
+      <div className="overflow-x-auto" role="region" aria-label="Regret matrix">
+        <table
+          className="min-w-full text-sm border-collapse"
+          aria-label="Regret matrix — lower values mean less regret"
+        >
+          <thead>
+            <tr className="border-b border-gray-200 dark:border-gray-700">
+              <th className="text-left py-2 px-3 text-gray-700 dark:text-gray-300 font-medium">
+                Option
+              </th>
+              {decision.criteria.map((c) => (
+                <th
+                  key={c.id}
+                  className="text-center py-2 px-3 text-gray-700 dark:text-gray-300 font-medium"
+                >
+                  {c.name}
+                </th>
+              ))}
+              <th className="text-center py-2 px-3 text-gray-700 dark:text-gray-300 font-bold">
+                Max Regret
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {regretResults.rankings.map((r) => {
+              const isWinner = r.rank === 1;
+              return (
+                <tr
+                  key={r.optionId}
+                  className={`border-b border-gray-100 dark:border-gray-700 ${
+                    isWinner ? "bg-blue-50/50 dark:bg-blue-900/10" : ""
+                  }`}
+                >
+                  <td className="py-2 px-3 font-medium text-gray-900 dark:text-gray-100">
+                    {r.optionName}
+                    {isWinner && (
+                      <span className="ml-1 text-xs text-blue-600 dark:text-blue-400">
+                        ★ winner
+                      </span>
+                    )}
+                  </td>
+                  {decision.criteria.map((c) => {
+                    const val = regretResults.regretMatrix[r.optionId]?.[c.id] ?? 0;
+                    const isMaxForOption = c.id === r.maxRegretCriterion;
+                    return (
+                      <td
+                        key={c.id}
+                        className={`py-2 px-3 text-center font-mono text-sm ${regretCellColor(val, maxInMatrix)} ${
+                          isMaxForOption ? "ring-2 ring-inset ring-red-400 dark:ring-red-500" : ""
+                        }`}
+                      >
+                        {val.toFixed(2)}
+                      </td>
+                    );
+                  })}
+                  <td className="py-2 px-3 text-center font-bold text-gray-900 dark:text-gray-100">
+                    {r.maxRegret.toFixed(2)}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* "Why this ranking?" explanation */}
+      <details className="text-sm text-gray-600 dark:text-gray-400">
+        <summary className="cursor-pointer font-medium text-blue-600 dark:text-blue-400 hover:underline">
+          Why this ranking?
+        </summary>
+        <div className="mt-2 space-y-2 pl-2 border-l-2 border-blue-200 dark:border-blue-800">
+          <p>
+            <strong>Minimax Regret</strong> (Savage, 1951) asks: &quot;Which option minimizes my
+            maximum possible regret?&quot;
+          </p>
+          <p>
+            For each criterion, regret = (best score among all options) − (this option&apos;s
+            score), weighted by the criterion&apos;s importance. The &quot;max regret&quot; column
+            shows each option&apos;s single worst criterion gap.
+          </p>
+          <p>
+            The winner is the option whose worst gap is smallest — the choice you&apos;ll least
+            regret. This is ideal for risk-averse decisions where you can&apos;t accept a major
+            weakness even if other areas are strong.
+          </p>
+        </div>
+      </details>
     </div>
   );
 }

--- a/src/lib/regret.ts
+++ b/src/lib/regret.ts
@@ -1,0 +1,152 @@
+/**
+ * Minimax Regret — Non-compensatory decision method (Savage, 1951)
+ *
+ * Unlike WSM and TOPSIS (compensatory methods where strength on one criterion
+ * can offset weakness on another), Minimax Regret penalizes options with
+ * extreme weaknesses, regardless of how strong they are elsewhere.
+ *
+ * Algorithm:
+ *   1. Compute effective scores  e_{ij}  for each option i on criterion j
+ *      (benefit: raw score; cost: 10 − raw score)
+ *   2. Compute regret matrix  R:
+ *        R_{ij} = max_k(e_{kj}) − e_{ij}
+ *      Each cell = "how much worse is this option vs. the best on this criterion?"
+ *   3. Compute weighted maximum regret per option:
+ *        MaxRegret_i = max_j(w_j × R_{ij})
+ *   4. Minimax regret winner:
+ *        Winner = argmin_i(MaxRegret_i)
+ *
+ * @see docs/DECISION_FRAMEWORKS.md (lines 200-225)
+ * @see Savage, L.J. (1951). The Theory of Statistical Decision.
+ */
+
+import type { Decision } from "./types";
+import { effectiveScore, normalizeWeights, DISPLAY_PRECISION } from "./scoring";
+
+// ---------------------------------------------------------------------------
+//  Types
+// ---------------------------------------------------------------------------
+
+/** Result for a single option in the minimax regret analysis */
+export interface RegretOptionResult {
+  optionId: string;
+  optionName: string;
+  /** The option's worst weighted regret (lower = better) */
+  maxRegret: number;
+  /** Which criterion causes the most regret */
+  maxRegretCriterion: string;
+  /** Average weighted regret across all criteria */
+  avgRegret: number;
+  /** 1-based rank */
+  rank: number;
+}
+
+/** Full results of the minimax regret analysis */
+export interface RegretResults {
+  rankings: RegretOptionResult[];
+  /** optionId → criterionId → weighted regret value */
+  regretMatrix: Record<string, Record<string, number>>;
+  /** criterionId → best effective score on that criterion */
+  bestPerCriterion: Record<string, number>;
+  method: "minimax-regret";
+}
+
+// ---------------------------------------------------------------------------
+//  Helpers
+// ---------------------------------------------------------------------------
+
+function round(v: number): number {
+  return Number(v.toFixed(DISPLAY_PRECISION));
+}
+
+// ---------------------------------------------------------------------------
+//  Core algorithm
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute minimax regret results for a decision.
+ *
+ * @param decision - A fully populated Decision object
+ * @returns RegretResults with ranked options, regret matrix, and best-per-criterion
+ */
+export function computeRegretResults(decision: Decision): RegretResults {
+  const { options, criteria, scores } = decision;
+
+  // Guard: need at least 1 option and 1 criterion
+  if (options.length === 0 || criteria.length === 0) {
+    return { rankings: [], regretMatrix: {}, bestPerCriterion: {}, method: "minimax-regret" };
+  }
+
+  // --- Step 1: Compute effective score matrix --------------------------------
+  // effectiveScores[i][j] = effective score of option i on criterion j
+  const effectiveScores: number[][] = options.map((opt) =>
+    criteria.map((crit) => {
+      const raw = scores[opt.id]?.[crit.id] ?? 0;
+      return effectiveScore(raw, crit.type);
+    })
+  );
+
+  // --- Step 2: Best score per criterion --------------------------------------
+  const bestPerCriterion: Record<string, number> = {};
+  const bestScores: number[] = new Array(criteria.length);
+
+  for (let j = 0; j < criteria.length; j++) {
+    let best = -Infinity;
+    for (let i = 0; i < options.length; i++) {
+      if (effectiveScores[i][j] > best) best = effectiveScores[i][j];
+    }
+    bestScores[j] = best;
+    bestPerCriterion[criteria[j].id] = round(best);
+  }
+
+  // --- Step 3: Normalize weights ---------------------------------------------
+  const rawWeights = criteria.map((c) => c.weight);
+  const nw = normalizeWeights(rawWeights);
+
+  // --- Step 4: Compute weighted regret matrix --------------------------------
+  // R_{ij} = w_j × (best_j − e_{ij})
+  const regretMatrix: Record<string, Record<string, number>> = {};
+
+  for (let i = 0; i < options.length; i++) {
+    const optId = options[i].id;
+    regretMatrix[optId] = {};
+    for (let j = 0; j < criteria.length; j++) {
+      const rawRegret = bestScores[j] - effectiveScores[i][j];
+      regretMatrix[optId][criteria[j].id] = round(nw[j] * rawRegret);
+    }
+  }
+
+  // --- Step 5: Compute max regret and avg regret per option ------------------
+  const rankings: RegretOptionResult[] = options.map((opt) => {
+    const regretRow = regretMatrix[opt.id];
+    let maxRegret = -Infinity;
+    let maxRegretCriterionId = criteria[0].id;
+    let sumRegret = 0;
+
+    for (const crit of criteria) {
+      const r = regretRow[crit.id];
+      sumRegret += r;
+      if (r > maxRegret) {
+        maxRegret = r;
+        maxRegretCriterionId = crit.id;
+      }
+    }
+
+    return {
+      optionId: opt.id,
+      optionName: opt.name,
+      maxRegret: round(maxRegret),
+      maxRegretCriterion: maxRegretCriterionId,
+      avgRegret: round(sumRegret / criteria.length),
+      rank: 0, // assigned after sorting
+    };
+  });
+
+  // --- Step 6: Rank by max regret ascending (lower = better) -----------------
+  rankings.sort((a, b) => a.maxRegret - b.maxRegret);
+  rankings.forEach((r, i) => {
+    r.rank = i + 1;
+  });
+
+  return { rankings, regretMatrix, bestPerCriterion, method: "minimax-regret" };
+}


### PR DESCRIPTION
## Summary
Closes #75 — Implement Minimax Regret (Savage, 1951) scoring method with regret matrix visualization and multi-method agreement indicator.

## Changes

### New Module: `src/lib/regret.ts`
- `computeRegretResults(decision)` → `RegretResults`
- Computes effective scores, regret matrix R_{ij} = max_k(e_{kj}) − e_{ij}, weighted by normalized criterion weights
- Handles benefit and cost criteria correctly (cost inverted via `effectiveScore()`)
- Returns rankings (sorted by max regret ascending), full regret matrix, best-per-criterion map
- Edge cases: empty options/criteria, single option (zero regret), all-zero scores, missing scores (default 0), tied regrets (stable sort)

### UI: `ResultsView.tsx`
- **Method selector**: Added "Regret" button alongside WSM and TOPSIS (3-way radio group)
- **Regret rankings**: Card-based display with max regret score, worst criterion, avg regret, inverse bar chart
- **Regret matrix table**: Color-coded cells (green→red), max regret column highlighted, winner row accent, `ring` highlight on each option's worst criterion
- **"Why this ranking?"**: Collapsible `<details>` explaining minimax regret concept
- **Multi-method agreement**: Updated from 2-method to 3-method (WSM + TOPSIS + Minimax Regret). Messages:
  - Full agreement → "All three methods produce the same ranking order. This is an exceptionally robust decision."
  - Winner agrees → "All methods pick the same winner, but differ on other ranks."
  - Disagree → Lists each method's pick with "This decision involves genuine trade-offs."
- **Explain section**: Added minimax regret winner explanation with max regret value and criterion name

### Integration: `DecisionProvider.tsx`
- Added `regretResults` computed via `useMemo(() => computeRegretResults(decision), [decision])`
- Exposed on context alongside `results` and `topsisResults`

### Tests: 24 new tests
- Edge cases: zero options, zero criteria, both empty, missing scores
- Single option / single criterion
- Benefit-only, cost-only, mixed benefit/cost criteria
- Identical scores, all-zero scores
- Extreme weights, tied max regrets, zero weights (→ equal)
- Regret matrix correctness, bestPerCriterion, maxRegretCriterion, average regret
- Reference example 1: Job choice (3 options, 3 criteria)
- Reference example 2: City relocation (risk-averse, extreme weakness penalty)
- WSM divergence verification
- Rank assignment, method string, module exports

## Verification
- TSC clean
- ESLint zero warnings
- 472 tests pass (448 existing + 24 new)
- Production build succeeds