### PR TITLE
feat(analysis): Pareto frontier scatter plot with dominated-option detection (#78)

### DIFF
--- a/src/__tests__/pareto.test.ts
+++ b/src/__tests__/pareto.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Unit tests for Pareto frontier computation.
+ */
+
+import { describe, it, expect } from "vitest";
+import { computeParetoFrontier, defaultAxes } from "@/lib/pareto";
+import type { Decision } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDecision(overrides?: Partial<Decision>): Decision {
+  return {
+    id: "test",
+    title: "Test",
+    description: "",
+    options: [
+      { id: "a", name: "A" },
+      { id: "b", name: "B" },
+      { id: "c", name: "C" },
+    ],
+    criteria: [
+      { id: "x", name: "X", weight: 50, type: "benefit" },
+      { id: "y", name: "Y", weight: 50, type: "benefit" },
+    ],
+    scores: {
+      a: { x: 9, y: 2 },
+      b: { x: 5, y: 6 },
+      c: { x: 3, y: 9 },
+    },
+    createdAt: "2025-01-01T00:00:00.000Z",
+    updatedAt: "2025-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// computeParetoFrontier
+// ---------------------------------------------------------------------------
+
+describe("computeParetoFrontier", () => {
+  it("identifies a basic Pareto frontier (no dominated options)", () => {
+    // A(9,2), B(5,6), C(3,9) — all Pareto-optimal (trade-offs)
+    const d = makeDecision();
+    const result = computeParetoFrontier(d, "x", "y");
+
+    expect(result.frontier).toEqual(expect.arrayContaining(["a", "b", "c"]));
+    expect(result.dominated).toEqual([]);
+    expect(result.points).toHaveLength(3);
+    expect(result.points.every((p) => p.isPareto)).toBe(true);
+  });
+
+  it("detects dominated options", () => {
+    // A(9,8) dominates B(5,6) and C(3,4)
+    const d = makeDecision({
+      scores: {
+        a: { x: 9, y: 8 },
+        b: { x: 5, y: 6 },
+        c: { x: 3, y: 4 },
+      },
+    });
+    const result = computeParetoFrontier(d, "x", "y");
+
+    expect(result.frontier).toEqual(["a"]);
+    expect(result.dominated).toEqual(expect.arrayContaining(["b", "c"]));
+    expect(result.dominanceMap["b"]).toContain("a");
+    expect(result.dominanceMap["c"]).toContain("a");
+  });
+
+  it("handles all options on frontier (diagonal trade-offs)", () => {
+    const d = makeDecision({
+      scores: {
+        a: { x: 10, y: 0 },
+        b: { x: 0, y: 10 },
+        c: { x: 5, y: 5 },
+      },
+    });
+    const result = computeParetoFrontier(d, "x", "y");
+
+    // All three are Pareto-optimal
+    expect(result.frontier).toHaveLength(3);
+    expect(result.dominated).toHaveLength(0);
+  });
+
+  it("handles all options dominated (single dominator)", () => {
+    const d = makeDecision({
+      scores: {
+        a: { x: 10, y: 10 },
+        b: { x: 5, y: 5 },
+        c: { x: 3, y: 3 },
+      },
+    });
+    const result = computeParetoFrontier(d, "x", "y");
+
+    expect(result.frontier).toEqual(["a"]);
+    expect(result.dominated).toHaveLength(2);
+  });
+
+  it("handles tied scores — tied options are not dominated by each other", () => {
+    const d = makeDecision({
+      scores: {
+        a: { x: 5, y: 5 },
+        b: { x: 5, y: 5 },
+        c: { x: 3, y: 3 },
+      },
+    });
+    const result = computeParetoFrontier(d, "x", "y");
+
+    // A and B tie — neither dominates the other (need strict > on at least one)
+    expect(result.frontier).toEqual(expect.arrayContaining(["a", "b"]));
+    // C is dominated by both A and B
+    expect(result.dominated).toEqual(["c"]);
+    expect(result.dominanceMap["c"]).toEqual(expect.arrayContaining(["a", "b"]));
+  });
+
+  it("handles a single option (always Pareto-optimal)", () => {
+    const d = makeDecision({
+      options: [{ id: "solo", name: "Solo" }],
+      scores: { solo: { x: 5, y: 5 } },
+    });
+    const result = computeParetoFrontier(d, "x", "y");
+
+    expect(result.frontier).toEqual(["solo"]);
+    expect(result.dominated).toEqual([]);
+  });
+
+  it("handles two options — one dominates other", () => {
+    const d = makeDecision({
+      options: [
+        { id: "a", name: "A" },
+        { id: "b", name: "B" },
+      ],
+      scores: {
+        a: { x: 7, y: 8 },
+        b: { x: 4, y: 3 },
+      },
+    });
+    const result = computeParetoFrontier(d, "x", "y");
+
+    expect(result.frontier).toEqual(["a"]);
+    expect(result.dominated).toEqual(["b"]);
+  });
+
+  it("handles two options — neither dominates (trade-off)", () => {
+    const d = makeDecision({
+      options: [
+        { id: "a", name: "A" },
+        { id: "b", name: "B" },
+      ],
+      scores: {
+        a: { x: 9, y: 2 },
+        b: { x: 2, y: 9 },
+      },
+    });
+    const result = computeParetoFrontier(d, "x", "y");
+
+    expect(result.frontier).toEqual(["a", "b"]);
+    expect(result.dominated).toEqual([]);
+  });
+
+  it("handles cost criteria (inverts scores)", () => {
+    // cost criterion: lower raw = better, so effective = 10 - raw
+    const d = makeDecision({
+      criteria: [
+        { id: "x", name: "Price", weight: 50, type: "cost" },
+        { id: "y", name: "Quality", weight: 50, type: "benefit" },
+      ],
+      scores: {
+        a: { x: 2, y: 8 }, // effective x = 8, y = 8 → dominant
+        b: { x: 8, y: 4 }, // effective x = 2, y = 4 → dominated
+        c: { x: 5, y: 9 }, // effective x = 5, y = 9 → Pareto
+      },
+    });
+    const result = computeParetoFrontier(d, "x", "y");
+
+    // A(8,8) dominates B(2,4); A and C are both Pareto-optimal
+    expect(result.frontier).toEqual(expect.arrayContaining(["a", "c"]));
+    expect(result.dominated).toEqual(["b"]);
+  });
+
+  it("handles missing scores (treated as 0)", () => {
+    const d = makeDecision({
+      scores: {
+        a: { x: 5 }, // y missing → 0
+        b: { y: 5 }, // x missing → 0
+        c: { x: 3, y: 3 },
+      },
+    });
+    const result = computeParetoFrontier(d, "x", "y");
+
+    // A(5,0), B(0,5), C(3,3) — all Pareto (no one dominates another)
+    expect(result.frontier).toHaveLength(3);
+  });
+
+  it("handles null scores (treated as 0)", () => {
+    const d = makeDecision({
+      scores: {
+        a: { x: null, y: 8 },
+        b: { x: 7, y: null },
+        c: { x: 5, y: 5 },
+      },
+    });
+    const result = computeParetoFrontier(d, "x", "y");
+
+    // A(0,8), B(7,0), C(5,5) — all Pareto
+    expect(result.frontier).toHaveLength(3);
+  });
+
+  it("returns correct axis labels", () => {
+    const d = makeDecision({
+      criteria: [
+        { id: "x", name: "Price", weight: 50, type: "cost" },
+        { id: "y", name: "Quality", weight: 50, type: "benefit" },
+      ],
+    });
+    const result = computeParetoFrontier(d, "x", "y");
+
+    expect(result.xLabel).toBe("Price");
+    expect(result.yLabel).toBe("Quality");
+  });
+
+  it("returns empty result for invalid criterion IDs", () => {
+    const d = makeDecision();
+    const result = computeParetoFrontier(d, "nonexistent", "y");
+    expect(result.points).toEqual([]);
+    expect(result.frontier).toEqual([]);
+  });
+
+  it("handles ScoredCell values (extracts numeric value)", () => {
+    const d = makeDecision({
+      scores: {
+        a: { x: { value: 9, confidence: "high" }, y: 2 },
+        b: { x: 5, y: { value: 6, confidence: "low" } },
+        c: { x: 3, y: { value: 9, confidence: "medium" } },
+      },
+    });
+    const result = computeParetoFrontier(d, "x", "y");
+
+    // Same as basic test: A(9,2), B(5,6), C(3,9) — all Pareto
+    expect(result.frontier).toHaveLength(3);
+    expect(result.points[0].x).toBe(9);
+    expect(result.points[0].y).toBe(2);
+  });
+
+  it("handles many options (stress test)", () => {
+    const options = Array.from({ length: 20 }, (_, i) => ({
+      id: `opt-${i}`,
+      name: `Option ${i}`,
+    }));
+    const scores: Record<string, Record<string, number>> = {};
+    for (let i = 0; i < 20; i++) {
+      scores[`opt-${i}`] = { x: i, y: 19 - i }; // Diagonal — all Pareto
+    }
+    const d = makeDecision({ options, scores });
+    const result = computeParetoFrontier(d, "x", "y");
+
+    expect(result.frontier).toHaveLength(20);
+    expect(result.dominated).toHaveLength(0);
+  });
+
+  it("dominanceMap lists all dominators for a dominated option", () => {
+    const d = makeDecision({
+      options: [
+        { id: "a", name: "A" },
+        { id: "b", name: "B" },
+        { id: "c", name: "C" },
+      ],
+      scores: {
+        a: { x: 10, y: 8 },
+        b: { x: 8, y: 10 },
+        c: { x: 5, y: 5 }, // dominated by both A and B
+      },
+    });
+    const result = computeParetoFrontier(d, "x", "y");
+
+    expect(result.dominanceMap["c"]).toEqual(expect.arrayContaining(["a", "b"]));
+    expect(result.dominanceMap["c"]).toHaveLength(2);
+  });
+
+  it("partial domination (equal on one axis, strictly better on other)", () => {
+    const d = makeDecision({
+      scores: {
+        a: { x: 5, y: 8 },
+        b: { x: 5, y: 6 }, // A dominates B (equal on x, better on y)
+        c: { x: 3, y: 9 },
+      },
+    });
+    const result = computeParetoFrontier(d, "x", "y");
+
+    expect(result.frontier).toEqual(expect.arrayContaining(["a", "c"]));
+    expect(result.dominated).toEqual(["b"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// defaultAxes
+// ---------------------------------------------------------------------------
+
+describe("defaultAxes", () => {
+  it("returns the two highest-weighted criteria", () => {
+    const d = makeDecision({
+      criteria: [
+        { id: "c1", name: "C1", weight: 20, type: "benefit" },
+        { id: "c2", name: "C2", weight: 40, type: "benefit" },
+        { id: "c3", name: "C3", weight: 30, type: "benefit" },
+      ],
+    });
+    const axes = defaultAxes(d);
+    expect(axes).toEqual(["c2", "c3"]); // 40 and 30
+  });
+
+  it("returns null with fewer than 2 criteria", () => {
+    const d = makeDecision({
+      criteria: [{ id: "c1", name: "C1", weight: 50, type: "benefit" }],
+    });
+    expect(defaultAxes(d)).toBeNull();
+  });
+
+  it("returns null with no criteria", () => {
+    const d = makeDecision({ criteria: [] });
+    expect(defaultAxes(d)).toBeNull();
+  });
+});

--- a/src/components/ParetoChart.tsx
+++ b/src/components/ParetoChart.tsx
@@ -1,0 +1,377 @@
+/**
+ * Pareto Chart — Trade-Off Explorer scatter plot with dominated-option detection.
+ *
+ * Renders a Recharts ScatterChart with Pareto frontier line and
+ * dropdown axis selectors. Lazy-loaded from ResultsView.
+ *
+ * @see https://github.com/ericsocrat/decision-os/issues/78
+ */
+
+"use client";
+
+import { memo, useMemo, useState, useCallback } from "react";
+import {
+  Scatter,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Line,
+  ComposedChart,
+  Cell,
+} from "recharts";
+import { AlertTriangle, Info } from "lucide-react";
+import type { Decision, DecisionResults } from "@/lib/types";
+import {
+  computeParetoFrontier,
+  defaultAxes,
+  type ParetoPoint,
+  type ParetoResult,
+} from "@/lib/pareto";
+
+// ---------------------------------------------------------------------------
+// Color palette
+// ---------------------------------------------------------------------------
+
+/** Blue for Pareto-optimal, gray for dominated */
+const PARETO_COLOR = "#2563eb"; // blue-600
+const DOMINATED_COLOR = "#9ca3af"; // gray-400
+const FRONTIER_LINE_COLOR = "#3b82f6"; // blue-500
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ParetoChartProps {
+  decision: Decision;
+  results: DecisionResults;
+}
+
+// ---------------------------------------------------------------------------
+// Custom Tooltip
+// ---------------------------------------------------------------------------
+
+function ParetoTooltip({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: Array<{ payload?: ParetoPoint }>;
+}) {
+  if (!active || !payload || payload.length === 0) return null;
+
+  const data = payload[0]?.payload;
+  if (!data) return null;
+
+  return (
+    <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3 shadow-lg text-sm">
+      <p className="font-semibold text-gray-900 dark:text-gray-100">{data.optionName}</p>
+      <p className="text-gray-600 dark:text-gray-400">
+        X: {data.x.toFixed(1)} · Y: {data.y.toFixed(1)}
+      </p>
+      <p
+        className={`mt-1 text-xs font-medium ${
+          data.isPareto ? "text-blue-600 dark:text-blue-400" : "text-gray-500 dark:text-gray-500"
+        }`}
+      >
+        {data.isPareto ? "★ Pareto-optimal" : "Dominated"}
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Custom scatter dot
+// ---------------------------------------------------------------------------
+
+interface DotProps {
+  cx?: number;
+  cy?: number;
+  payload?: ParetoPoint;
+}
+
+function ParetoScatterDot({ cx, cy, payload }: DotProps) {
+  if (cx == null || cy == null || !payload) return null;
+
+  const isPareto = payload.isPareto;
+  const r = isPareto ? 6 : 4;
+  const fill = isPareto ? PARETO_COLOR : DOMINATED_COLOR;
+  const opacity = isPareto ? 1 : 0.6;
+
+  return (
+    <g>
+      <circle cx={cx} cy={cy} r={r} fill={fill} opacity={opacity} stroke="#fff" strokeWidth={1.5} />
+      {/* Label */}
+      <text
+        x={cx}
+        y={cy - r - 6}
+        textAnchor="middle"
+        fontSize={11}
+        fill={isPareto ? PARETO_COLOR : DOMINATED_COLOR}
+        className="select-none pointer-events-none"
+      >
+        {payload.optionName}
+      </text>
+    </g>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main Component
+// ---------------------------------------------------------------------------
+
+function ParetoChartInner({ decision, results }: ParetoChartProps) {
+  // ── Default axes: two highest-weighted criteria ──────────
+  const axes = useMemo(() => defaultAxes(decision), [decision]);
+  const [xAxis, setXAxis] = useState<string>(axes?.[0] ?? "");
+  const [yAxis, setYAxis] = useState<string>(axes?.[1] ?? "");
+
+  // Update axes if criteria change and current selection is invalid
+  const validX = decision.criteria.some((c) => c.id === xAxis) ? xAxis : (axes?.[0] ?? "");
+  const validY = decision.criteria.some((c) => c.id === yAxis) ? yAxis : (axes?.[1] ?? "");
+
+  if (validX !== xAxis) setXAxis(validX);
+  if (validY !== yAxis) setYAxis(validY);
+
+  const sameAxis = validX === validY && validX !== "";
+
+  // ── Compute Pareto frontier ──────────────────────────────
+  const pareto: ParetoResult = useMemo(
+    () => computeParetoFrontier(decision, validX, validY),
+    [decision, validX, validY]
+  );
+
+  // ── Frontier line data (sorted by x for a clean step line) ──
+  const frontierLineData = useMemo(() => {
+    const frontierPoints = pareto.points.filter((p) => p.isPareto).sort((a, b) => a.x - b.x);
+    return frontierPoints.map((p) => ({ x: p.x, y: p.y }));
+  }, [pareto]);
+
+  // WSM rank lookup
+  const rankMap = useMemo(() => {
+    const map: Record<string, number> = {};
+    for (const r of results.optionResults) {
+      map[r.optionId] = r.rank;
+    }
+    return map;
+  }, [results]);
+
+  const handleXChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    setXAxis(e.target.value);
+  }, []);
+
+  const handleYChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    setYAxis(e.target.value);
+  }, []);
+
+  // ── Tooltip content enrichment ───────────────────────────
+  const enrichedPoints = useMemo(
+    () =>
+      pareto.points.map((p) => ({
+        ...p,
+        rank: rankMap[p.optionId] ?? 0,
+      })),
+    [pareto.points, rankMap]
+  );
+
+  // ── Guard: < 2 criteria ──────────────────────────────────
+  if (decision.criteria.length < 2) {
+    return (
+      <div className="text-sm text-gray-500 dark:text-gray-400 text-center py-6">
+        Add at least 2 criteria to see trade-off analysis.
+      </div>
+    );
+  }
+
+  if (decision.options.length < 2) {
+    return (
+      <div className="text-sm text-gray-500 dark:text-gray-400 text-center py-6">
+        Add at least 2 options to see trade-off analysis.
+      </div>
+    );
+  }
+
+  // Ensure chart domain has some padding
+  const xValues = pareto.points.map((p) => p.x);
+  const yValues = pareto.points.map((p) => p.y);
+  const xMin = Math.max(0, Math.min(...xValues) - 0.5);
+  const xMax = Math.min(10, Math.max(...xValues) + 0.5);
+  const yMin = Math.max(0, Math.min(...yValues) - 0.5);
+  const yMax = Math.min(10, Math.max(...yValues) + 0.5);
+
+  return (
+    <div className="space-y-4">
+      {/* Axis Selectors */}
+      <div className="flex flex-wrap gap-4 items-center">
+        <label className="flex items-center gap-2 text-sm">
+          <span className="text-gray-600 dark:text-gray-400 font-medium">X Axis:</span>
+          <select
+            value={validX}
+            onChange={handleXChange}
+            className="rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 px-2 py-1 text-sm"
+          >
+            {decision.criteria.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <span className="text-gray-600 dark:text-gray-400 font-medium">Y Axis:</span>
+          <select
+            value={validY}
+            onChange={handleYChange}
+            className="rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 px-2 py-1 text-sm"
+          >
+            {decision.criteria.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {/* Same axis warning */}
+      {sameAxis && (
+        <div className="flex items-center gap-2 rounded-lg bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-700 p-3 text-sm text-amber-800 dark:text-amber-300">
+          <AlertTriangle className="h-4 w-4 flex-shrink-0" />
+          Select different criteria for X and Y axes to see trade-offs.
+        </div>
+      )}
+
+      {/* Scatter Chart */}
+      {!sameAxis && (
+        <div
+          className="w-full"
+          aria-label={`Trade-off scatter plot: ${pareto.xLabel} vs ${pareto.yLabel}. ${pareto.frontier.length} Pareto-optimal options, ${pareto.dominated.length} dominated options.`}
+          role="img"
+        >
+          <ResponsiveContainer width="100%" height={320}>
+            <ComposedChart margin={{ top: 20, right: 20, bottom: 20, left: 10 }}>
+              <CartesianGrid
+                strokeDasharray="3 3"
+                className="stroke-gray-200 dark:stroke-gray-700"
+              />
+              <XAxis
+                type="number"
+                dataKey="x"
+                domain={[xMin, xMax]}
+                name={pareto.xLabel}
+                label={{
+                  value: pareto.xLabel,
+                  position: "insideBottom",
+                  offset: -10,
+                  className: "fill-gray-600 dark:fill-gray-400",
+                }}
+                tick={{ fontSize: 12, className: "fill-gray-500 dark:fill-gray-400" }}
+                className="stroke-gray-300 dark:stroke-gray-600"
+              />
+              <YAxis
+                type="number"
+                dataKey="y"
+                domain={[yMin, yMax]}
+                name={pareto.yLabel}
+                label={{
+                  value: pareto.yLabel,
+                  angle: -90,
+                  position: "insideLeft",
+                  offset: 5,
+                  className: "fill-gray-600 dark:fill-gray-400",
+                }}
+                tick={{ fontSize: 12, className: "fill-gray-500 dark:fill-gray-400" }}
+                className="stroke-gray-300 dark:stroke-gray-600"
+              />
+              <Tooltip content={<ParetoTooltip />} />
+
+              {/* Pareto frontier line */}
+              {frontierLineData.length >= 2 && (
+                <Line
+                  data={frontierLineData}
+                  type="monotone"
+                  dataKey="y"
+                  stroke={FRONTIER_LINE_COLOR}
+                  strokeWidth={2}
+                  strokeDasharray="6 3"
+                  dot={false}
+                  legendType="none"
+                  isAnimationActive={false}
+                />
+              )}
+
+              {/* Scatter points */}
+              <Scatter data={enrichedPoints} shape={<ParetoScatterDot />} isAnimationActive={false}>
+                {enrichedPoints.map((p) => (
+                  <Cell key={p.optionId} fill={p.isPareto ? PARETO_COLOR : DOMINATED_COLOR} />
+                ))}
+              </Scatter>
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+
+      {/* Legend */}
+      {!sameAxis && (
+        <div className="flex flex-wrap gap-4 text-xs text-gray-500 dark:text-gray-400">
+          <span className="flex items-center gap-1.5">
+            <span
+              className="inline-block w-3 h-3 rounded-full"
+              style={{ backgroundColor: PARETO_COLOR }}
+            />
+            Pareto-optimal ({pareto.frontier.length})
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span
+              className="inline-block w-3 h-3 rounded-full opacity-60"
+              style={{ backgroundColor: DOMINATED_COLOR }}
+            />
+            Dominated ({pareto.dominated.length})
+          </span>
+          {frontierLineData.length >= 2 && (
+            <span className="flex items-center gap-1.5">
+              <span
+                className="inline-block w-6 border-t-2 border-dashed"
+                style={{ borderColor: FRONTIER_LINE_COLOR }}
+              />
+              Frontier
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Dominated option insights */}
+      {!sameAxis && pareto.dominated.length > 0 && (
+        <div className="space-y-2">
+          {pareto.dominated.map((domId) => {
+            const dominators = pareto.dominanceMap[domId] ?? [];
+            const domOpt = decision.options.find((o) => o.id === domId);
+            // Show only the first dominator for brevity
+            const dominator = decision.options.find((o) => o.id === dominators[0]);
+            if (!domOpt || !dominator) return null;
+
+            return (
+              <div
+                key={domId}
+                className="flex items-start gap-2 rounded-lg bg-gray-50 dark:bg-gray-800/60 border border-gray-200 dark:border-gray-700 p-3 text-sm text-gray-600 dark:text-gray-400"
+              >
+                <Info className="h-4 w-4 mt-0.5 flex-shrink-0 text-gray-400 dark:text-gray-500" />
+                <span>
+                  <strong className="text-gray-800 dark:text-gray-200">{domOpt.name}</strong> is
+                  dominated by{" "}
+                  <strong className="text-gray-800 dark:text-gray-200">{dominator.name}</strong> —{" "}
+                  {dominator.name} scores higher on both {pareto.xLabel} and {pareto.yLabel}.
+                  {dominators.length > 1 &&
+                    ` (and ${dominators.length - 1} other${dominators.length > 2 ? "s" : ""})`}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const ParetoChart = memo(ParetoChartInner);

--- a/src/components/ResultsView.tsx
+++ b/src/components/ResultsView.tsx
@@ -15,6 +15,7 @@ import {
   AlertCircle,
   AlertTriangle,
   X,
+  Crosshair,
 } from "lucide-react";
 import { useState, lazy, Suspense, useMemo } from "react";
 import { buildShareLink } from "@/lib/share";
@@ -28,6 +29,7 @@ import { BiasWarnings } from "./BiasWarnings";
 import { useBiasDetection } from "@/hooks/useBiasDetection";
 
 const ScoreChart = lazy(() => import("./ScoreChart").then((m) => ({ default: m.ScoreChart })));
+const ParetoChart = lazy(() => import("./ParetoChart").then((m) => ({ default: m.ParetoChart })));
 
 interface ResultsViewProps {
   validation: ValidationResult;
@@ -366,6 +368,30 @@ export function ResultsView({ validation, completeness, onSwitchToBuilder }: Res
           </Suspense>
         </div>
       </section>
+
+      {/* Trade-Off Explorer (Pareto Frontier) */}
+      {decision.criteria.length >= 2 && decision.options.length >= 2 && (
+        <section aria-labelledby="pareto-heading" className="print:hidden">
+          <h2
+            id="pareto-heading"
+            className="text-lg font-semibold text-gray-900 dark:text-gray-100 flex items-center gap-2 mb-3"
+          >
+            <Crosshair className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+            Trade-Off Explorer
+          </h2>
+          <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4">
+            <Suspense
+              fallback={
+                <div className="h-[200px] flex items-center justify-center text-sm text-gray-400 dark:text-gray-500">
+                  Loading chart…
+                </div>
+              }
+            >
+              <ParetoChart decision={decision} results={results} />
+            </Suspense>
+          </div>
+        </section>
+      )}
 
       {/* Top Drivers */}
       <section aria-labelledby="drivers-heading">

--- a/src/lib/pareto.ts
+++ b/src/lib/pareto.ts
@@ -1,0 +1,157 @@
+/**
+ * Pareto Frontier Computation
+ *
+ * Determines which options are Pareto-optimal (non-dominated) and which are
+ * dominated when projected onto any two chosen criteria.
+ *
+ * An option A dominates option B if A scores ≥ B on BOTH criteria and
+ * strictly > on at least one. Options on the Pareto frontier represent
+ * genuine trade-offs — no other option beats them on both axes simultaneously.
+ *
+ * Complexity: O(n²) for n options — fine for typical decisions (< 30 options).
+ *
+ * Future extension: N-dimensional Pareto using non-dominated sorting (NSGA-II).
+ *
+ * @see https://github.com/ericsocrat/decision-os/issues/78
+ */
+
+import type { Decision } from "./types";
+import { readScoreOrZero } from "./scoring";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ParetoPoint {
+  /** Option ID */
+  optionId: string;
+  /** Option display name */
+  optionName: string;
+  /** Score on the X-axis criterion (effective score: benefit = raw, cost = 10 − raw) */
+  x: number;
+  /** Score on the Y-axis criterion (effective score) */
+  y: number;
+  /** Whether this option is on the Pareto frontier */
+  isPareto: boolean;
+  /** IDs of options that dominate this one (empty if Pareto-optimal) */
+  dominatedBy: string[];
+}
+
+export interface ParetoResult {
+  /** All option points with Pareto status */
+  points: ParetoPoint[];
+  /** Option IDs on the Pareto frontier */
+  frontier: string[];
+  /** Option IDs that are dominated */
+  dominated: string[];
+  /** Map from dominated option ID → IDs of options that dominate it */
+  dominanceMap: Record<string, string[]>;
+  /** X-axis criterion name */
+  xLabel: string;
+  /** Y-axis criterion name */
+  yLabel: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the effective score for Pareto comparison.
+ * For benefit criteria: higher is better (use raw score).
+ * For cost criteria: lower is better, so we invert (10 − raw) so "higher = better" holds.
+ */
+function effectiveScore(rawScore: number, criterionType: "benefit" | "cost"): number {
+  return criterionType === "cost" ? 10 - rawScore : rawScore;
+}
+
+/**
+ * Select the two default axes — the two highest-weighted criteria.
+ * Returns [xCriterionId, yCriterionId] or null if < 2 criteria.
+ */
+export function defaultAxes(decision: Decision): [string, string] | null {
+  if (decision.criteria.length < 2) return null;
+  const sorted = [...decision.criteria].sort((a, b) => b.weight - a.weight);
+  return [sorted[0].id, sorted[1].id];
+}
+
+// ---------------------------------------------------------------------------
+// Core Computation
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the 2D Pareto frontier for the given decision and two criteria.
+ *
+ * @param decision - The full decision object
+ * @param criterionXId - Criterion ID for the X axis
+ * @param criterionYId - Criterion ID for the Y axis
+ * @returns ParetoResult with frontier points, dominated points, and dominance map
+ */
+export function computeParetoFrontier(
+  decision: Decision,
+  criterionXId: string,
+  criterionYId: string
+): ParetoResult {
+  const critX = decision.criteria.find((c) => c.id === criterionXId);
+  const critY = decision.criteria.find((c) => c.id === criterionYId);
+
+  if (!critX || !critY) {
+    return {
+      points: [],
+      frontier: [],
+      dominated: [],
+      dominanceMap: {},
+      xLabel: critX?.name ?? criterionXId,
+      yLabel: critY?.name ?? criterionYId,
+    };
+  }
+
+  // Build points with effective scores
+  const points: ParetoPoint[] = decision.options.map((opt) => {
+    const rawX = readScoreOrZero(decision.scores, opt.id, criterionXId);
+    const rawY = readScoreOrZero(decision.scores, opt.id, criterionYId);
+
+    return {
+      optionId: opt.id,
+      optionName: opt.name,
+      x: effectiveScore(rawX, critX.type),
+      y: effectiveScore(rawY, critY.type),
+      isPareto: true, // assume true, will be marked false if dominated
+      dominatedBy: [],
+    };
+  });
+
+  // Determine domination: O(n²)
+  for (let i = 0; i < points.length; i++) {
+    for (let j = 0; j < points.length; j++) {
+      if (i === j) continue;
+      const a = points[j]; // potential dominator
+      const b = points[i]; // potential dominated
+
+      // A dominates B if A ≥ B on both and A > B on at least one
+      if (a.x >= b.x && a.y >= b.y && (a.x > b.x || a.y > b.y)) {
+        b.isPareto = false;
+        b.dominatedBy.push(a.optionId);
+      }
+    }
+  }
+
+  const frontier = points.filter((p) => p.isPareto).map((p) => p.optionId);
+  const dominated = points.filter((p) => !p.isPareto).map((p) => p.optionId);
+
+  const dominanceMap: Record<string, string[]> = {};
+  for (const p of points) {
+    if (p.dominatedBy.length > 0) {
+      dominanceMap[p.optionId] = p.dominatedBy;
+    }
+  }
+
+  return {
+    points,
+    frontier,
+    dominated,
+    dominanceMap,
+    xLabel: critX.name,
+    yLabel: critY.name,
+  };
+}


### PR DESCRIPTION
## Summary
Adds an interactive **Pareto frontier scatter plot** (Trade-Off Explorer) to the Results view, enabling users to visually identify dominated options and understand trade-offs between any two criteria.

## Changes

### New: \src/lib/pareto.ts\
- \computeParetoFrontier(decision, xCriterionId, yCriterionId)\ — O(n²) domination check returning points, frontier, dominated sets, and dominance map
- \ffectiveScore()\ — inverts cost criteria (10 − raw) so higher = better universally
- \defaultAxes()\ — selects two highest-weighted criteria as default axes

### New: \src/components/ParetoChart.tsx\
- Recharts \ComposedChart\ with \Scatter\ (points) + \Line\ (dashed Pareto frontier)
- Custom \ParetoScatterDot\: large blue circles for Pareto-optimal, small gray for dominated, with labels
- Custom \ParetoTooltip\: shows option name, axis scores, and Pareto status
- Dropdown axis selectors defaulting to highest-weighted criteria
- Same-axis warning with AlertTriangle icon
- Dominated option insight cards explaining which options dominate each dominated option
- Color-coded legend with Pareto/dominated/frontier indicators
- Full dark mode support, responsive layout, screen-reader accessible

### Modified: \src/components/ResultsView.tsx\
- Added lazy-loaded Trade-Off Explorer section between Score Chart and Top Drivers
- Conditional render: requires ≥ 2 criteria and ≥ 2 options

### New: \src/__tests__/pareto.test.ts\ (20 tests)
- Basic frontier, all dominated, diagonal trade-offs, tied scores, single option
- Cost criteria inversion, missing/null scores, ScoredCell values
- Stress test (20 options), dominance map, partial domination, defaultAxes

## Verification
- [x] 583 tests pass (32 files)
- [x] TypeScript strict — zero errors
- [x] ESLint — zero warnings
- [x] Production build — successful

Closes #78