### PR TITLE
feat(logic): per-score confidence levels and null-score handling

### DIFF
--- a/src/__tests__/components/MobileScoreCards.test.tsx
+++ b/src/__tests__/components/MobileScoreCards.test.tsx
@@ -88,12 +88,12 @@ function makeDecision(): Decision {
 describe("MobileScoreCards", () => {
   let decision: Decision;
   let updateScore: ReturnType<
-    typeof vi.fn<(optionId: string, criterionId: string, value: number) => void>
+    typeof vi.fn<(optionId: string, criterionId: string, value: number | null) => void>
   >;
 
   beforeEach(() => {
     decision = makeDecision();
-    updateScore = vi.fn<(optionId: string, criterionId: string, value: number) => void>();
+    updateScore = vi.fn<(optionId: string, criterionId: string, value: number | null) => void>();
   });
 
   it("renders a card for each option", () => {

--- a/src/__tests__/import.test.ts
+++ b/src/__tests__/import.test.ts
@@ -265,7 +265,7 @@ describe("csvToDecision", () => {
     expect(decision.scores[opt1Id][crit1Id]).toBe(4);
   });
 
-  it("defaults null scores to 0", () => {
+  it("preserves null scores from CSV", () => {
     const preview = {
       headers: ["A"],
       rows: [{ option: "X", scores: [null] as (number | null)[] }],
@@ -274,7 +274,7 @@ describe("csvToDecision", () => {
     const decision = csvToDecision(preview, "Test", ["benefit"], [50]);
     const optId = decision.options[0].id;
     const critId = decision.criteria[0].id;
-    expect(decision.scores[optId][critId]).toBe(0);
+    expect(decision.scores[optId][critId]).toBeNull();
   });
 
   it("uses default title when empty", () => {

--- a/src/__tests__/score-confidence.test.ts
+++ b/src/__tests__/score-confidence.test.ts
@@ -1,0 +1,649 @@
+/**
+ * Per-Score Confidence & Null-Score Handling — Unit Tests
+ *
+ * Covers:
+ *  - ScoreValue helpers: resolveScoreValue, resolveConfidence, isScoredCell,
+ *    readScore, readScoreOrZero
+ *  - scoreOption with null scores (excluded, re-normalized)
+ *  - Backward compat (plain numbers behave identically)
+ *  - TOPSIS / regret with null scores
+ *  - Completeness with null cells
+ *  - Share encoding / decoding with null + confidence
+ *  - Import with null scores
+ *  - Monte Carlo: hasNonHighConfidence, perturbScores, simulation with confidence
+ *
+ * @see https://github.com/ericsocrat/decision-os/issues/76
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  resolveScoreValue,
+  resolveConfidence,
+  isScoredCell,
+  readScore,
+  readScoreOrZero,
+  scoreOption,
+  normalizeWeights,
+  computeResults,
+} from "@/lib/scoring";
+import {
+  createPRNG,
+  perturbScores,
+  hasNonHighConfidence,
+  CONFIDENCE_PERTURBATION,
+  runMonteCarloSimulation,
+} from "@/lib/monte-carlo";
+import { decisionToSharePayload, sharePayloadToDecision } from "@/lib/share";
+import { computeCompleteness } from "@/lib/completeness";
+import type { Decision, Criterion, ScoreMatrix, ScoreValue, ScoredCell } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeDecision(overrides: Partial<Decision> = {}): Decision {
+  return {
+    id: "test-1",
+    title: "Test Decision",
+    description: "",
+    options: [
+      { id: "opt-a", name: "Option A" },
+      { id: "opt-b", name: "Option B" },
+    ],
+    criteria: [
+      { id: "c1", name: "Speed", weight: 50, type: "benefit" },
+      { id: "c2", name: "Cost", weight: 50, type: "cost" },
+    ],
+    scores: {
+      "opt-a": { c1: 8, c2: 3 },
+      "opt-b": { c1: 6, c2: 7 },
+    },
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+const scoredCell = (value: number, confidence: "high" | "medium" | "low"): ScoredCell => ({
+  value,
+  confidence,
+});
+
+// ===========================================================================
+// resolveScoreValue
+// ===========================================================================
+
+describe("resolveScoreValue", () => {
+  it("returns null for null", () => {
+    expect(resolveScoreValue(null)).toBeNull();
+  });
+
+  it("returns null for undefined", () => {
+    expect(resolveScoreValue(undefined)).toBeNull();
+  });
+
+  it("returns the number for a plain number", () => {
+    expect(resolveScoreValue(7)).toBe(7);
+  });
+
+  it("returns .value for a ScoredCell", () => {
+    expect(resolveScoreValue(scoredCell(5, "medium"))).toBe(5);
+  });
+
+  it("handles zero as a valid number", () => {
+    expect(resolveScoreValue(0)).toBe(0);
+  });
+});
+
+// ===========================================================================
+// resolveConfidence
+// ===========================================================================
+
+describe("resolveConfidence", () => {
+  it("returns null for null", () => {
+    expect(resolveConfidence(null)).toBeNull();
+  });
+
+  it("returns null for undefined", () => {
+    expect(resolveConfidence(undefined)).toBeNull();
+  });
+
+  it('returns "high" for a plain number', () => {
+    expect(resolveConfidence(7)).toBe("high");
+  });
+
+  it("returns the confidence from a ScoredCell", () => {
+    expect(resolveConfidence(scoredCell(5, "low"))).toBe("low");
+    expect(resolveConfidence(scoredCell(5, "medium"))).toBe("medium");
+    expect(resolveConfidence(scoredCell(5, "high"))).toBe("high");
+  });
+});
+
+// ===========================================================================
+// isScoredCell
+// ===========================================================================
+
+describe("isScoredCell", () => {
+  it("returns true for a ScoredCell object", () => {
+    expect(isScoredCell(scoredCell(3, "low"))).toBe(true);
+  });
+
+  it("returns false for a plain number", () => {
+    expect(isScoredCell(7)).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isScoredCell(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isScoredCell(undefined)).toBe(false);
+  });
+});
+
+// ===========================================================================
+// readScore / readScoreOrZero
+// ===========================================================================
+
+describe("readScore", () => {
+  const scores: ScoreMatrix = {
+    opt1: { c1: 8, c2: null, c3: scoredCell(5, "low") },
+  };
+
+  it("reads a plain number", () => {
+    expect(readScore(scores, "opt1", "c1")).toBe(8);
+  });
+
+  it("returns null for a null cell", () => {
+    expect(readScore(scores, "opt1", "c2")).toBeNull();
+  });
+
+  it("unwraps a ScoredCell value", () => {
+    expect(readScore(scores, "opt1", "c3")).toBe(5);
+  });
+
+  it("returns null for a missing option", () => {
+    expect(readScore(scores, "missing", "c1")).toBeNull();
+  });
+
+  it("returns null for a missing criterion", () => {
+    expect(readScore(scores, "opt1", "missing")).toBeNull();
+  });
+});
+
+describe("readScoreOrZero", () => {
+  const scores: ScoreMatrix = {
+    opt1: { c1: 8, c2: null },
+  };
+
+  it("reads a plain number", () => {
+    expect(readScoreOrZero(scores, "opt1", "c1")).toBe(8);
+  });
+
+  it("returns 0 for a null cell", () => {
+    expect(readScoreOrZero(scores, "opt1", "c2")).toBe(0);
+  });
+
+  it("returns 0 for a missing option", () => {
+    expect(readScoreOrZero(scores, "missing", "c1")).toBe(0);
+  });
+});
+
+// ===========================================================================
+// scoreOption — null score handling
+// ===========================================================================
+
+describe("scoreOption with null scores", () => {
+  const criteria: Criterion[] = [
+    { id: "c1", name: "Speed", weight: 60, type: "benefit" },
+    { id: "c2", name: "Cost", weight: 40, type: "cost" },
+  ];
+  const nw = normalizeWeights(criteria.map((c) => c.weight));
+
+  it("excludes null cells and re-normalizes by scored weight sum", () => {
+    // opt-a has only c1 scored (8/10 benefit), c2 is null
+    const scores: ScoreMatrix = { "opt-a": { c1: 8, c2: null } };
+    const result = scoreOption("opt-a", "Option A", criteria, scores, nw);
+
+    // With only c1 scored: effectiveScore = 8, weight = 0.6
+    // totalScore = (8 * 0.6) / 0.6 = 8.0
+    expect(result.totalScore).toBe(8);
+  });
+
+  it("marks null cells as isNull in criterionScores", () => {
+    const scores: ScoreMatrix = { "opt-a": { c1: 8, c2: null } };
+    const result = scoreOption("opt-a", "Option A", criteria, scores, nw);
+    const c2Score = result.criterionScores.find((cs) => cs.criterionId === "c2");
+    expect(c2Score?.isNull).toBe(true);
+  });
+
+  it("uses rawScore=0 for null cells in criterionScores breakdown", () => {
+    const scores: ScoreMatrix = { "opt-a": { c1: 8, c2: null } };
+    const result = scoreOption("opt-a", "Option A", criteria, scores, nw);
+    const c2Score = result.criterionScores.find((cs) => cs.criterionId === "c2");
+    expect(c2Score?.rawScore).toBe(0);
+  });
+
+  it("returns 0 when all cells are null", () => {
+    const scores: ScoreMatrix = { "opt-a": { c1: null, c2: null } };
+    const result = scoreOption("opt-a", "Option A", criteria, scores, nw);
+    expect(result.totalScore).toBe(0);
+  });
+
+  it("backward compat: plain numbers produce same result as before", () => {
+    const scores: ScoreMatrix = { "opt-a": { c1: 8, c2: 3 } };
+    const result = scoreOption("opt-a", "Option A", criteria, scores, nw);
+
+    // benefit c1: eff = 8, cost c2: eff = 10 - 3 = 7
+    // total = 8 * 0.6 + 7 * 0.4 = 4.8 + 2.8 = 7.6
+    expect(result.totalScore).toBe(7.6);
+  });
+});
+
+// ===========================================================================
+// computeResults with mixed null/scored cells
+// ===========================================================================
+
+describe("computeResults with null scores", () => {
+  it("ranks options correctly when some cells are null", () => {
+    const decision = makeDecision({
+      scores: {
+        "opt-a": { c1: 8, c2: null },
+        "opt-b": { c1: 6, c2: 7 },
+      },
+    });
+    const results = computeResults(decision);
+
+    // opt-a: only c1 scored → total = 8.0
+    // opt-b: both scored → 6*0.5 + (10-7)*0.5 = 3 + 1.5 = 4.5
+    expect(results.optionResults[0].optionId).toBe("opt-a");
+    expect(results.optionResults[0].totalScore).toBe(8);
+    expect(results.optionResults[1].optionId).toBe("opt-b");
+    expect(results.optionResults[1].totalScore).toBe(4.5);
+  });
+
+  it("handles ScoredCell values correctly in computation", () => {
+    const decision = makeDecision({
+      scores: {
+        "opt-a": { c1: scoredCell(8, "low"), c2: scoredCell(3, "medium") },
+        "opt-b": { c1: 6, c2: 7 },
+      },
+    });
+    const results = computeResults(decision);
+
+    // ScoredCell extracts .value — same result as plain numbers
+    // makeDecision uses [50,50] weights: 8*0.5 + (10-3)*0.5 = 4 + 3.5 = 7.5
+    const optA = results.optionResults.find((r) => r.optionId === "opt-a");
+    expect(optA?.totalScore).toBe(7.5);
+  });
+});
+
+// ===========================================================================
+// Completeness with null cells
+// ===========================================================================
+
+describe("computeCompleteness with null cells", () => {
+  it("counts null cells as unfilled", () => {
+    const decision = makeDecision({
+      scores: {
+        "opt-a": { c1: 8, c2: null },
+        "opt-b": { c1: null, c2: null },
+      },
+    });
+    const result = computeCompleteness(decision);
+
+    // Total cells: 2 options × 2 criteria = 4
+    // Filled: 1 (opt-a/c1)
+    expect(result.filled).toBe(1);
+    expect(result.total).toBe(4);
+  });
+
+  it("ScoredCell counts as filled", () => {
+    const decision = makeDecision({
+      scores: {
+        "opt-a": { c1: scoredCell(8, "low"), c2: scoredCell(3, "medium") },
+        "opt-b": { c1: 6, c2: 7 },
+      },
+    });
+    const result = computeCompleteness(decision);
+    expect(result.filled).toBe(4);
+    expect(result.total).toBe(4);
+  });
+});
+
+// ===========================================================================
+// Share encoding / decoding — null + confidence
+// ===========================================================================
+
+describe("share encoding/decoding with null + confidence", () => {
+  it("round-trips null scores", () => {
+    const decision = makeDecision({
+      scores: {
+        "opt-a": { c1: 8, c2: null },
+        "opt-b": { c1: null, c2: 5 },
+      },
+    });
+    const payload = decisionToSharePayload(decision);
+
+    expect(payload.s[0][1]).toBeNull(); // opt-a/c2 = null
+    expect(payload.s[1][0]).toBeNull(); // opt-b/c1 = null
+
+    const decoded = sharePayloadToDecision(payload);
+    expect(readScore(decoded.scores, decoded.options[0].id, decoded.criteria[1].id)).toBeNull();
+    expect(readScore(decoded.scores, decoded.options[1].id, decoded.criteria[0].id)).toBeNull();
+    // Non-null scores preserved
+    expect(readScore(decoded.scores, decoded.options[0].id, decoded.criteria[0].id)).toBe(8);
+    expect(readScore(decoded.scores, decoded.options[1].id, decoded.criteria[1].id)).toBe(5);
+  });
+
+  it("includes cf grid when non-high confidence exists", () => {
+    const decision = makeDecision({
+      scores: {
+        "opt-a": { c1: scoredCell(8, "low"), c2: 3 },
+        "opt-b": { c1: 6, c2: scoredCell(7, "medium") },
+      },
+    });
+    const payload = decisionToSharePayload(decision);
+
+    // cf grid should exist
+    expect(payload.cf).toBeDefined();
+    // opt-a/c1 = low → 2, opt-a/c2 = high → 0
+    expect(payload.cf![0][0]).toBe(2);
+    expect(payload.cf![0][1]).toBe(0);
+    // opt-b/c1 = high → 0, opt-b/c2 = medium → 1
+    expect(payload.cf![1][0]).toBe(0);
+    expect(payload.cf![1][1]).toBe(1);
+  });
+
+  it("omits cf grid when all cells are high confidence", () => {
+    const decision = makeDecision({
+      scores: {
+        "opt-a": { c1: 8, c2: 3 },
+        "opt-b": { c1: 6, c2: 7 },
+      },
+    });
+    const payload = decisionToSharePayload(decision);
+    expect(payload.cf).toBeUndefined();
+  });
+
+  it("round-trips confidence levels", () => {
+    const decision = makeDecision({
+      scores: {
+        "opt-a": { c1: scoredCell(8, "low"), c2: scoredCell(3, "medium") },
+        "opt-b": { c1: 6, c2: scoredCell(7, "low") },
+      },
+    });
+    const payload = decisionToSharePayload(decision);
+    const decoded = sharePayloadToDecision(payload);
+
+    // opt-a/c1 should be low confidence
+    const optA = decoded.options[0].id;
+    const c1 = decoded.criteria[0].id;
+    const c2 = decoded.criteria[1].id;
+
+    expect(resolveConfidence(decoded.scores[optA]?.[c1])).toBe("low");
+    expect(resolveConfidence(decoded.scores[optA]?.[c2])).toBe("medium");
+
+    // opt-b/c1 was plain number → decoded as plain (high)
+    const optB = decoded.options[1].id;
+    expect(resolveScoreValue(decoded.scores[optB]?.[c1])).toBe(6);
+    expect(resolveConfidence(decoded.scores[optB]?.[c2])).toBe("low");
+  });
+});
+
+// ===========================================================================
+// Monte Carlo — hasNonHighConfidence
+// ===========================================================================
+
+describe("hasNonHighConfidence", () => {
+  it("returns false for all-plain-number matrix", () => {
+    const scores: ScoreMatrix = {
+      o1: { c1: 8, c2: 5 },
+    };
+    expect(hasNonHighConfidence(scores)).toBe(false);
+  });
+
+  it("returns false for all-high ScoredCell matrix", () => {
+    const scores: ScoreMatrix = {
+      o1: { c1: scoredCell(8, "high"), c2: scoredCell(5, "high") },
+    };
+    expect(hasNonHighConfidence(scores)).toBe(false);
+  });
+
+  it("returns true when any cell has medium confidence", () => {
+    const scores: ScoreMatrix = {
+      o1: { c1: 8, c2: scoredCell(5, "medium") },
+    };
+    expect(hasNonHighConfidence(scores)).toBe(true);
+  });
+
+  it("returns true when any cell has low confidence", () => {
+    const scores: ScoreMatrix = {
+      o1: { c1: scoredCell(8, "low"), c2: 5 },
+    };
+    expect(hasNonHighConfidence(scores)).toBe(true);
+  });
+
+  it("returns false for empty matrix", () => {
+    expect(hasNonHighConfidence({})).toBe(false);
+  });
+
+  it("handles null cells gracefully", () => {
+    const scores: ScoreMatrix = {
+      o1: { c1: null, c2: 5 },
+    };
+    expect(hasNonHighConfidence(scores)).toBe(false);
+  });
+});
+
+// ===========================================================================
+// Monte Carlo — CONFIDENCE_PERTURBATION multipliers
+// ===========================================================================
+
+describe("CONFIDENCE_PERTURBATION", () => {
+  it("has correct multipliers", () => {
+    expect(CONFIDENCE_PERTURBATION.high).toBe(1.0);
+    expect(CONFIDENCE_PERTURBATION.medium).toBe(1.5);
+    expect(CONFIDENCE_PERTURBATION.low).toBe(2.5);
+  });
+});
+
+// ===========================================================================
+// Monte Carlo — perturbScores
+// ===========================================================================
+
+describe("perturbScores", () => {
+  const options = [{ id: "o1" }, { id: "o2" }];
+  const criteria = [{ id: "c1" }, { id: "c2" }];
+
+  it("preserves null cells as null", () => {
+    const scores: ScoreMatrix = {
+      o1: { c1: 8, c2: null },
+      o2: { c1: null, c2: 5 },
+    };
+    const rand = createPRNG(42);
+    const result = perturbScores(scores, options, criteria, rand, 0.15, "uniform");
+
+    expect(result.o1.c2).toBeNull();
+    expect(result.o2.c1).toBeNull();
+  });
+
+  it("perturbs plain number cells", () => {
+    const scores: ScoreMatrix = {
+      o1: { c1: 5, c2: 5 },
+      o2: { c1: 5, c2: 5 },
+    };
+    const rand = createPRNG(42);
+    const result = perturbScores(scores, options, criteria, rand, 0.15, "uniform");
+
+    // Scores should be perturbed — at least some should differ from 5
+    const vals = [result.o1.c1, result.o1.c2, result.o2.c1, result.o2.c2];
+    const numericVals = vals.map((v) => resolveScoreValue(v as ScoreValue));
+    const anyDifferent = numericVals.some((v) => v !== 5);
+    expect(anyDifferent).toBe(true);
+  });
+
+  it("clamps results to [0, 10]", () => {
+    const scores: ScoreMatrix = {
+      o1: { c1: 0.1, c2: 9.9 },
+      o2: { c1: 10, c2: 0 },
+    };
+    // Run many times with different seeds
+    for (let seed = 1; seed <= 50; seed++) {
+      const rand = createPRNG(seed);
+      const result = perturbScores(scores, options, criteria, rand, 0.5, "uniform");
+      for (const optId of Object.keys(result)) {
+        for (const critId of Object.keys(result[optId])) {
+          const v = resolveScoreValue(result[optId][critId]);
+          if (v !== null) {
+            expect(v).toBeGreaterThanOrEqual(0);
+            expect(v).toBeLessThanOrEqual(10);
+          }
+        }
+      }
+    }
+  });
+
+  it("is deterministic with the same seed", () => {
+    const scores: ScoreMatrix = {
+      o1: { c1: 8, c2: 3 },
+      o2: { c1: 6, c2: 7 },
+    };
+    const r1 = perturbScores(scores, options, criteria, createPRNG(99), 0.15, "uniform");
+    const r2 = perturbScores(scores, options, criteria, createPRNG(99), 0.15, "uniform");
+
+    expect(resolveScoreValue(r1.o1.c1 as ScoreValue)).toBe(
+      resolveScoreValue(r2.o1.c1 as ScoreValue)
+    );
+    expect(resolveScoreValue(r1.o2.c2 as ScoreValue)).toBe(
+      resolveScoreValue(r2.o2.c2 as ScoreValue)
+    );
+  });
+
+  it("low-confidence cells have wider perturbation than high", () => {
+    // Statistical test: over many seeds, low-confidence cells should have
+    // higher variance than high-confidence cells with the same base value.
+    const scoresHigh: ScoreMatrix = {
+      o1: { c1: scoredCell(5, "high"), c2: scoredCell(5, "high") },
+      o2: { c1: scoredCell(5, "high"), c2: scoredCell(5, "high") },
+    };
+    const scoresLow: ScoreMatrix = {
+      o1: { c1: scoredCell(5, "low"), c2: scoredCell(5, "low") },
+      o2: { c1: scoredCell(5, "low"), c2: scoredCell(5, "low") },
+    };
+
+    let varianceHigh = 0;
+    let varianceLow = 0;
+    const N = 200;
+
+    for (let i = 1; i <= N; i++) {
+      const rH = perturbScores(scoresHigh, options, criteria, createPRNG(i), 0.15, "uniform");
+      const rL = perturbScores(scoresLow, options, criteria, createPRNG(i), 0.15, "uniform");
+      const vH = resolveScoreValue(rH.o1.c1 as ScoreValue)!;
+      const vL = resolveScoreValue(rL.o1.c1 as ScoreValue)!;
+      varianceHigh += (vH - 5) ** 2;
+      varianceLow += (vL - 5) ** 2;
+    }
+
+    varianceHigh /= N;
+    varianceLow /= N;
+
+    // Low-confidence should have higher variance
+    expect(varianceLow).toBeGreaterThan(varianceHigh);
+  });
+});
+
+// ===========================================================================
+// Monte Carlo — full simulation with confidence
+// ===========================================================================
+
+describe("runMonteCarloSimulation with confidence", () => {
+  it("runs successfully with ScoredCell scores", () => {
+    const decision = makeDecision({
+      options: [
+        { id: "o1", name: "A" },
+        { id: "o2", name: "B" },
+      ],
+      criteria: [
+        { id: "c1", name: "Speed", weight: 50, type: "benefit" },
+        { id: "c2", name: "Cost", weight: 50, type: "cost" },
+      ],
+      scores: {
+        o1: { c1: scoredCell(8, "low"), c2: scoredCell(3, "medium") },
+        o2: { c1: 6, c2: 7 },
+      },
+    });
+
+    const result = runMonteCarloSimulation(decision, {
+      numSimulations: 100,
+      seed: 42,
+    });
+
+    expect(result.options).toHaveLength(2);
+    expect(result.options[0].winProbability + result.options[1].winProbability).toBeCloseTo(1.0, 5);
+  });
+
+  it("runs successfully with null scores", () => {
+    const decision = makeDecision({
+      scores: {
+        "opt-a": { c1: 8, c2: null },
+        "opt-b": { c1: null, c2: 7 },
+      },
+    });
+
+    const result = runMonteCarloSimulation(decision, {
+      numSimulations: 100,
+      seed: 42,
+    });
+
+    expect(result.options).toHaveLength(2);
+    // Should complete without errors
+    expect(result.elapsedMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("produces different distributions for low vs high confidence", () => {
+    const highConfDecision = makeDecision({
+      options: [
+        { id: "o1", name: "A" },
+        { id: "o2", name: "B" },
+      ],
+      criteria: [
+        { id: "c1", name: "Speed", weight: 50, type: "benefit" },
+        { id: "c2", name: "Cost", weight: 50, type: "cost" },
+      ],
+      scores: {
+        o1: { c1: scoredCell(8, "high"), c2: scoredCell(3, "high") },
+        o2: { c1: scoredCell(6, "high"), c2: scoredCell(7, "high") },
+      },
+    });
+
+    const lowConfDecision = makeDecision({
+      options: [
+        { id: "o1", name: "A" },
+        { id: "o2", name: "B" },
+      ],
+      criteria: [
+        { id: "c1", name: "Speed", weight: 50, type: "benefit" },
+        { id: "c2", name: "Cost", weight: 50, type: "cost" },
+      ],
+      scores: {
+        o1: { c1: scoredCell(8, "low"), c2: scoredCell(3, "low") },
+        o2: { c1: scoredCell(6, "low"), c2: scoredCell(7, "low") },
+      },
+    });
+
+    const resultHigh = runMonteCarloSimulation(highConfDecision, {
+      numSimulations: 500,
+      seed: 42,
+    });
+    const resultLow = runMonteCarloSimulation(lowConfDecision, {
+      numSimulations: 500,
+      seed: 42,
+    });
+
+    // Low-confidence should have wider std deviations
+    const highStd = resultHigh.options[0].stdDev;
+    const lowStd = resultLow.options[0].stdDev;
+    expect(lowStd).toBeGreaterThan(highStd);
+  });
+});

--- a/src/__tests__/scoring.test.ts
+++ b/src/__tests__/scoring.test.ts
@@ -130,11 +130,10 @@ describe("scoreOption", () => {
     expect(result.criterionScores[1].effectiveScore).toBe(4.0);
   });
 
-  it("treats missing scores as 0", () => {
+  it("treats missing scores as null (not scored)", () => {
     const result = scoreOption("opt_missing", "Missing", criteria, {}, nw);
-    // c1 (cost): eff = 10-0 = 10, weighted = 5.0
-    // c2 (benefit): eff = 0, weighted = 0
-    expect(result.totalScore).toBe(5.0);
+    // All cells are null (missing) → excluded from computation → 0
+    expect(result.totalScore).toBe(0);
   });
 });
 

--- a/src/__tests__/share.test.ts
+++ b/src/__tests__/share.test.ts
@@ -93,10 +93,11 @@ describe("decisionToSharePayload", () => {
   test("handles missing scores gracefully", () => {
     const missing = { ...sampleDecision, scores: {} };
     const payload = decisionToSharePayload(missing);
+    // Missing scores are encoded as null (not scored)
     expect(payload.s).toEqual([
-      [0, 0, 0],
-      [0, 0, 0],
-      [0, 0, 0],
+      [null, null, null],
+      [null, null, null],
+      [null, null, null],
     ]);
   });
 });

--- a/src/__tests__/templates.test.ts
+++ b/src/__tests__/templates.test.ts
@@ -74,11 +74,11 @@ describe("instantiateTemplate", () => {
     expect(new Set(allIds).size).toBe(allIds.length);
   });
 
-  it("initializes all scores to 0", () => {
+  it("initializes all scores to null (not yet scored)", () => {
     const decision = instantiateTemplate(TEMPLATES[0]);
     for (const opt of decision.options) {
       for (const crit of decision.criteria) {
-        expect(decision.scores[opt.id][crit.id]).toBe(0);
+        expect(decision.scores[opt.id][crit.id]).toBeNull();
       }
     }
   });

--- a/src/components/ConfidenceDot.tsx
+++ b/src/components/ConfidenceDot.tsx
@@ -1,0 +1,50 @@
+/**
+ * ConfidenceDot — Small colored indicator for per-cell confidence level.
+ *
+ * Renders a clickable dot that cycles through high → medium → low → high.
+ * - 🟢 High confidence (default)
+ * - 🟡 Medium confidence
+ * - 🔴 Low confidence
+ *
+ * Accessible: aria-label describes the level, keyboard-toggleable.
+ */
+
+"use client";
+
+import type { Confidence } from "@/lib/types";
+
+interface ConfidenceDotProps {
+  confidence: Confidence;
+  onChange: (next: Confidence) => void;
+  /** Size variant */
+  size?: "sm" | "md";
+}
+
+const CYCLE: Confidence[] = ["high", "medium", "low"];
+
+const CONF_COLORS: Record<Confidence, string> = {
+  high: "bg-green-500",
+  medium: "bg-amber-400",
+  low: "bg-red-500",
+};
+
+const CONF_LABELS: Record<Confidence, string> = {
+  high: "High confidence",
+  medium: "Medium confidence",
+  low: "Low confidence",
+};
+
+export function ConfidenceDot({ confidence, onChange, size = "sm" }: ConfidenceDotProps) {
+  const next = CYCLE[(CYCLE.indexOf(confidence) + 1) % CYCLE.length];
+  const dotSize = size === "sm" ? "w-2 h-2" : "w-2.5 h-2.5";
+
+  return (
+    <button
+      type="button"
+      onClick={() => onChange(next)}
+      className={`inline-flex items-center justify-center rounded-full ${dotSize} ${CONF_COLORS[confidence]} ring-1 ring-inset ring-black/10 dark:ring-white/20 cursor-pointer hover:scale-125 transition-transform focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1`}
+      aria-label={`${CONF_LABELS[confidence]} — click to change to ${CONF_LABELS[next].toLowerCase()}`}
+      title={CONF_LABELS[confidence]}
+    />
+  );
+}

--- a/src/components/DecisionBuilder.tsx
+++ b/src/components/DecisionBuilder.tsx
@@ -23,6 +23,8 @@ import type { CriterionType } from "@/lib/types";
 import type { ValidationResult } from "@/hooks/useValidation";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { computeCompleteness } from "@/lib/completeness";
+import { readScore, resolveConfidence } from "@/lib/scoring";
+import { ConfidenceDot } from "./ConfidenceDot";
 import { CompletionRing } from "./CompletionRing";
 import { WeightSlider } from "./WeightSlider";
 import { WeightDistributionBar } from "./WeightDistributionBar";
@@ -46,6 +48,7 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
     updateCriterion,
     removeCriterion,
     updateScore,
+    updateConfidence,
     undo,
     redo,
     canUndo,
@@ -556,7 +559,11 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
         </span>
 
         {/* Mobile: Card-based scoring (< 640px) */}
-        <MobileScoreCards decision={decision} updateScore={updateScore} />
+        <MobileScoreCards
+          decision={decision}
+          updateScore={updateScore}
+          updateConfidence={updateConfidence}
+        />
 
         {/* Desktop: Table layout (≥ 640px) */}
         <div className="hidden sm:block overflow-x-auto">
@@ -608,32 +615,55 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
                   <td className="px-3 py-2 text-sm font-medium text-gray-900 dark:text-gray-100 border-b border-gray-100 dark:border-gray-700">
                     {opt.name}
                   </td>
-                  {decision.criteria.map((crit, colIdx) => (
-                    <td
-                      key={crit.id}
-                      className="px-3 py-2 text-center border-b border-gray-100 dark:border-gray-700"
-                    >
-                      <input
-                        type="number"
-                        min={0}
-                        max={10}
-                        step={1}
-                        value={decision.scores[opt.id]?.[crit.id] ?? 0}
-                        onChange={(e) => {
-                          const v = Number(e.target.value);
-                          if (Number.isFinite(v)) {
-                            updateScore(opt.id, crit.id, Math.max(0, Math.min(10, v)));
-                          }
-                        }}
-                        onKeyDown={(e) => handleGridKeyDown(e, rowIdx, colIdx)}
-                        data-grid-row={rowIdx}
-                        data-grid-col={colIdx}
-                        className="w-14 rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-2 py-1.5 text-sm text-center focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                        aria-label={`Score for ${opt.name} on ${crit.name}`}
-                        aria-describedby="score-range-desc"
-                      />
-                    </td>
-                  ))}
+                  {decision.criteria.map((crit, colIdx) => {
+                    const cellValue = readScore(decision.scores, opt.id, crit.id);
+                    const isNull = cellValue === null;
+                    const confidence = resolveConfidence(decision.scores[opt.id]?.[crit.id]);
+                    return (
+                      <td
+                        key={crit.id}
+                        className="px-3 py-2 text-center border-b border-gray-100 dark:border-gray-700"
+                      >
+                        <div className="inline-flex items-center gap-1">
+                          <input
+                            type="number"
+                            min={0}
+                            max={10}
+                            step={1}
+                            value={isNull ? "" : cellValue}
+                            placeholder={isNull ? "?" : undefined}
+                            onChange={(e) => {
+                              const raw = e.target.value;
+                              if (raw === "") {
+                                updateScore(opt.id, crit.id, null);
+                              } else {
+                                const v = Number(raw);
+                                if (Number.isFinite(v)) {
+                                  updateScore(opt.id, crit.id, Math.max(0, Math.min(10, v)));
+                                }
+                              }
+                            }}
+                            onKeyDown={(e) => handleGridKeyDown(e, rowIdx, colIdx)}
+                            data-grid-row={rowIdx}
+                            data-grid-col={colIdx}
+                            className={`w-14 rounded-md px-2 py-1.5 text-sm text-center focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 ${
+                              isNull
+                                ? "border-2 border-dashed border-gray-300 dark:border-gray-500 bg-gray-50 dark:bg-gray-800 text-gray-400 dark:text-gray-500 placeholder:text-gray-400 dark:placeholder:text-gray-500"
+                                : "border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+                            }`}
+                            aria-label={`Score for ${opt.name} on ${crit.name}${isNull ? " (not scored)" : ""}`}
+                            aria-describedby="score-range-desc"
+                          />
+                          {confidence && (
+                            <ConfidenceDot
+                              confidence={confidence}
+                              onChange={(next) => updateConfidence(opt.id, crit.id, next)}
+                            />
+                          )}
+                        </div>
+                      </td>
+                    );
+                  })}
                 </tr>
               ))}
             </tbody>

--- a/src/components/DecisionProvider.tsx
+++ b/src/components/DecisionProvider.tsx
@@ -20,8 +20,8 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import type { Criterion, Decision, Option, ScoreMatrix } from "@/lib/types";
-import { computeResults, sensitivityAnalysis } from "@/lib/scoring";
+import type { Confidence, Criterion, Decision, Option, ScoreMatrix } from "@/lib/types";
+import { computeResults, sensitivityAnalysis, resolveScoreValue } from "@/lib/scoring";
 import { computeTopsisResults, type TopsisResults } from "@/lib/topsis";
 import { computeRegretResults, type RegretResults } from "@/lib/regret";
 import {
@@ -72,7 +72,8 @@ interface DecisionContextValue {
   removeCriterion: (id: string) => void;
 
   // Scores
-  updateScore: (optionId: string, criterionId: string, value: number) => void;
+  updateScore: (optionId: string, criterionId: string, value: number | null) => void;
+  updateConfidence: (optionId: string, criterionId: string, confidence: Confidence) => void;
 
   // Sensitivity
   swingPercent: number;
@@ -457,13 +458,44 @@ export function DecisionProvider({ children }: { children: ReactNode }) {
 
   // Scores
   const updateScore = useCallback(
-    (optionId: string, criterionId: string, value: number) => {
-      const clamped = Math.max(0, Math.min(10, Math.round(value)));
+    (optionId: string, criterionId: string, value: number | null) => {
       const newScores = { ...decision.scores };
       if (!newScores[optionId]) newScores[optionId] = {};
+      if (value === null) {
+        // Set to null (unscored)
+        newScores[optionId] = {
+          ...newScores[optionId],
+          [criterionId]: null,
+        };
+      } else {
+        const clamped = Math.max(0, Math.min(10, Math.round(value)));
+        // Preserve existing confidence if cell was a ScoredCell
+        const existing = newScores[optionId]?.[criterionId];
+        const existingConf =
+          typeof existing === "object" && existing !== null && "confidence" in existing
+            ? existing.confidence
+            : undefined;
+        newScores[optionId] = {
+          ...newScores[optionId],
+          [criterionId]: existingConf ? { value: clamped, confidence: existingConf } : clamped,
+        };
+      }
+      setDecision({ ...decision, scores: newScores });
+    },
+    [decision, setDecision]
+  );
+
+  // Confidence toggle
+  const updateConfidence = useCallback(
+    (optionId: string, criterionId: string, confidence: Confidence) => {
+      const newScores = { ...decision.scores };
+      if (!newScores[optionId]) newScores[optionId] = {};
+      const existing = newScores[optionId]?.[criterionId];
+      const numValue = resolveScoreValue(existing);
+      if (numValue === null) return; // Can't set confidence on unscored cell
       newScores[optionId] = {
         ...newScores[optionId],
-        [criterionId]: clamped,
+        [criterionId]: { value: numValue, confidence },
       };
       setDecision({ ...decision, scores: newScores });
     },
@@ -493,6 +525,7 @@ export function DecisionProvider({ children }: { children: ReactNode }) {
     updateCriterion,
     removeCriterion,
     updateScore,
+    updateConfidence,
     swingPercent,
     setSwingPercent,
     undo,

--- a/src/components/MobileScoreCards.tsx
+++ b/src/components/MobileScoreCards.tsx
@@ -11,11 +11,15 @@
 import { useCallback, useState } from "react";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import { ScoreSlider } from "./ScoreSlider";
-import type { Criterion, Decision, Option } from "@/lib/types";
+import type { Criterion, Decision, Option, ScoreValue } from "@/lib/types";
+import { resolveScoreValue, resolveConfidence } from "@/lib/scoring";
+import { ConfidenceDot } from "./ConfidenceDot";
+import type { Confidence } from "@/lib/types";
 
 interface MobileScoreCardsProps {
   decision: Decision;
-  updateScore: (optionId: string, criterionId: string, value: number) => void;
+  updateScore: (optionId: string, criterionId: string, value: number | null) => void;
+  updateConfidence?: (optionId: string, criterionId: string, confidence: Confidence) => void;
 }
 
 /** Letter label for option index (A, B, C, …) */
@@ -32,14 +36,16 @@ function OptionCard({
   expanded,
   onToggle,
   updateScore,
+  updateConfidence,
 }: {
   option: Option;
   index: number;
   criteria: Criterion[];
-  scores: Record<string, number>;
+  scores: Record<string, ScoreValue>;
   expanded: boolean;
   onToggle: () => void;
   updateScore: (criterionId: string, value: number) => void;
+  updateConfidence?: (criterionId: string, confidence: Confidence) => void;
 }) {
   return (
     <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 overflow-hidden">
@@ -101,10 +107,23 @@ function OptionCard({
                 </p>
               )}
               <ScoreSlider
-                value={scores[crit.id] ?? 0}
+                value={resolveScoreValue(scores[crit.id]) ?? 0}
                 onChange={(v) => updateScore(crit.id, v)}
                 label={`Score for ${option.name} on ${crit.name}`}
               />
+              {resolveConfidence(scores[crit.id]) && updateConfidence && (
+                <div className="mt-1 flex items-center gap-1.5">
+                  <span className="text-[10px] text-gray-400 dark:text-gray-500">Confidence:</span>
+                  <ConfidenceDot
+                    confidence={resolveConfidence(scores[crit.id])!}
+                    onChange={(next) => updateConfidence(crit.id, next)}
+                    size="md"
+                  />
+                  <span className="text-[10px] text-gray-500 dark:text-gray-400">
+                    {resolveConfidence(scores[crit.id])}
+                  </span>
+                </div>
+              )}
             </div>
           ))}
         </div>
@@ -113,7 +132,11 @@ function OptionCard({
   );
 }
 
-export function MobileScoreCards({ decision, updateScore }: MobileScoreCardsProps) {
+export function MobileScoreCards({
+  decision,
+  updateScore,
+  updateConfidence,
+}: MobileScoreCardsProps) {
   // Accordion: keep track of which option is expanded (first by default)
   const [expandedId, setExpandedId] = useState<string | null>(decision.options[0]?.id ?? null);
 
@@ -133,6 +156,9 @@ export function MobileScoreCards({ decision, updateScore }: MobileScoreCardsProp
           expanded={expandedId === opt.id}
           onToggle={() => toggle(opt.id)}
           updateScore={(critId, v) => updateScore(opt.id, critId, v)}
+          updateConfidence={
+            updateConfidence ? (critId, c) => updateConfidence(opt.id, critId, c) : undefined
+          }
         />
       ))}
     </div>

--- a/src/lib/bias-detection.ts
+++ b/src/lib/bias-detection.ts
@@ -7,7 +7,7 @@
  */
 
 import type { Decision } from "./types";
-import { normalizeWeights, effectiveScore, computeResults } from "./scoring";
+import { normalizeWeights, effectiveScore, computeResults, readScoreOrZero } from "./scoring";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -57,10 +57,10 @@ function detectHaloEffect(decision: Decision): BiasWarning[] {
   for (const opt of options) {
     let highestCount = 0;
     for (const crit of criteria) {
-      const optScore = scores[opt.id]?.[crit.id] ?? 0;
+      const optScore = readScoreOrZero(scores, opt.id, crit.id);
       const isHighest = options.every((other) => {
         if (other.id === opt.id) return true;
-        return (scores[other.id]?.[crit.id] ?? 0) <= optScore;
+        return readScoreOrZero(scores, other.id, crit.id) <= optScore;
       });
       if (isHighest) highestCount++;
     }
@@ -85,7 +85,7 @@ function detectUniformityBias(decision: Decision): BiasWarning[] {
   if (criteria.length < 2) return warnings;
 
   for (const opt of options) {
-    const optScores = criteria.map((c) => scores[opt.id]?.[c.id] ?? 0);
+    const optScores = criteria.map((c) => readScoreOrZero(scores, opt.id, c.id));
     const min = Math.min(...optScores);
     const max = Math.max(...optScores);
     if (max - min <= UNIFORMITY_RANGE && optScores.length >= 2) {
@@ -109,7 +109,7 @@ function detectScoreAnchoring(decision: Decision): BiasWarning[] {
   const allScores: number[] = [];
   for (const opt of options) {
     for (const crit of criteria) {
-      allScores.push(scores[opt.id]?.[crit.id] ?? 0);
+      allScores.push(readScoreOrZero(scores, opt.id, crit.id));
     }
   }
   if (allScores.length < 4) return [];
@@ -198,7 +198,7 @@ function detectExtremeScores(decision: Decision): BiasWarning[] {
   if (criteria.length < 2) return warnings;
 
   for (const opt of options) {
-    const optScores = criteria.map((c) => scores[opt.id]?.[c.id] ?? 0);
+    const optScores = criteria.map((c) => readScoreOrZero(scores, opt.id, c.id));
     const extremeCount = optScores.filter((s) => s === 0 || s === 10).length;
     if (extremeCount / optScores.length > EXTREME_FRACTION && optScores.length >= 2) {
       warnings.push({
@@ -245,7 +245,7 @@ function detectSingleCriterionDominance(decision: Decision): BiasWarning[] {
       let total = 0;
       for (let ri = 0; ri < remainingCriteria.length; ri++) {
         const rc = remainingCriteria[ri];
-        const raw = scores[opt.id]?.[rc.id] ?? 0;
+        const raw = readScoreOrZero(scores, opt.id, rc.id);
         total += effectiveScore(raw, rc.type) * remainingNw[ri];
       }
       if (total > newWinnerScore) {

--- a/src/lib/comparison.ts
+++ b/src/lib/comparison.ts
@@ -7,7 +7,7 @@
  */
 
 import type { Decision } from "./types";
-import { computeResults } from "./scoring";
+import { computeResults, readScoreOrZero } from "./scoring";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -215,8 +215,8 @@ export function compareDecisions(decA: Decision, decB: Decision): ComparisonResu
       const criterionB = decB.criteria.find((c) => normalizeName(c.name) === critKey);
       if (!criterionA || !criterionB) continue;
 
-      const sA = decA.scores[optionA.id]?.[criterionA.id] ?? 0;
-      const sB = decB.scores[optionB.id]?.[criterionB.id] ?? 0;
+      const sA = readScoreOrZero(decA.scores, optionA.id, criterionA.id);
+      const sB = readScoreOrZero(decB.scores, optionB.id, criterionB.id);
 
       scoreMatrix.push({
         optionName: opt.optionName,

--- a/src/lib/completeness.ts
+++ b/src/lib/completeness.ts
@@ -2,12 +2,15 @@
  * Completeness calculation — pure functions to determine how "complete"
  * a decision's score matrix is.
  *
- * A cell is considered "filled" when its value is > 0.
- * (Future: when per-score confidence / null-score (#76) is implemented,
- * the definition can change to "explicitly set".)
+ * A cell is considered "filled" when it has a non-null value > 0.
+ * - `null` or absent: not scored → unfilled
+ * - `0`: scored but zero → unfilled (user scored it zero)
+ * - `ScoredCell` with value > 0: filled
+ * - plain number > 0: filled
  */
 
 import type { Decision } from "./types";
+import { readScore } from "@/lib/scoring";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -58,10 +61,9 @@ export function computeCompleteness(decision: Decision): CompletenessResult {
 
   let filled = 0;
   for (const opt of options) {
-    const row = scores[opt.id];
-    if (!row) continue;
     for (const crit of criteria) {
-      if ((row[crit.id] ?? 0) > 0) filled++;
+      const val = readScore(scores, opt.id, crit.id);
+      if (val !== null && val > 0) filled++;
     }
   }
 

--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -9,6 +9,7 @@
  */
 
 import type { Criterion, Decision, Option, ScoreMatrix } from "./types";
+import type { ScoreValue } from "./types";
 import { isDecision } from "./validation";
 import { generateId } from "./utils";
 
@@ -357,7 +358,8 @@ export function csvToDecision(
     row.scores.forEach((score, ci) => {
       const criterionId = criteria[ci]?.id;
       if (criterionId) {
-        scores[optionId][criterionId] = score ?? 0;
+        // Preserve null from CSV empty cells
+        scores[optionId][criterionId] = score as ScoreValue;
       }
     });
   });

--- a/src/lib/monte-carlo.ts
+++ b/src/lib/monte-carlo.ts
@@ -26,8 +26,10 @@ import type {
   MonteCarloOptionResult,
   MonteCarloResults,
   PerturbationDistribution,
+  ScoreMatrix,
+  Confidence,
 } from "./types";
-import { computeResults, roundDisplay } from "./scoring";
+import { computeResults, roundDisplay, resolveScoreValue, resolveConfidence } from "./scoring";
 
 // ---------------------------------------------------------------------------
 // Callback interface for progress reporting & cancellation
@@ -156,6 +158,72 @@ export function perturbWeights(
 }
 
 // ---------------------------------------------------------------------------
+// Confidence-based score perturbation
+// ---------------------------------------------------------------------------
+
+/** Multiplier for per-cell score perturbation based on confidence */
+export const CONFIDENCE_PERTURBATION: Record<Confidence, number> = {
+  high: 1.0, // standard perturbation
+  medium: 1.5, // 50% wider
+  low: 2.5, // 150% wider
+};
+
+/**
+ * Check if any cell in the ScoreMatrix has a non-high confidence level.
+ * Used to skip score perturbation entirely when all are plain numbers.
+ */
+export function hasNonHighConfidence(scores: ScoreMatrix): boolean {
+  for (const optId of Object.keys(scores)) {
+    const row = scores[optId];
+    for (const critId of Object.keys(row)) {
+      const conf = resolveConfidence(row[critId]);
+      if (conf && conf !== "high") return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Create a perturbed copy of the score matrix.
+ * Each cell is perturbed independently:
+ *   perturbed = clamp(base ± delta, 0, 10)
+ * where delta scales with the cell's confidence level.
+ *
+ * High-confidence cells: standard range
+ * Medium-confidence: 1.5× wider
+ * Low-confidence: 2.5× wider
+ * Null cells: preserved as-is
+ */
+export function perturbScores(
+  scores: ScoreMatrix,
+  options: { id: string }[],
+  criteria: { id: string }[],
+  rand: () => number,
+  range: number,
+  distribution: PerturbationDistribution
+): ScoreMatrix {
+  const result: ScoreMatrix = {};
+  for (const opt of options) {
+    result[opt.id] = {};
+    for (const crit of criteria) {
+      const sv = scores[opt.id]?.[crit.id];
+      const numVal = resolveScoreValue(sv);
+      if (numVal === null) {
+        result[opt.id][crit.id] = null;
+        continue;
+      }
+      const conf = resolveConfidence(sv) ?? "high";
+      const multiplier = CONFIDENCE_PERTURBATION[conf];
+      const effectiveRange = range * multiplier;
+      const perturbation = samplePerturbation(rand, effectiveRange, distribution);
+      const perturbed = numVal * perturbation;
+      result[opt.id][crit.id] = Math.max(0, Math.min(10, perturbed));
+    }
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
 // Histogram helpers
 // ---------------------------------------------------------------------------
 
@@ -254,6 +322,7 @@ export function runMonteCarloSimulation(
   const rand = createPRNG(seed);
   const baseWeights = criteria.map((c) => c.weight);
   const numOptions = options.length;
+  const shouldPerturbScores = hasNonHighConfidence(decision.scores);
 
   // Accumulators ----------------------------------------------------------
 
@@ -280,9 +349,15 @@ export function runMonteCarloSimulation(
     // Perturb weights
     const perturbedWeights = perturbWeights(baseWeights, rand, perturbationRange, distribution);
 
-    // Build a shallow-copy decision with the perturbed weights
+    // Perturb scores based on per-cell confidence (skip if all high)
+    const perturbedScores = shouldPerturbScores
+      ? perturbScores(decision.scores, options, criteria, rand, perturbationRange, distribution)
+      : decision.scores;
+
+    // Build a shallow-copy decision with the perturbed weights and scores
     const simDecision: Decision = {
       ...decision,
+      scores: perturbedScores,
       criteria: criteria.map((c, i) => ({ ...c, weight: perturbedWeights[i] })),
     };
 

--- a/src/lib/regret.ts
+++ b/src/lib/regret.ts
@@ -21,7 +21,7 @@
  */
 
 import type { Decision } from "./types";
-import { effectiveScore, normalizeWeights, DISPLAY_PRECISION } from "./scoring";
+import { effectiveScore, normalizeWeights, DISPLAY_PRECISION, readScoreOrZero } from "./scoring";
 
 // ---------------------------------------------------------------------------
 //  Types
@@ -79,9 +79,10 @@ export function computeRegretResults(decision: Decision): RegretResults {
 
   // --- Step 1: Compute effective score matrix --------------------------------
   // effectiveScores[i][j] = effective score of option i on criterion j
+  // Null scores are treated as 0 for regret computation
   const effectiveScores: number[][] = options.map((opt) =>
     criteria.map((crit) => {
-      const raw = scores[opt.id]?.[crit.id] ?? 0;
+      const raw = readScoreOrZero(scores, opt.id, crit.id);
       return effectiveScore(raw, crit.type);
     })
   );

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -13,12 +13,15 @@
  */
 
 import type {
+  Confidence,
   Criterion,
   CriterionScore,
   Decision,
   DecisionResults,
   OptionResult,
   ScoreMatrix,
+  ScoreValue,
+  ScoredCell,
   SensitivityAnalysis,
   SensitivityPoint,
   TopDriver,
@@ -33,6 +36,64 @@ export const MAX_SCORE = 10;
 
 /** Decimal places for displayed scores */
 export const DISPLAY_PRECISION = 2;
+
+// ---------------------------------------------------------------------------
+// ScoreValue helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the raw numeric value from a ScoreValue.
+ * - `null` → `null` (not scored)
+ * - `number` → the number
+ * - `ScoredCell` → its `.value`
+ */
+export function resolveScoreValue(sv: ScoreValue | undefined): number | null {
+  if (sv === null || sv === undefined) return null;
+  if (typeof sv === "number") return sv;
+  return sv.value;
+}
+
+/**
+ * Extract the confidence level from a ScoreValue.
+ * - `null` / `undefined` → `null`
+ * - plain `number` → "high" (default)
+ * - `ScoredCell` → its `.confidence`
+ */
+export function resolveConfidence(sv: ScoreValue | undefined): Confidence | null {
+  if (sv === null || sv === undefined) return null;
+  if (typeof sv === "number") return "high";
+  return sv.confidence;
+}
+
+/**
+ * Check whether a ScoreValue is a ScoredCell (object with value + confidence).
+ */
+export function isScoredCell(sv: ScoreValue | undefined): sv is ScoredCell {
+  return typeof sv === "object" && sv !== null && "value" in sv && "confidence" in sv;
+}
+
+/**
+ * Read a score cell from the matrix, returning `null` if not scored.
+ */
+export function readScore(
+  scores: ScoreMatrix,
+  optionId: string,
+  criterionId: string
+): number | null {
+  return resolveScoreValue(scores[optionId]?.[criterionId]);
+}
+
+/**
+ * Read a score cell, defaulting `null` to 0 for backward compatibility
+ * in contexts that cannot handle nulls (e.g. comparison, bias detection).
+ */
+export function readScoreOrZero(
+  scores: ScoreMatrix,
+  optionId: string,
+  criterionId: string
+): number {
+  return resolveScoreValue(scores[optionId]?.[criterionId]) ?? 0;
+}
 
 // ---------------------------------------------------------------------------
 // Weight normalization
@@ -77,6 +138,14 @@ export function effectiveScore(rawScore: number, criterionType: "benefit" | "cos
 /**
  * Score a single option across all criteria.
  * Returns the total weighted score and per-criterion breakdown.
+ *
+ * Null scores are excluded: the option's total is normalized by
+ * the sum of weights for scored criteria only, so unscored cells
+ * don't silently bias the result.
+ *
+ * Formula: score_i = Σ(w_j · e_ij) / Σ(w_j)  for j ∈ scored criteria
+ * When all criteria are scored, Σ(w_j) = 1.0, so results are identical
+ * to the original behavior (backward compatible).
  */
 export function scoreOption(
   optionId: string,
@@ -86,28 +155,39 @@ export function scoreOption(
   normalizedWeights: number[]
 ): OptionResult {
   const criterionScores: CriterionScore[] = criteria.map((criterion, i) => {
-    const rawScore = scores[optionId]?.[criterion.id] ?? 0;
-    const eff = effectiveScore(rawScore, criterion.type);
+    const raw = readScore(scores, optionId, criterion.id);
+    const numericRaw = raw ?? 0;
+    const eff = effectiveScore(numericRaw, criterion.type);
     const nw = normalizedWeights[i];
 
     return {
       criterionId: criterion.id,
       criterionName: criterion.name,
-      rawScore,
+      rawScore: numericRaw,
       normalizedWeight: nw,
       effectiveScore: roundDisplay(eff * nw),
       criterionType: criterion.type,
+      isNull: raw === null,
     };
   });
 
-  // Accumulate from unrounded weighted scores to avoid double-rounding errors
-  const totalScore = roundDisplay(
-    criteria.reduce((sum, criterion, i) => {
-      const rawScore = scores[optionId]?.[criterion.id] ?? 0;
-      const eff = effectiveScore(rawScore, criterion.type);
-      return sum + eff * normalizedWeights[i];
-    }, 0)
-  );
+  // Accumulate only scored criteria; normalize by their weight sum
+  // Formula: score_i = Σ(w_j · e_ij) / Σ(w_j) for j ∈ scored
+  let scoredWeightSum = 0;
+  let weightedSum = 0;
+
+  criteria.forEach((criterion, i) => {
+    const raw = readScore(scores, optionId, criterion.id);
+    if (raw !== null) {
+      const eff = effectiveScore(raw, criterion.type);
+      weightedSum += eff * normalizedWeights[i];
+      scoredWeightSum += normalizedWeights[i];
+    }
+  });
+
+  // When all scored: scoredWeightSum ≈ 1.0, so result = weightedSum (unchanged)
+  // When partially scored: divide by scoredWeightSum to re-normalize
+  const totalScore = roundDisplay(scoredWeightSum > 0 ? weightedSum / scoredWeightSum : 0);
 
   return {
     optionId,

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -21,8 +21,9 @@
  */
 
 import { compressToEncodedURIComponent, decompressFromEncodedURIComponent } from "lz-string";
-import type { Decision, CriterionType } from "./types";
+import type { Decision, CriterionType, ScoreValue } from "./types";
 import { generateId } from "./utils";
+import { readScoreOrZero, resolveConfidence } from "./scoring";
 
 /** Compacted share payload — version 1 */
 export interface SharePayloadV1 {
@@ -36,8 +37,10 @@ export interface SharePayloadV1 {
   o: string[];
   /** Criteria: [name, weight, typeInitial("b"|"c")] */
   c: [string, number, string][];
-  /** Scores grid: scores[optionIdx][criterionIdx] */
-  s: number[][];
+  /** Scores grid: scores[optionIdx][criterionIdx]; null = unscored */
+  s: (number | null)[][];
+  /** Confidence grid (optional): conf[optionIdx][criterionIdx]; 0=high, 1=medium, 2=low, absent=high */
+  cf?: (number | null)[][];
 }
 
 /**
@@ -93,19 +96,42 @@ export function buildShareLink(decision: Decision, origin: string): string | nul
 //  Internal helpers
 // ---------------------------------------------------------------------------
 
+const CONF_TO_INT: Record<string, number> = { high: 0, medium: 1, low: 2 };
+const INT_TO_CONF = ["high", "medium", "low"] as const;
+
 /** Convert a Decision into a compact share payload. */
 export function decisionToSharePayload(decision: Decision): SharePayloadV1 {
+  let hasConfidence = false;
+  const confGrid: (number | null)[][] = [];
+
+  const scoreGrid = decision.options.map((opt) => {
+    const confRow: (number | null)[] = [];
+    const row = decision.criteria.map((cri) => {
+      const sv = decision.scores[opt.id]?.[cri.id];
+      const conf = resolveConfidence(sv);
+      if (conf && conf !== "high") hasConfidence = true;
+      confRow.push(sv === null || sv === undefined ? null : CONF_TO_INT[conf ?? "high"]);
+      return sv === null || sv === undefined
+        ? null
+        : readScoreOrZero(decision.scores, opt.id, cri.id);
+    });
+    confGrid.push(confRow);
+    return row;
+  });
+
   const payload: SharePayloadV1 = {
     v: 1,
     t: decision.title,
     o: decision.options.map((o) => o.name),
     c: decision.criteria.map((c) => [c.name, c.weight, c.type[0]]),
-    s: decision.options.map((opt) =>
-      decision.criteria.map((cri) => decision.scores[opt.id]?.[cri.id] ?? 0)
-    ),
+    s: scoreGrid,
   };
   if (decision.description) {
     payload.d = decision.description;
+  }
+  // Only include confidence grid if any cell has non-high confidence
+  if (hasConfidence) {
+    payload.cf = confGrid;
   }
   return payload;
 }
@@ -128,11 +154,25 @@ export function sharePayloadToDecision(payload: SharePayloadV1): Decision {
     type: typeMap[typeInitial] ?? ("benefit" as CriterionType),
   }));
 
-  const scores: Record<string, Record<string, number>> = {};
+  const scores: Record<string, Record<string, ScoreValue>> = {};
   for (let oi = 0; oi < options.length; oi++) {
     scores[options[oi].id] = {};
     for (let ci = 0; ci < criteria.length; ci++) {
-      scores[options[oi].id][criteria[ci].id] = payload.s[oi]?.[ci] ?? 0;
+      const cell = payload.s[oi]?.[ci];
+      if (cell === null || cell === undefined) {
+        scores[options[oi].id][criteria[ci].id] = null;
+      } else {
+        // Check for confidence data
+        const confInt = payload.cf?.[oi]?.[ci];
+        if (confInt !== undefined && confInt !== null && confInt > 0) {
+          scores[options[oi].id][criteria[ci].id] = {
+            value: cell,
+            confidence: INT_TO_CONF[confInt] ?? "high",
+          };
+        } else {
+          scores[options[oi].id][criteria[ci].id] = cell;
+        }
+      }
     }
   }
 

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -153,7 +153,7 @@ export function getTemplateById(templateId: string): DecisionTemplate | undefine
 /**
  * Instantiate a Decision from a template.
  * Generates fresh IDs for options, criteria, and the decision itself.
- * Scores default to 0 for all combinations.
+ * Scores default to null (unscored) for all combinations.
  */
 export function instantiateTemplate(template: DecisionTemplate): Decision {
   const now = new Date().toISOString();
@@ -165,12 +165,12 @@ export function instantiateTemplate(template: DecisionTemplate): Decision {
     type: c.type,
   }));
 
-  // Initialize all scores to 0
-  const scores: Record<string, Record<string, number>> = {};
+  // Initialize all scores to null (not yet scored)
+  const scores: Record<string, Record<string, null>> = {};
   for (const opt of options) {
     scores[opt.id] = {};
     for (const crit of criteria) {
-      scores[opt.id][crit.id] = 0;
+      scores[opt.id][crit.id] = null;
     }
   }
 

--- a/src/lib/topsis.ts
+++ b/src/lib/topsis.ts
@@ -24,7 +24,7 @@
  */
 
 import type { Decision } from "./types";
-import { normalizeWeights, DISPLAY_PRECISION } from "./scoring";
+import { normalizeWeights, DISPLAY_PRECISION, readScoreOrZero } from "./scoring";
 
 // ---------------------------------------------------------------------------
 //  Types
@@ -82,8 +82,9 @@ export function computeTopsisResults(decision: Decision): TopsisResults {
   const numCriteria = criteria.length;
 
   // --- Step 1: Build raw decision matrix (options × criteria) ----------------
+  // Null scores are treated as 0 in TOPSIS (included in vector normalization)
   const rawMatrix: number[][] = options.map((opt) =>
-    criteria.map((crit) => scores[opt.id]?.[crit.id] ?? 0)
+    criteria.map((crit) => readScoreOrZero(scores, opt.id, crit.id))
   );
 
   // --- Step 2: Vector normalization ------------------------------------------

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -24,11 +24,30 @@ export interface Option {
   description?: string;
 }
 
+/** Confidence level for a per-cell score */
+export type Confidence = "high" | "medium" | "low";
+
+/** A score cell with an explicit confidence annotation */
+export interface ScoredCell {
+  value: number;
+  confidence: Confidence;
+}
+
 /**
- * Score matrix entry: maps `optionId -> criterionId -> score (0–10)`.
- * Stored as a flat record for simplicity.
+ * A single cell in the score matrix:
+ * - `number`     — plain numeric score (backward-compatible; implicitly high confidence)
+ * - `ScoredCell` — annotated score with explicit confidence
+ * - `null`       — not yet scored (distinct from "scored 0")
  */
-export type ScoreMatrix = Record<string, Record<string, number>>;
+export type ScoreValue = number | ScoredCell | null;
+
+/**
+ * Score matrix: maps `optionId -> criterionId -> ScoreValue`.
+ *
+ * `null` means "not yet scored" (the user hasn't evaluated this cell).
+ * `0` means "deliberately scored zero".
+ */
+export type ScoreMatrix = Record<string, Record<string, ScoreValue>>;
 
 /** A complete decision with all its data */
 export interface Decision {
@@ -59,6 +78,8 @@ export interface CriterionScore {
   normalizedWeight: number;
   effectiveScore: number; // rawScore (or inverted) * normalizedWeight
   criterionType: CriterionType;
+  /** True when the score cell was null (not yet scored) */
+  isNull?: boolean;
 }
 
 /** Full results for a decision */

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -7,7 +7,7 @@
  */
 
 import type { Criterion, Decision, Option, ScoreMatrix } from "./types";
-import { MAX_SCORE } from "./scoring";
+import { MAX_SCORE, resolveScoreValue } from "./scoring";
 
 export interface ValidationError {
   field: string;
@@ -170,7 +170,8 @@ export function validateCriterion(criterion: Criterion): ValidationError[] {
 
 /**
  * Validate the scores matrix.
- * Ensures all scores are numbers between 0 and MAX_SCORE.
+ * Ensures all scored values are numbers between 0 and MAX_SCORE.
+ * `null` values are valid (not yet scored).
  */
 export function validateScores(
   scores: ScoreMatrix,
@@ -181,14 +182,14 @@ export function validateScores(
 
   for (const option of options) {
     for (const criterion of criteria) {
-      const value = scores[option.id]?.[criterion.id];
-      if (value !== undefined && value !== null) {
-        if (!Number.isFinite(value) || value < 0 || value > MAX_SCORE) {
-          errors.push({
-            field: `scores.${option.id}.${criterion.id}`,
-            message: `Score for "${option.name}" on "${criterion.name}" must be 0–${MAX_SCORE}.`,
-          });
-        }
+      const raw = scores[option.id]?.[criterion.id];
+      if (raw === null || raw === undefined) continue; // null = unscored, valid
+      const value = resolveScoreValue(raw);
+      if (value !== null && (!Number.isFinite(value) || value < 0 || value > MAX_SCORE)) {
+        errors.push({
+          field: `scores.${option.id}.${criterion.id}`,
+          message: `Score for "${option.name}" on "${criterion.name}" must be 0–${MAX_SCORE}.`,
+        });
       }
     }
   }


### PR DESCRIPTION
## Summary

Implements per-score confidence levels and null-score handling across the entire scoring pipeline.

**Closes #76**

## Changes

### Phase 1 — Null Score Support
- **Types**: `ScoreValue = number | ScoredCell | null` union type, `ScoreMatrix` now uses `ScoreValue`
- **Scoring helpers**: `resolveScoreValue()`, `resolveConfidence()`, `isScoredCell()`, `readScore()`, `readScoreOrZero()`
- **Scoring engine**: Null scores excluded from weighted sum; normalization formula `score_i = Σ(w_j · e_ij) / Σ(w_j)` for scored criteria only
- **All score consumers updated**: TOPSIS, regret, bias-detection, comparison, completeness, validation
- **Templates**: Initialize scores to `null` (not yet scored) instead of `0`
- **CSV import**: Preserves null scores from empty cells
- **Share URLs**: Null-safe score grid encoding

### Phase 2 — Confidence Levels UI
- **ConfidenceDot component**: Clickable colored dot (🟢 high → 🟡 medium → 🔴 low), keyboard accessible
- **Desktop builder**: Confidence dot next to each scored cell, dashed border + "?" placeholder for null cells
- **Mobile score cards**: Confidence dot below slider with label
- **DecisionProvider**: `updateConfidence()` callback; `updateScore()` accepts `number | null`

### Phase 3 — Monte Carlo Integration
- **`perturbScores()`**: Per-cell perturbation scaled by confidence multipliers (high: 1.0×, medium: 1.5×, low: 2.5×)
- **`hasNonHighConfidence()`**: Skip score perturbation when all cells are high/plain
- **Simulation loop**: Perturbs both weights AND scores per iteration
- **Share encoding**: `cf` grid for confidence (only included if any non-high)

## Testing
- 49 new tests in `score-confidence.test.ts`
- 4 existing tests updated for new null-score semantics
- **521 total tests passing** (30 test files)
- TSC clean, ESLint zero warnings, production build passes