### PR TITLE
feat(ui): add tab-level ErrorBoundaries for each analysis view (#81)

### DIFF
--- a/src/__tests__/components/TabErrorBoundary.test.tsx
+++ b/src/__tests__/components/TabErrorBoundary.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * Tests for TabErrorFallback component and tab-level ErrorBoundary isolation.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { TabErrorFallback } from "@/components/TabErrorFallback";
+
+// Suppress React error boundary console.error in tests
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+function ThrowingComponent({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) throw new Error("Tab explosion");
+  return <div>Tab content works</div>;
+}
+
+describe("TabErrorFallback", () => {
+  it("renders tab name and reassurance message", () => {
+    render(<TabErrorFallback tab="Monte Carlo" />);
+    expect(screen.getByText("Monte Carlo encountered an error")).toBeInTheDocument();
+    expect(
+      screen.getByText("Your decision data is safe. Other tabs are unaffected.")
+    ).toBeInTheDocument();
+  });
+
+  it("renders Try Again button when onReset is provided", () => {
+    const onReset = vi.fn();
+    render(<TabErrorFallback tab="Results" onReset={onReset} />);
+    const btn = screen.getByRole("button", { name: /try again/i });
+    expect(btn).toBeInTheDocument();
+    fireEvent.click(btn);
+    expect(onReset).toHaveBeenCalledOnce();
+  });
+
+  it("does not render Try Again button when onReset is omitted", () => {
+    render(<TabErrorFallback tab="Sensitivity" />);
+    expect(screen.queryByRole("button", { name: /try again/i })).not.toBeInTheDocument();
+  });
+
+  it("has role=alert for screen readers", () => {
+    render(<TabErrorFallback tab="Compare" />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+});
+
+describe("Tab-level ErrorBoundary isolation", () => {
+  it("crash in one tab does not affect sibling tabs", () => {
+    render(
+      <div>
+        <ErrorBoundary fallback={(reset) => <TabErrorFallback tab="Results" onReset={reset} />}>
+          <ThrowingComponent shouldThrow={true} />
+        </ErrorBoundary>
+        <ErrorBoundary fallback={(reset) => <TabErrorFallback tab="Sensitivity" onReset={reset} />}>
+          <div>Sensitivity works</div>
+        </ErrorBoundary>
+        <div>Builder always works</div>
+      </div>
+    );
+
+    // Results crashed
+    expect(screen.getByText("Results encountered an error")).toBeInTheDocument();
+    // Sensitivity and Builder are unaffected
+    expect(screen.getByText("Sensitivity works")).toBeInTheDocument();
+    expect(screen.getByText("Builder always works")).toBeInTheDocument();
+  });
+
+  it("render-prop fallback receives reset callback that works", () => {
+    let shouldThrow = true;
+    function Crasher() {
+      if (shouldThrow) throw new Error("Boom");
+      return <div>Recovered tab</div>;
+    }
+
+    const { rerender } = render(
+      <ErrorBoundary fallback={(reset) => <TabErrorFallback tab="Monte Carlo" onReset={reset} />}>
+        <Crasher />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText("Monte Carlo encountered an error")).toBeInTheDocument();
+
+    // Stop throwing and reset
+    shouldThrow = false;
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    rerender(
+      <ErrorBoundary fallback={(reset) => <TabErrorFallback tab="Monte Carlo" onReset={reset} />}>
+        <Crasher />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText("Recovered tab")).toBeInTheDocument();
+  });
+
+  it("ErrorBoundary calls reportError on tab crash", async () => {
+    const errorReporter = await import("@/lib/error-reporter");
+    const spy = vi.spyOn(errorReporter, "reportError").mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary fallback={(reset) => <TabErrorFallback tab="Compare" onReset={reset} />}>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Tab explosion" }),
+      expect.objectContaining({ source: "ErrorBoundary" })
+    );
+
+    spy.mockRestore();
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,6 +18,7 @@ import {
 import { AnnouncerProvider, useAnnounce } from "@/components/Announcer";
 import { DecisionProvider, useDecision } from "@/components/DecisionProvider";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { TabErrorFallback } from "@/components/TabErrorFallback";
 import { Header } from "@/components/Header";
 import { DecisionBuilder } from "@/components/DecisionBuilder";
 import { ResultsView } from "@/components/ResultsView";
@@ -432,11 +433,13 @@ function AppContent() {
           aria-labelledby="tab-results"
           className={activeTab === "results" ? "" : "hidden"}
         >
-          <ResultsView
-            validation={validation}
-            completeness={completeness}
-            onSwitchToBuilder={() => setActiveTab("builder")}
-          />
+          <ErrorBoundary fallback={(reset) => <TabErrorFallback tab="Results" onReset={reset} />}>
+            <ResultsView
+              validation={validation}
+              completeness={completeness}
+              onSwitchToBuilder={() => setActiveTab("builder")}
+            />
+          </ErrorBoundary>
         </div>
         <div
           id="panel-sensitivity"
@@ -444,9 +447,13 @@ function AppContent() {
           aria-labelledby="tab-sensitivity"
           className={activeTab === "sensitivity" ? "" : "hidden"}
         >
-          <Suspense fallback={<TabPanelSkeleton label="Sensitivity" />}>
-            <SensitivityView />
-          </Suspense>
+          <ErrorBoundary
+            fallback={(reset) => <TabErrorFallback tab="Sensitivity" onReset={reset} />}
+          >
+            <Suspense fallback={<TabPanelSkeleton label="Sensitivity" />}>
+              <SensitivityView />
+            </Suspense>
+          </ErrorBoundary>
         </div>
         <div
           id="panel-compare"
@@ -454,9 +461,11 @@ function AppContent() {
           aria-labelledby="tab-compare"
           className={activeTab === "compare" ? "" : "hidden"}
         >
-          <Suspense fallback={<TabPanelSkeleton label="Compare" />}>
-            <CompareView />
-          </Suspense>
+          <ErrorBoundary fallback={(reset) => <TabErrorFallback tab="Compare" onReset={reset} />}>
+            <Suspense fallback={<TabPanelSkeleton label="Compare" />}>
+              <CompareView />
+            </Suspense>
+          </ErrorBoundary>
         </div>
         <div
           id="panel-montecarlo"
@@ -464,9 +473,13 @@ function AppContent() {
           aria-labelledby="tab-montecarlo"
           className={activeTab === "montecarlo" ? "" : "hidden"}
         >
-          <Suspense fallback={<TabPanelSkeleton label="Monte Carlo" />}>
-            <MonteCarloView />
-          </Suspense>
+          <ErrorBoundary
+            fallback={(reset) => <TabErrorFallback tab="Monte Carlo" onReset={reset} />}
+          >
+            <Suspense fallback={<TabPanelSkeleton label="Monte Carlo" />}>
+              <MonteCarloView />
+            </Suspense>
+          </ErrorBoundary>
         </div>
       </main>
 

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -13,7 +13,8 @@ import { reportError } from "@/lib/error-reporter";
 
 interface Props {
   children: ReactNode;
-  fallback?: ReactNode;
+  /** Static fallback node, or render-prop receiving a reset callback */
+  fallback?: ReactNode | ((reset: () => void) => ReactNode);
 }
 
 interface State {
@@ -45,7 +46,9 @@ export class ErrorBoundary extends Component<Props, State> {
   render() {
     if (this.state.hasError) {
       if (this.props.fallback) {
-        return this.props.fallback;
+        return typeof this.props.fallback === "function"
+          ? this.props.fallback(this.handleReset)
+          : this.props.fallback;
       }
 
       return (

--- a/src/components/TabErrorFallback.tsx
+++ b/src/components/TabErrorFallback.tsx
@@ -1,0 +1,43 @@
+/**
+ * TabErrorFallback — lightweight fallback for tab-level ErrorBoundaries.
+ *
+ * Shown when a single analysis tab (Results, Sensitivity, Compare, Monte Carlo)
+ * crashes during render. Reassures the user their data is safe and provides
+ * a retry button that resets just this tab's error boundary.
+ */
+
+"use client";
+
+import { AlertTriangle, RotateCcw } from "lucide-react";
+
+interface TabErrorFallbackProps {
+  /** Display name for the tab that errored */
+  tab: string;
+  /** Called when the user clicks "Try Again" — should reset the ErrorBoundary */
+  onReset?: () => void;
+}
+
+export function TabErrorFallback({ tab, onReset }: TabErrorFallbackProps) {
+  return (
+    <div role="alert" className="min-h-[200px] flex items-center justify-center p-6">
+      <div className="text-center max-w-md">
+        <AlertTriangle className="h-8 w-8 text-amber-500 dark:text-amber-400 mx-auto mb-3" />
+        <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-1">
+          {tab} encountered an error
+        </h3>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+          Your decision data is safe. Other tabs are unaffected.
+        </p>
+        {onReset && (
+          <button
+            onClick={onReset}
+            className="inline-flex items-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+          >
+            <RotateCcw className="h-4 w-4" />
+            Try Again
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Wraps each analysis tab (Results, Sensitivity, Compare, Monte Carlo) in its own ErrorBoundary so a crash in one tab does not take down the entire app. The Builder tab remains always accessible.

## Changes
- New TabErrorFallback component with tab name, reassurance message, retry button, role=alert, dark mode
- Enhanced ErrorBoundary fallback prop to accept render-prop (reset callback)
- Wrapped Results, Sensitivity, Compare, Monte Carlo panels in individual ErrorBoundaries in page.tsx
- 7 unit tests covering isolation, reset, reportError, accessibility

## Verification
- 599 tests pass (34 files)
- TypeScript strict: zero errors
- ESLint: zero warnings
- Production build: successful

Closes #81
