### PR TITLE
feat(hybrid): add multi-algorithm consensus ranking display

### DIFF
--- a/src/__tests__/components/HybridResults.test.tsx
+++ b/src/__tests__/components/HybridResults.test.tsx
@@ -1,0 +1,314 @@
+/**
+ * Tests for HybridResults — multi-algorithm consensus ranking display.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { HybridResults, buildHybridSummary } from "@/components/HybridResults";
+import type { Decision, DecisionResults } from "@/lib/types";
+import type { TopsisResults, TopsisOptionResult } from "@/lib/topsis";
+import type { RegretResults, RegretOptionResult } from "@/lib/regret";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDecision(optionCount: number): Decision {
+  const options = Array.from({ length: optionCount }, (_, i) => ({
+    id: `opt-${i + 1}`,
+    name: `Option ${String.fromCharCode(65 + i)}`,
+  }));
+  return {
+    id: "d1",
+    title: "Test Decision",
+    options,
+    criteria: [
+      { id: "c1", name: "Cost", weight: 5, type: "cost" as const },
+      { id: "c2", name: "Quality", weight: 5, type: "benefit" as const },
+    ],
+    scores: {},
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function makeWsmResults(ranks: number[]): DecisionResults {
+  return {
+    decisionId: "d1",
+    optionResults: ranks.map((rank, i) => ({
+      optionId: `opt-${i + 1}`,
+      optionName: `Option ${String.fromCharCode(65 + i)}`,
+      totalScore: 10 - rank,
+      rank,
+      criterionScores: [],
+    })),
+    topDrivers: [],
+  };
+}
+
+function makeTopsisResults(ranks: number[]): TopsisResults {
+  return {
+    rankings: ranks.map((rank, i) => ({
+      optionId: `opt-${i + 1}`,
+      optionName: `Option ${String.fromCharCode(65 + i)}`,
+      closenessCoefficient: 1 - rank * 0.1,
+      distanceToIdeal: rank * 0.1,
+      distanceToAntiIdeal: 1 - rank * 0.1,
+      rank,
+    })) as TopsisOptionResult[],
+    idealSolution: {},
+    antiIdealSolution: {},
+    method: "topsis" as const,
+  };
+}
+
+function makeRegretResults(ranks: number[]): RegretResults {
+  return {
+    rankings: ranks.map((rank, i) => ({
+      optionId: `opt-${i + 1}`,
+      optionName: `Option ${String.fromCharCode(65 + i)}`,
+      maxRegret: rank * 0.1,
+      maxRegretCriterion: "c1",
+      avgRegret: rank * 0.05,
+      rank,
+    })) as RegretOptionResult[],
+    regretMatrix: {},
+    bestPerCriterion: {},
+    method: "minimax-regret" as const,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// buildHybridSummary — pure logic tests
+// ---------------------------------------------------------------------------
+
+describe("buildHybridSummary", () => {
+  it("detects unanimous consensus when all algorithms agree", () => {
+    const decision = makeDecision(3);
+    const summary = buildHybridSummary(
+      makeWsmResults([1, 2, 3]),
+      makeTopsisResults([1, 2, 3]),
+      makeRegretResults([1, 2, 3]),
+      decision
+    );
+
+    expect(summary.agreementCount).toBe(3);
+    expect(summary.winnerName).toBe("Option A");
+    expect(summary.summaryText).toContain("All 3 algorithms agree");
+    expect(summary.rows.every((r) => r.consensus === "unanimous")).toBe(true);
+  });
+
+  it("detects 2-of-3 agreement when one method disagrees on the winner", () => {
+    const decision = makeDecision(3);
+    const summary = buildHybridSummary(
+      makeWsmResults([1, 2, 3]),
+      makeTopsisResults([1, 2, 3]),
+      makeRegretResults([2, 1, 3]), // Regret picks Option B
+      decision
+    );
+
+    expect(summary.agreementCount).toBe(2);
+    expect(summary.winnerName).toBe("Option A");
+    expect(summary.summaryText).toContain("2 of 3 algorithms agree");
+  });
+
+  it("detects all-different winners", () => {
+    const decision = makeDecision(3);
+    const summary = buildHybridSummary(
+      makeWsmResults([1, 2, 3]), // A wins
+      makeTopsisResults([2, 1, 3]), // B wins
+      makeRegretResults([3, 2, 1]), // C wins
+      decision
+    );
+
+    expect(summary.agreementCount).toBe(1);
+    expect(summary.summaryText).toContain("different winners");
+  });
+
+  it("marks rows as near when rank spread is 1", () => {
+    const decision = makeDecision(3);
+    const summary = buildHybridSummary(
+      makeWsmResults([1, 2, 3]),
+      makeTopsisResults([1, 3, 2]), // B and C swapped
+      makeRegretResults([1, 2, 3]),
+      decision
+    );
+
+    const optB = summary.rows.find((r) => r.optionId === "opt-2")!;
+    expect(optB.consensus).toBe("near");
+    expect(optB.maxRankSpread).toBe(1);
+  });
+
+  it("marks rows as divergent when rank spread is 2+", () => {
+    const decision = makeDecision(3);
+    const summary = buildHybridSummary(
+      makeWsmResults([1, 2, 3]),
+      makeTopsisResults([3, 1, 2]), // A drastically different
+      makeRegretResults([1, 2, 3]),
+      decision
+    );
+
+    const optA = summary.rows.find((r) => r.optionId === "opt-1")!;
+    expect(optA.consensus).toBe("divergent");
+    expect(optA.maxRankSpread).toBe(2);
+  });
+
+  it("sorts rows by average rank (best first)", () => {
+    const decision = makeDecision(3);
+    const summary = buildHybridSummary(
+      makeWsmResults([1, 2, 3]),
+      makeTopsisResults([1, 2, 3]),
+      makeRegretResults([1, 2, 3]),
+      decision
+    );
+
+    expect(summary.rows[0].optionId).toBe("opt-1");
+    expect(summary.rows[1].optionId).toBe("opt-2");
+    expect(summary.rows[2].optionId).toBe("opt-3");
+  });
+
+  it("handles two options", () => {
+    const decision = makeDecision(2);
+    const summary = buildHybridSummary(
+      makeWsmResults([1, 2]),
+      makeTopsisResults([1, 2]),
+      makeRegretResults([2, 1]),
+      decision
+    );
+
+    expect(summary.rows).toHaveLength(2);
+    expect(summary.agreementCount).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HybridResults component tests
+// ---------------------------------------------------------------------------
+
+describe("HybridResults", () => {
+  it("renders the consensus table with correct columns", () => {
+    const decision = makeDecision(3);
+    render(
+      <HybridResults
+        results={makeWsmResults([1, 2, 3])}
+        topsisResults={makeTopsisResults([1, 2, 3])}
+        regretResults={makeRegretResults([1, 2, 3])}
+        decision={decision}
+      />
+    );
+
+    expect(screen.getByTestId("consensus-table")).toBeInTheDocument();
+    expect(screen.getByText("Option")).toBeInTheDocument();
+    expect(screen.getByText("WSM")).toBeInTheDocument();
+    expect(screen.getByText("TOPSIS")).toBeInTheDocument();
+    expect(screen.getByText("Regret")).toBeInTheDocument();
+    expect(screen.getByText("Consensus")).toBeInTheDocument();
+  });
+
+  it("displays all option names", () => {
+    const decision = makeDecision(3);
+    render(
+      <HybridResults
+        results={makeWsmResults([1, 2, 3])}
+        topsisResults={makeTopsisResults([1, 2, 3])}
+        regretResults={makeRegretResults([1, 2, 3])}
+        decision={decision}
+      />
+    );
+
+    expect(screen.getByText("Option A")).toBeInTheDocument();
+    expect(screen.getByText("Option B")).toBeInTheDocument();
+    expect(screen.getByText("Option C")).toBeInTheDocument();
+  });
+
+  it("renders rank numbers for each method", () => {
+    const decision = makeDecision(2);
+    render(
+      <HybridResults
+        results={makeWsmResults([1, 2])}
+        topsisResults={makeTopsisResults([2, 1])}
+        regretResults={makeRegretResults([1, 2])}
+        decision={decision}
+      />
+    );
+
+    // Option A: WSM #1, TOPSIS #2, Regret #1
+    const cells = screen.getAllByText(/#[12]/);
+    expect(cells.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("shows summary text for full agreement", () => {
+    const decision = makeDecision(2);
+    render(
+      <HybridResults
+        results={makeWsmResults([1, 2])}
+        topsisResults={makeTopsisResults([1, 2])}
+        regretResults={makeRegretResults([1, 2])}
+        decision={decision}
+      />
+    );
+
+    const summary = screen.getByTestId("consensus-summary");
+    expect(summary.textContent).toContain("All 3 algorithms agree");
+    expect(summary.textContent).toContain("Option A");
+  });
+
+  it("shows unanimous consensus labels when all methods agree", () => {
+    const decision = makeDecision(2);
+    render(
+      <HybridResults
+        results={makeWsmResults([1, 2])}
+        topsisResults={makeTopsisResults([1, 2])}
+        regretResults={makeRegretResults([1, 2])}
+        decision={decision}
+      />
+    );
+
+    const unanimousLabels = screen.getAllByText("✓ Unanimous");
+    expect(unanimousLabels).toHaveLength(2);
+  });
+
+  it("shows divergent label when methods strongly disagree", () => {
+    const decision = makeDecision(3);
+    render(
+      <HybridResults
+        results={makeWsmResults([1, 2, 3])}
+        topsisResults={makeTopsisResults([3, 2, 1])}
+        regretResults={makeRegretResults([1, 2, 3])}
+        decision={decision}
+      />
+    );
+
+    expect(screen.getAllByText("✗ Divergent").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders the color legend", () => {
+    const decision = makeDecision(2);
+    render(
+      <HybridResults
+        results={makeWsmResults([1, 2])}
+        topsisResults={makeTopsisResults([1, 2])}
+        regretResults={makeRegretResults([1, 2])}
+        decision={decision}
+      />
+    );
+
+    expect(screen.getByText(/Unanimous — all methods agree/)).toBeInTheDocument();
+    expect(screen.getByText(/Close — 1 rank difference/)).toBeInTheDocument();
+    expect(screen.getByText(/Divergent — 2\+ rank difference/)).toBeInTheDocument();
+  });
+
+  it("shows empty message when no options", () => {
+    const decision = makeDecision(0);
+    render(
+      <HybridResults
+        results={makeWsmResults([])}
+        topsisResults={makeTopsisResults([])}
+        regretResults={makeRegretResults([])}
+        decision={decision}
+      />
+    );
+
+    expect(screen.getByText(/Add at least 2 options/)).toBeInTheDocument();
+  });
+});

--- a/src/components/HybridResults.tsx
+++ b/src/components/HybridResults.tsx
@@ -1,0 +1,261 @@
+/**
+ * HybridResults — side-by-side multi-algorithm consensus ranking table.
+ *
+ * Shows each option's rank across WSM, TOPSIS, and Minimax Regret
+ * with color-coded consensus indicators and a summary sentence.
+ */
+
+"use client";
+
+import type { DecisionResults, Decision } from "@/lib/types";
+import type { TopsisResults } from "@/lib/topsis";
+import type { RegretResults } from "@/lib/regret";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ConsensusRow {
+  optionId: string;
+  optionName: string;
+  wsmRank: number;
+  topsisRank: number;
+  regretRank: number;
+  /** Maximum absolute rank difference across any pair of algorithms */
+  maxRankSpread: number;
+  /** "unanimous" | "near" | "divergent" */
+  consensus: "unanimous" | "near" | "divergent";
+}
+
+export interface HybridSummary {
+  rows: ConsensusRow[];
+  agreementCount: number; // how many algorithms agree on the winner
+  totalMethods: number;
+  winnerName: string | null;
+  summaryText: string;
+}
+
+// ---------------------------------------------------------------------------
+// Pure logic
+// ---------------------------------------------------------------------------
+
+export function buildHybridSummary(
+  results: DecisionResults,
+  topsisResults: TopsisResults,
+  regretResults: RegretResults,
+  decision: Decision
+): HybridSummary {
+  const wsm = results.optionResults;
+  const topsis = topsisResults.rankings;
+  const regret = regretResults.rankings;
+
+  // Build rank maps: optionId → rank
+  const wsmRankMap = new Map(wsm.map((r) => [r.optionId, r.rank]));
+  const topsisRankMap = new Map(topsis.map((r) => [r.optionId, r.rank]));
+  const regretRankMap = new Map(regret.map((r) => [r.optionId, r.rank]));
+
+  const rows: ConsensusRow[] = decision.options.map((opt) => {
+    const wsmRank = wsmRankMap.get(opt.id) ?? 0;
+    const topsisRank = topsisRankMap.get(opt.id) ?? 0;
+    const regretRank = regretRankMap.get(opt.id) ?? 0;
+
+    const ranks = [wsmRank, topsisRank, regretRank];
+    const maxRankSpread = Math.max(...ranks) - Math.min(...ranks);
+    const consensus: ConsensusRow["consensus"] =
+      maxRankSpread === 0 ? "unanimous" : maxRankSpread === 1 ? "near" : "divergent";
+
+    return {
+      optionId: opt.id,
+      optionName: opt.name,
+      wsmRank,
+      topsisRank,
+      regretRank,
+      maxRankSpread,
+      consensus,
+    };
+  });
+
+  // Sort rows by average rank (best consensus ranking first)
+  rows.sort((a, b) => {
+    const avgA = (a.wsmRank + a.topsisRank + a.regretRank) / 3;
+    const avgB = (b.wsmRank + b.topsisRank + b.regretRank) / 3;
+    return avgA - avgB;
+  });
+
+  // Count how many methods agree on the winner (rank 1)
+  const winners = [
+    wsm.find((r) => r.rank === 1)?.optionId ?? null,
+    topsis.find((r) => r.rank === 1)?.optionId ?? null,
+    regret.find((r) => r.rank === 1)?.optionId ?? null,
+  ].filter(Boolean);
+
+  const winnerCounts = new Map<string, number>();
+  for (const w of winners) {
+    if (w) winnerCounts.set(w, (winnerCounts.get(w) ?? 0) + 1);
+  }
+
+  let topWinner: string | null = null;
+  let maxCount = 0;
+  for (const [id, count] of winnerCounts) {
+    if (count > maxCount) {
+      maxCount = count;
+      topWinner = id;
+    }
+  }
+
+  const totalMethods = 3;
+  const winnerName = topWinner
+    ? (decision.options.find((o) => o.id === topWinner)?.name ?? null)
+    : null;
+
+  let summaryText: string;
+  if (maxCount === totalMethods) {
+    summaryText = `All ${totalMethods} algorithms agree: ${winnerName} is the best choice.`;
+  } else if (maxCount >= 2) {
+    summaryText = `${maxCount} of ${totalMethods} algorithms agree: ${winnerName} is the best choice.`;
+  } else {
+    summaryText = `All ${totalMethods} algorithms pick different winners. This decision involves genuine trade-offs.`;
+  }
+
+  return {
+    rows,
+    agreementCount: maxCount,
+    totalMethods,
+    winnerName,
+    summaryText,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface HybridResultsProps {
+  results: DecisionResults;
+  topsisResults: TopsisResults;
+  regretResults: RegretResults;
+  decision: Decision;
+}
+
+const consensusStyles = {
+  unanimous: {
+    cell: "bg-green-100 dark:bg-green-900/40 text-green-800 dark:text-green-200",
+    label: "✓ Unanimous",
+    icon: "text-green-600 dark:text-green-400",
+  },
+  near: {
+    cell: "bg-yellow-100 dark:bg-yellow-900/40 text-yellow-800 dark:text-yellow-200",
+    label: "~ Close",
+    icon: "text-yellow-600 dark:text-yellow-400",
+  },
+  divergent: {
+    cell: "bg-red-100 dark:bg-red-900/40 text-red-800 dark:text-red-200",
+    label: "✗ Divergent",
+    icon: "text-red-600 dark:text-red-400",
+  },
+};
+
+export function HybridResults({
+  results,
+  topsisResults,
+  regretResults,
+  decision,
+}: HybridResultsProps) {
+  const summary = buildHybridSummary(results, topsisResults, regretResults, decision);
+
+  if (summary.rows.length === 0) {
+    return (
+      <div className="text-sm text-gray-500 dark:text-gray-400 text-center py-4">
+        Add at least 2 options to see consensus rankings.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* Summary sentence */}
+      <p
+        className={`text-sm font-medium px-3 py-2 rounded-md ${
+          summary.agreementCount === summary.totalMethods
+            ? "bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-300"
+            : summary.agreementCount >= 2
+              ? "bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300"
+              : "bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300"
+        }`}
+        data-testid="consensus-summary"
+      >
+        {summary.summaryText}
+      </p>
+
+      {/* Consensus table */}
+      <div className="overflow-x-auto -mx-1 px-1">
+        <table className="w-full text-sm border-collapse" data-testid="consensus-table">
+          <thead>
+            <tr className="border-b border-gray-200 dark:border-gray-700">
+              <th className="text-left py-2 px-3 font-medium text-gray-700 dark:text-gray-300">
+                Option
+              </th>
+              <th className="text-center py-2 px-3 font-medium text-gray-700 dark:text-gray-300">
+                WSM
+              </th>
+              <th className="text-center py-2 px-3 font-medium text-gray-700 dark:text-gray-300">
+                TOPSIS
+              </th>
+              <th className="text-center py-2 px-3 font-medium text-gray-700 dark:text-gray-300">
+                Regret
+              </th>
+              <th className="text-center py-2 px-3 font-medium text-gray-700 dark:text-gray-300">
+                Consensus
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {summary.rows.map((row) => {
+              const style = consensusStyles[row.consensus];
+              return (
+                <tr
+                  key={row.optionId}
+                  className="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                >
+                  <td className="py-2 px-3 font-medium text-gray-900 dark:text-gray-100">
+                    {row.optionName}
+                  </td>
+                  <td className="py-2 px-3 text-center text-gray-600 dark:text-gray-400">
+                    #{row.wsmRank}
+                  </td>
+                  <td className="py-2 px-3 text-center text-gray-600 dark:text-gray-400">
+                    #{row.topsisRank}
+                  </td>
+                  <td className="py-2 px-3 text-center text-gray-600 dark:text-gray-400">
+                    #{row.regretRank}
+                  </td>
+                  <td
+                    className={`py-2 px-3 text-center text-xs font-semibold rounded ${style.cell}`}
+                  >
+                    {style.label}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Legend */}
+      <div className="flex flex-wrap gap-4 text-xs text-gray-500 dark:text-gray-400 pt-1">
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-3 h-3 rounded bg-green-200 dark:bg-green-800" />
+          Unanimous — all methods agree
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-3 h-3 rounded bg-yellow-200 dark:bg-yellow-800" />
+          Close — 1 rank difference
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-3 h-3 rounded bg-red-200 dark:bg-red-800" />
+          Divergent — 2+ rank difference
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ResultsView.tsx
+++ b/src/components/ResultsView.tsx
@@ -27,6 +27,7 @@ import type { ValidationResult } from "@/hooks/useValidation";
 import type { CompletenessResult } from "@/lib/completeness";
 import { BiasWarnings } from "./BiasWarnings";
 import { useBiasDetection } from "@/hooks/useBiasDetection";
+import { HybridResults } from "./HybridResults";
 
 const ScoreChart = lazy(() => import("./ScoreChart").then((m) => ({ default: m.ScoreChart })));
 const ParetoChart = lazy(() => import("./ParetoChart").then((m) => ({ default: m.ParetoChart })));
@@ -41,7 +42,7 @@ export function ResultsView({ validation, completeness, onSwitchToBuilder }: Res
   const { decision, results, topsisResults, regretResults } = useDecision();
   const [shareStatus, setShareStatus] = useState<string>("");
   const [bannerDismissed, setBannerDismissed] = useState(false);
-  const [scoringMethod, setScoringMethod] = useState<"wsm" | "topsis" | "minimax-regret">("wsm");
+  const [scoringMethod, setScoringMethod] = useState<"wsm" | "topsis" | "minimax-regret" | "consensus">("wsm");
   const biasDetection = useBiasDetection(decision);
 
   // Agreement / disagreement between WSM, TOPSIS, and Minimax Regret
@@ -254,6 +255,18 @@ export function ResultsView({ validation, completeness, onSwitchToBuilder }: Res
               >
                 Regret
               </button>
+              <button
+                role="radio"
+                aria-checked={scoringMethod === "consensus"}
+                onClick={() => setScoringMethod("consensus")}
+                className={`px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-inset ${
+                  scoringMethod === "consensus"
+                    ? "bg-blue-600 text-white"
+                    : "text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+                }`}
+              >
+                Consensus
+              </button>
             </div>
             <button
               onClick={handleExportJson}
@@ -342,6 +355,13 @@ export function ResultsView({ validation, completeness, onSwitchToBuilder }: Res
           <WsmRankings results={results} decision={decision} maxScore={maxScore} />
         ) : scoringMethod === "topsis" ? (
           <TopsisRankings topsisResults={topsisResults} decision={decision} />
+        ) : scoringMethod === "consensus" ? (
+          <HybridResults
+            results={results}
+            topsisResults={topsisResults}
+            regretResults={regretResults}
+            decision={decision}
+          />
         ) : (
           <RegretRankings regretResults={regretResults} decision={decision} />
         )}


### PR DESCRIPTION
## Summary

Adds a new **Consensus** tab to the Results view that shows a side-by-side multi-algorithm ranking comparison table for all scoring methods (WSM, TOPSIS, Minimax Regret).

## Changes

### New Component: `HybridResults.tsx`
- **Consensus table**: columns for Option, WSM rank, TOPSIS rank, Regret rank, and Consensus indicator
- **Color-coded consensus**: green (unanimous — all methods agree), yellow (close — 1 rank diff), red (divergent — 2+ rank diff)
- **Summary sentence**: "All 3 algorithms agree: Option A is the best choice" / "2 of 3 agree..." / "All pick different winners..."
- **Legend**: explains color coding below the table
- **Responsive**: horizontal scroll on mobile via `overflow-x-auto`
- **Pure logic**: `buildHybridSummary()` exported for testability — sorts by average rank, finds winners by `rank === 1`

### ResultsView Integration
- Added `"consensus"` to scoring method union type
- Added "Consensus" button to the radio group selector
- Renders `<HybridResults>` when consensus tab is selected

### Tests: 15 (7 pure logic + 8 component)
- **buildHybridSummary**: unanimous detection, 2-of-3 agreement, all-different winners, near/divergent classification, sort order, 2-option edge case
- **HybridResults**: table columns, option names, rank numbers, summary text, unanimous labels, divergent labels, color legend, empty state

## Test Stats
- Full suite: **744 tests, 47 files, all passing**
- TSC and ESLint clean, Prettier formatted

Closes #97
