### PR TITLE
security: add rate limiting with exponential backoff for Supabase calls (#84)

### DIFF
--- a/src/__tests__/cloud-storage.test.ts
+++ b/src/__tests__/cloud-storage.test.ts
@@ -20,6 +20,12 @@ vi.mock("@/lib/supabase", () => ({
   isCloudEnabled: () => true,
 }));
 
+// Bypass retry/backoff in cloud-storage tests — pass-through immediately
+vi.mock("@/lib/rate-limiter", () => ({
+  withRetry: <T>(fn: () => Promise<T>) => fn(),
+  enqueueWrite: <T>(fn: () => Promise<T>) => fn(),
+}));
+
 // Import AFTER mocking
 const {
   cloudGetDecisions,

--- a/src/__tests__/rate-limiter.test.ts
+++ b/src/__tests__/rate-limiter.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for the rate limiter with exponential backoff.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  withRetry,
+  enqueueWrite,
+  computeBackoff,
+  getRetryState,
+  subscribeRetryState,
+  resetRetryState,
+  _resetForTests,
+} from "@/lib/rate-limiter";
+
+beforeEach(() => {
+  _resetForTests();
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("computeBackoff", () => {
+  it("returns 1s for first failure", () => {
+    expect(computeBackoff(0)).toBe(1_000);
+  });
+
+  it("returns 2s for second failure", () => {
+    expect(computeBackoff(1)).toBe(2_000);
+  });
+
+  it("returns 4s for third failure", () => {
+    expect(computeBackoff(2)).toBe(4_000);
+  });
+
+  it("caps at 30s", () => {
+    expect(computeBackoff(10)).toBe(30_000);
+  });
+});
+
+describe("withRetry", () => {
+  it("resolves immediately on success", async () => {
+    const fn = vi.fn().mockResolvedValue("ok");
+    const result = await withRetry(fn);
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it("retries on failure and resolves on eventual success", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("fail1"))
+      .mockRejectedValueOnce(new Error("fail2"))
+      .mockResolvedValue("ok");
+
+    const promise = withRetry(fn);
+    // Advance past both backoff delays
+    await vi.advanceTimersByTimeAsync(1_000); // 1st backoff
+    await vi.advanceTimersByTimeAsync(2_000); // 2nd backoff
+    const result = await promise;
+
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("rejects after MAX_RETRIES (3) failures", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("always fails"));
+
+    const promise = withRetry(fn).catch((e: Error) => e);
+    // Advance through all backoff delays
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(4_000);
+
+    const result = await promise;
+    expect(result).toBeInstanceOf(Error);
+    expect((result as Error).message).toBe("always fails");
+    expect(fn).toHaveBeenCalledTimes(4); // 1 initial + 3 retries
+  });
+
+  it("sets state to failed after exhausting retries", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("boom"));
+
+    const promise = withRetry(fn).catch(() => {});
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(4_000);
+    await promise;
+
+    expect(getRetryState().status).toBe("failed");
+    expect(getRetryState().failures).toBe(4);
+  });
+
+  it("resets state to idle on success after prior failures", async () => {
+    const fn = vi.fn().mockRejectedValueOnce(new Error("fail")).mockResolvedValue("ok");
+
+    const promise = withRetry(fn);
+    await vi.advanceTimersByTimeAsync(1_000);
+    await promise;
+
+    expect(getRetryState().status).toBe("idle");
+    expect(getRetryState().failures).toBe(0);
+  });
+});
+
+describe("enqueueWrite", () => {
+  it("serializes concurrent writes", async () => {
+    const order: number[] = [];
+    const fn1 = vi.fn(async () => {
+      order.push(1);
+      return "a";
+    });
+    const fn2 = vi.fn(async () => {
+      order.push(2);
+      return "b";
+    });
+
+    const p1 = enqueueWrite(fn1);
+    const p2 = enqueueWrite(fn2);
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1).toBe("a");
+    expect(r2).toBe("b");
+    expect(order).toEqual([1, 2]); // sequential, not concurrent
+  });
+
+  it("continues queue after a failed write", async () => {
+    const fn1 = vi.fn().mockRejectedValue(new Error("fail"));
+    const fn2 = vi.fn().mockResolvedValue("ok");
+
+    const p1 = enqueueWrite(fn1).catch(() => "caught");
+    // Advance timers past all retry attempts for fn1
+    await vi.advanceTimersByTimeAsync(10_000);
+    await p1;
+
+    _resetForTests(); // reset backoff state for fn2
+    const r2 = await enqueueWrite(fn2);
+    expect(r2).toBe("ok");
+  });
+});
+
+describe("subscribeRetryState", () => {
+  it("notifies listeners on state change", async () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeRetryState(listener);
+
+    const fn = vi.fn().mockRejectedValueOnce(new Error("fail")).mockResolvedValue("ok");
+
+    const promise = withRetry(fn);
+    await vi.advanceTimersByTimeAsync(1_000);
+    await promise;
+
+    // Should have been called with backoff state, retrying state, then idle
+    expect(listener).toHaveBeenCalled();
+    const statuses = listener.mock.calls.map((c: Array<{ status: string }>) => c[0].status);
+    expect(statuses).toContain("backoff");
+    expect(statuses).toContain("idle");
+
+    unsubscribe();
+  });
+
+  it("stops notifying after unsubscribe", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeRetryState(listener);
+    unsubscribe();
+
+    resetRetryState();
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/cloud-storage.ts
+++ b/src/lib/cloud-storage.ts
@@ -9,6 +9,7 @@
 import type { Decision } from "./types";
 import { isDecision } from "./validation";
 import { getSupabase } from "./supabase";
+import { withRetry, enqueueWrite } from "./rate-limiter";
 
 // ─── Helpers ───────────────────────────────────────────────────────
 
@@ -33,18 +34,24 @@ export async function cloudGetDecisions(): Promise<Decision[]> {
   const userId = await currentUserId();
   if (!sb || !userId) return [];
 
-  const { data, error } = await sb
-    .from("decisions")
-    .select("data")
-    .eq("user_id", userId)
-    .order("updated_at", { ascending: false });
+  try {
+    return await withRetry(async () => {
+      const { data, error } = await sb
+        .from("decisions")
+        .select("data")
+        .eq("user_id", userId)
+        .order("updated_at", { ascending: false });
 
-  if (error) {
-    console.error("[DecisionOS:cloud] fetch decisions failed:", error.message);
+      if (error) throw new Error(error.message);
+
+      return (data ?? [])
+        .map((row) => row.data as unknown)
+        .filter((d): d is Decision => isDecision(d));
+    });
+  } catch (err) {
+    console.error("[DecisionOS:cloud] fetch decisions failed:", err);
     return [];
   }
-
-  return (data ?? []).map((row) => row.data as unknown).filter((d): d is Decision => isDecision(d));
 }
 
 /**
@@ -55,20 +62,24 @@ export async function cloudGetDecision(decisionId: string): Promise<Decision | n
   const userId = await currentUserId();
   if (!sb || !userId) return null;
 
-  const { data, error } = await sb
-    .from("decisions")
-    .select("data")
-    .eq("user_id", userId)
-    .eq("decision_id", decisionId)
-    .maybeSingle();
+  try {
+    return await withRetry(async () => {
+      const { data, error } = await sb
+        .from("decisions")
+        .select("data")
+        .eq("user_id", userId)
+        .eq("decision_id", decisionId)
+        .maybeSingle();
 
-  if (error) {
-    console.error("[DecisionOS:cloud] fetch decision failed:", error.message);
+      if (error) throw new Error(error.message);
+
+      const parsed = data?.data as unknown;
+      return isDecision(parsed) ? parsed : null;
+    });
+  } catch (err) {
+    console.error("[DecisionOS:cloud] fetch decision failed:", err);
     return null;
   }
-
-  const parsed = data?.data as unknown;
-  return isDecision(parsed) ? parsed : null;
 }
 
 /**
@@ -80,21 +91,25 @@ export async function cloudSaveDecision(decision: Decision): Promise<boolean> {
   const userId = await currentUserId();
   if (!sb || !userId) return false;
 
-  const { error } = await sb.from("decisions").upsert(
-    {
-      user_id: userId,
-      decision_id: decision.id,
-      data: decision as unknown as Record<string, unknown>,
-      updated_at: new Date().toISOString(),
-    },
-    { onConflict: "user_id,decision_id" }
-  );
+  try {
+    return await enqueueWrite(async () => {
+      const { error } = await sb.from("decisions").upsert(
+        {
+          user_id: userId,
+          decision_id: decision.id,
+          data: decision as unknown as Record<string, unknown>,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: "user_id,decision_id" }
+      );
 
-  if (error) {
-    console.error("[DecisionOS:cloud] save decision failed:", error.message);
+      if (error) throw new Error(error.message);
+      return true;
+    });
+  } catch (err) {
+    console.error("[DecisionOS:cloud] save decision failed:", err);
     return false;
   }
-  return true;
 }
 
 /**
@@ -105,17 +120,21 @@ export async function cloudDeleteDecision(decisionId: string): Promise<boolean> 
   const userId = await currentUserId();
   if (!sb || !userId) return false;
 
-  const { error } = await sb
-    .from("decisions")
-    .delete()
-    .eq("user_id", userId)
-    .eq("decision_id", decisionId);
+  try {
+    return await enqueueWrite(async () => {
+      const { error } = await sb
+        .from("decisions")
+        .delete()
+        .eq("user_id", userId)
+        .eq("decision_id", decisionId);
 
-  if (error) {
-    console.error("[DecisionOS:cloud] delete decision failed:", error.message);
+      if (error) throw new Error(error.message);
+      return true;
+    });
+  } catch (err) {
+    console.error("[DecisionOS:cloud] delete decision failed:", err);
     return false;
   }
-  return true;
 }
 
 /**
@@ -134,11 +153,17 @@ export async function cloudSaveAllDecisions(decisions: Decision[]): Promise<bool
     updated_at: d.updatedAt ?? new Date().toISOString(),
   }));
 
-  const { error } = await sb.from("decisions").upsert(rows, { onConflict: "user_id,decision_id" });
+  try {
+    return await enqueueWrite(async () => {
+      const { error } = await sb
+        .from("decisions")
+        .upsert(rows, { onConflict: "user_id,decision_id" });
 
-  if (error) {
-    console.error("[DecisionOS:cloud] batch save failed:", error.message);
+      if (error) throw new Error(error.message);
+      return true;
+    });
+  } catch (err) {
+    console.error("[DecisionOS:cloud] batch save failed:", err);
     return false;
   }
-  return true;
 }

--- a/src/lib/rate-limiter.ts
+++ b/src/lib/rate-limiter.ts
@@ -1,0 +1,126 @@
+/**
+ * Client-side rate limiter with exponential backoff for Supabase calls.
+ *
+ * Provides:
+ * - Serial write queue (max 1 concurrent write to avoid conflicts)
+ * - Exponential backoff on failure: 1 s → 2 s → 4 s → 8 s → cap 30 s
+ * - Max 3 retries before surfacing error
+ * - Observable status for UI (SyncStatus degradation)
+ *
+ * Architecture: wraps any `() => Promise<T>` call. Read calls are not queued
+ * (they can run concurrently) but still get retry + backoff.
+ */
+
+export type RetryStatus = "idle" | "retrying" | "backoff" | "failed";
+
+export interface RetryState {
+  status: RetryStatus;
+  /** Number of consecutive failures */
+  failures: number;
+  /** Timestamp (ms) when the next retry is allowed, or 0 if idle */
+  retryAfter: number;
+}
+
+// ─── Constants ─────────────────────────────────────────────────────
+
+const MAX_RETRIES = 3;
+const INITIAL_BACKOFF_MS = 1_000;
+const MAX_BACKOFF_MS = 30_000;
+const BACKOFF_FACTOR = 2;
+
+// ─── Retry state (module-level singleton) ──────────────────────────
+
+let _state: RetryState = { status: "idle", failures: 0, retryAfter: 0 };
+const _listeners = new Set<(s: RetryState) => void>();
+
+export function getRetryState(): RetryState {
+  return _state;
+}
+
+function setState(next: RetryState) {
+  _state = next;
+  _listeners.forEach((fn) => fn(next));
+}
+
+/** Subscribe to retry state changes. Returns unsubscribe fn. */
+export function subscribeRetryState(fn: (s: RetryState) => void): () => void {
+  _listeners.add(fn);
+  return () => {
+    _listeners.delete(fn);
+  };
+}
+
+/** Reset retry state (e.g. after successful call). */
+export function resetRetryState() {
+  setState({ status: "idle", failures: 0, retryAfter: 0 });
+}
+
+// ─── Backoff calculation ───────────────────────────────────────────
+
+/** Compute backoff delay for the nth failure (0-indexed). */
+export function computeBackoff(failureCount: number): number {
+  const delay = INITIAL_BACKOFF_MS * Math.pow(BACKOFF_FACTOR, failureCount);
+  return Math.min(delay, MAX_BACKOFF_MS);
+}
+
+// ─── Serial write queue ────────────────────────────────────────────
+
+let _writeQueue: Promise<unknown> = Promise.resolve();
+
+/**
+ * Enqueue a write operation so that writes execute serially.
+ * Returns the result of the operation.
+ */
+export function enqueueWrite<T>(fn: () => Promise<T>): Promise<T> {
+  const result = _writeQueue.then(() => withRetry(fn));
+  // Keep the chain going even if this call fails
+  _writeQueue = result.catch(() => {});
+  return result;
+}
+
+// ─── Retry wrapper ─────────────────────────────────────────────────
+
+/**
+ * Execute `fn` with exponential backoff retry.
+ * Resolves with the result on success, rejects after MAX_RETRIES failures.
+ */
+export async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
+  let attempt = 0;
+
+  while (true) {
+    try {
+      const result = await fn();
+      // Success — reset backoff state
+      if (_state.failures > 0) {
+        resetRetryState();
+      }
+      return result;
+    } catch (err) {
+      attempt++;
+      if (attempt > MAX_RETRIES) {
+        setState({ status: "failed", failures: attempt, retryAfter: 0 });
+        throw err;
+      }
+
+      const delay = computeBackoff(attempt - 1);
+      const retryAfter = Date.now() + delay;
+      setState({ status: "backoff", failures: attempt, retryAfter });
+
+      await sleep(delay);
+      setState({ status: "retrying", failures: attempt, retryAfter: 0 });
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ─── Test helpers ──────────────────────────────────────────────────
+
+/** Reset internal state for tests. */
+export function _resetForTests() {
+  _state = { status: "idle", failures: 0, retryAfter: 0 };
+  _listeners.clear();
+  _writeQueue = Promise.resolve();
+}


### PR DESCRIPTION
## Summary

Add client-side rate limiting with exponential backoff for all Supabase cloud storage operations.

## Changes

### New: \src/lib/rate-limiter.ts\ (~127 lines)
- **Exponential backoff**: 1s → 2s → 4s → 8s, capped at 30s
- **Serial write queue**: prevents concurrent Supabase mutations via promise chain
- **Max 3 retries** before surfacing error
- **Observable \RetryState\**: \idle | retrying | backoff | failed\ with subscriber pattern for UI consumption (SyncStatus degradation)
- Constants: \MAX_RETRIES=3\, \INITIAL_BACKOFF_MS=1000\, \MAX_BACKOFF_MS=30000\, \BACKOFF_FACTOR=2\

### Modified: \src/lib/cloud-storage.ts\
- Wrapped read operations (\cloudGetDecisions\, \cloudGetDecision\) with \withRetry\
- Wrapped write operations (\cloudSaveDecision\, \cloudDeleteDecision\, \cloudSaveAllDecisions\) with \nqueueWrite\ (serial queue + retry)
- Each function throws inside the retry wrapper and catches outside, returning graceful fallbacks

### New: \src/__tests__/rate-limiter.test.ts\ (13 tests)
- \computeBackoff\: 4 tests (1s, 2s, 4s, cap at 30s)
- \withRetry\: 4 tests (immediate success, retry+success, reject after max retries, state transitions)
- \nqueueWrite\: 2 tests (serialization, queue continues after failure)
- \subscribeRetryState\: 2 tests (notify + unsubscribe)
- Reset state: 1 test

### Modified: \src/__tests__/cloud-storage.test.ts\
- Added rate-limiter mock to bypass backoff delays in existing tests

## Acceptance Criteria
- [x] Exponential backoff: 1 s → 2 s → 4 s → 8 s → cap 30 s
- [x] Serial write queue (only 1 concurrent Supabase write)
- [x] Max 3 retries before surfacing error
- [x] Observable RetryState for UI degradation
- [x] 612 tests pass, 0 errors
- [x] TSC clean, ESLint clean, build passes

Closes #84