### PR TITLE
docs: renumber ADR-002-scoring-model to ADR-003 (#91)

### DIFF
--- a/docs/DECISIONS/ADR-003-scoring-model.md
+++ b/docs/DECISIONS/ADR-003-scoring-model.md
@@ -1,4 +1,4 @@
-# ADR-002: Weighted Sum Scoring Model
+# ADR-003: Weighted Sum Scoring Model
 
 ## Status
 


### PR DESCRIPTION
Fixes ADR numbering collision: two files were both named ADR-002. Renames ADR-002-scoring-model.md to ADR-003-scoring-model.md and updates the title inside the file.

Closes #91