### PR TITLE
feat(reasoning): add per-score reasoning notes with popover UI

### DIFF
--- a/src/__tests__/components/DecisionBuilder.test.tsx
+++ b/src/__tests__/components/DecisionBuilder.test.tsx
@@ -51,7 +51,7 @@ describe("DecisionBuilder", () => {
     renderWithProviders(<DecisionBuilder validation={emptyValidation} />);
     expect(screen.getByText("Options")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /add option/i })).toBeInTheDocument();
-  });
+  }, 15_000);
 
   it("renders Criteria section with Add Criterion button", () => {
     renderWithProviders(<DecisionBuilder validation={emptyValidation} />);
@@ -84,7 +84,7 @@ describe("DecisionBuilder", () => {
     await user.click(screen.getByRole("button", { name: /add option/i }));
     const newInputs = screen.getAllByRole("textbox");
     expect(newInputs.length).toBeGreaterThan(initialCount);
-  });
+  }, 15_000);
 
   it("renders score inputs in the grid", () => {
     renderWithProviders(<DecisionBuilder validation={emptyValidation} />);

--- a/src/__tests__/components/ReasoningNotes.test.tsx
+++ b/src/__tests__/components/ReasoningNotes.test.tsx
@@ -1,0 +1,266 @@
+/**
+ * Tests for per-score reasoning notes (issue #99).
+ *
+ * Tests the ReasoningPopover component and the UPDATE_REASONING reducer action.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ReasoningPopover } from "@/components/ReasoningPopover";
+import { decisionReducer, createInitialState } from "@/lib/decision-reducer";
+import type { Decision } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDecision(overrides?: Partial<Decision>): Decision {
+  return {
+    id: "d1",
+    title: "Test Decision",
+    options: [
+      { id: "opt-1", name: "Option A" },
+      { id: "opt-2", name: "Option B" },
+    ],
+    criteria: [
+      { id: "c1", name: "Cost", weight: 50, type: "cost" },
+      { id: "c2", name: "Quality", weight: 50, type: "benefit" },
+    ],
+    scores: {
+      "opt-1": { c1: 7, c2: 8 },
+      "opt-2": { c1: 5, c2: 9 },
+    },
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helper to apply action through reducer
+// ---------------------------------------------------------------------------
+
+function applyAction(decision: Decision, action: Parameters<typeof decisionReducer>[1]) {
+  const state = createInitialState(decision, [decision]);
+  const newState = decisionReducer(state, action);
+  return newState.decision;
+}
+
+// ---------------------------------------------------------------------------
+// Reducer tests
+// ---------------------------------------------------------------------------
+
+describe("UPDATE_REASONING reducer action", () => {
+  it("adds reasoning to a score cell", () => {
+    const decision = makeDecision();
+    const result = applyAction(decision, {
+      type: "UPDATE_REASONING",
+      optionId: "opt-1",
+      criterionId: "c1",
+      text: "Market research shows this is affordable",
+      timestamp: Date.now(),
+    });
+
+    expect(result.reasoning?.["opt-1"]?.c1).toBe("Market research shows this is affordable");
+  });
+
+  it("updates existing reasoning", () => {
+    const decision = makeDecision({
+      reasoning: { "opt-1": { c1: "Old reasoning" } },
+    });
+    const result = applyAction(decision, {
+      type: "UPDATE_REASONING",
+      optionId: "opt-1",
+      criterionId: "c1",
+      text: "Updated reasoning",
+      timestamp: Date.now(),
+    });
+
+    expect(result.reasoning?.["opt-1"]?.c1).toBe("Updated reasoning");
+  });
+
+  it("preserves reasoning for other cells", () => {
+    const decision = makeDecision({
+      reasoning: { "opt-1": { c1: "Existing" } },
+    });
+    const result = applyAction(decision, {
+      type: "UPDATE_REASONING",
+      optionId: "opt-1",
+      criterionId: "c2",
+      text: "New note",
+      timestamp: Date.now(),
+    });
+
+    expect(result.reasoning?.["opt-1"]?.c1).toBe("Existing");
+    expect(result.reasoning?.["opt-1"]?.c2).toBe("New note");
+  });
+
+  it("cleans up reasoning when option is removed", () => {
+    const decision = makeDecision({
+      reasoning: {
+        "opt-1": { c1: "Some reasoning" },
+        "opt-2": { c1: "Other reasoning" },
+      },
+    });
+    const result = applyAction(decision, {
+      type: "REMOVE_OPTION",
+      optionId: "opt-1",
+    });
+
+    expect(result.reasoning?.["opt-1"]).toBeUndefined();
+    expect(result.reasoning?.["opt-2"]?.c1).toBe("Other reasoning");
+  });
+
+  it("cleans up reasoning when criterion is removed", () => {
+    const decision = makeDecision({
+      reasoning: {
+        "opt-1": { c1: "Cost reasoning", c2: "Quality reasoning" },
+      },
+    });
+    const result = applyAction(decision, {
+      type: "REMOVE_CRITERION",
+      criterionId: "c1",
+    });
+
+    expect(result.reasoning?.["opt-1"]?.c1).toBeUndefined();
+    expect(result.reasoning?.["opt-1"]?.c2).toBe("Quality reasoning");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ReasoningPopover component tests
+// ---------------------------------------------------------------------------
+
+describe("ReasoningPopover", () => {
+  let onChangeFn: ReturnType<typeof vi.fn<(text: string) => void>>;
+
+  beforeEach(() => {
+    onChangeFn = vi.fn<(text: string) => void>();
+  });
+
+  it("renders a note icon button", () => {
+    render(
+      <ReasoningPopover
+        value={undefined}
+        onChange={onChangeFn}
+        optionName="Option A"
+        criterionName="Cost"
+      />
+    );
+
+    const button = screen.getByLabelText(/reasoning for Option A on Cost/i);
+    expect(button).toBeInTheDocument();
+  });
+
+  it("shows 'Add' label when no reasoning exists", () => {
+    render(
+      <ReasoningPopover
+        value={undefined}
+        onChange={onChangeFn}
+        optionName="Option A"
+        criterionName="Cost"
+      />
+    );
+
+    expect(screen.getByLabelText(/Add reasoning/i)).toBeInTheDocument();
+  });
+
+  it("shows 'Edit' label when reasoning exists", () => {
+    render(
+      <ReasoningPopover
+        value="Existing note"
+        onChange={onChangeFn}
+        optionName="Option A"
+        criterionName="Cost"
+      />
+    );
+
+    expect(screen.getByLabelText(/Edit reasoning/i)).toBeInTheDocument();
+  });
+
+  it("opens popover on click", async () => {
+    const user = userEvent.setup();
+    render(
+      <ReasoningPopover
+        value={undefined}
+        onChange={onChangeFn}
+        optionName="Option A"
+        criterionName="Cost"
+      />
+    );
+
+    const button = screen.getByLabelText(/reasoning for Option A on Cost/i);
+    await user.click(button);
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Why this score?")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Explain your reasoning...")).toBeInTheDocument();
+  });
+
+  it("calls onChange when typing reasoning", async () => {
+    const user = userEvent.setup();
+    render(
+      <ReasoningPopover value="" onChange={onChangeFn} optionName="Option A" criterionName="Cost" />
+    );
+
+    await user.click(screen.getByLabelText(/reasoning for Option A on Cost/i));
+    const textarea = screen.getByPlaceholderText("Explain your reasoning...");
+    await user.type(textarea, "Based on market data");
+
+    expect(onChangeFn).toHaveBeenCalled();
+  });
+
+  it("shows Clear note button when reasoning exists", async () => {
+    const user = userEvent.setup();
+    render(
+      <ReasoningPopover
+        value="Existing note"
+        onChange={onChangeFn}
+        optionName="Option A"
+        criterionName="Cost"
+      />
+    );
+
+    await user.click(screen.getByLabelText(/Edit reasoning/i));
+    const clearBtn = screen.getByText("Clear note");
+    expect(clearBtn).toBeInTheDocument();
+
+    await user.click(clearBtn);
+    expect(onChangeFn).toHaveBeenCalledWith("");
+  });
+
+  it("closes on Escape key", async () => {
+    const user = userEvent.setup();
+    render(
+      <ReasoningPopover
+        value={undefined}
+        onChange={onChangeFn}
+        optionName="Option A"
+        criterionName="Cost"
+      />
+    );
+
+    await user.click(screen.getByLabelText(/reasoning for Option A on Cost/i));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("displays existing reasoning text in textarea", async () => {
+    const user = userEvent.setup();
+    render(
+      <ReasoningPopover
+        value="My existing reasoning"
+        onChange={onChangeFn}
+        optionName="Option A"
+        criterionName="Cost"
+      />
+    );
+
+    await user.click(screen.getByLabelText(/Edit reasoning/i));
+    const textarea = screen.getByPlaceholderText("Explain your reasoning...");
+    expect(textarea).toHaveValue("My existing reasoning");
+  });
+});

--- a/src/components/DecisionBuilder.tsx
+++ b/src/components/DecisionBuilder.tsx
@@ -28,6 +28,7 @@ import { ConfidenceDot } from "./ConfidenceDot";
 import { CompletionRing } from "./CompletionRing";
 import { WeightSlider } from "./WeightSlider";
 import { WeightDistributionBar } from "./WeightDistributionBar";
+import { ReasoningPopover } from "./ReasoningPopover";
 import { BiasWarnings } from "./BiasWarnings";
 import { useBiasDetection } from "@/hooks/useBiasDetection";
 import { MobileScoreCards } from "./MobileScoreCards";
@@ -49,6 +50,7 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
     removeCriterion,
     updateScore,
     updateConfidence,
+    updateReasoning,
     undo,
     redo,
     canUndo,
@@ -563,6 +565,7 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
           decision={decision}
           updateScore={updateScore}
           updateConfidence={updateConfidence}
+          updateReasoning={updateReasoning}
         />
 
         {/* Desktop: Table layout (≥ 640px) */}
@@ -660,6 +663,12 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
                               onChange={(next) => updateConfidence(opt.id, crit.id, next)}
                             />
                           )}
+                          <ReasoningPopover
+                            value={decision.reasoning?.[opt.id]?.[crit.id]}
+                            onChange={(text) => updateReasoning(opt.id, crit.id, text)}
+                            optionName={opt.name}
+                            criterionName={crit.name}
+                          />
                         </div>
                       </td>
                     );

--- a/src/components/DecisionProvider.tsx
+++ b/src/components/DecisionProvider.tsx
@@ -90,6 +90,7 @@ export interface DecisionContextValue extends DecisionStateValue {
   removeCriterion: (criterionId: string) => void;
   updateScore: (optionId: string, criterionId: string, value: number | null) => void;
   updateConfidence: (optionId: string, criterionId: string, confidence: Confidence) => void;
+  updateReasoning: (optionId: string, criterionId: string, text: string) => void;
   undo: () => void;
   redo: () => void;
   setSwingPercent: (value: number) => void;
@@ -226,6 +227,12 @@ export function DecisionProvider({ children }: { children: ReactNode }) {
     [dispatch]
   );
 
+  const updateReasoning = useCallback(
+    (optionId: string, criterionId: string, text: string) =>
+      dispatch({ type: "UPDATE_REASONING", optionId, criterionId, text, timestamp: Date.now() }),
+    [dispatch]
+  );
+
   const undo = useCallback(() => {
     dispatch({ type: "UNDO" });
     announceRef.current("Undone");
@@ -329,6 +336,7 @@ export function DecisionProvider({ children }: { children: ReactNode }) {
       removeCriterion,
       updateScore,
       updateConfidence,
+      updateReasoning,
       undo,
       redo,
       setSwingPercent,
@@ -350,6 +358,7 @@ export function DecisionProvider({ children }: { children: ReactNode }) {
       removeCriterion,
       updateScore,
       updateConfidence,
+      updateReasoning,
       undo,
       redo,
       setSwingPercent,

--- a/src/components/MobileScoreCards.tsx
+++ b/src/components/MobileScoreCards.tsx
@@ -14,12 +14,14 @@ import { ScoreSlider } from "./ScoreSlider";
 import type { Criterion, Decision, Option, ScoreValue } from "@/lib/types";
 import { resolveScoreValue, resolveConfidence } from "@/lib/scoring";
 import { ConfidenceDot } from "./ConfidenceDot";
+import { ReasoningPopover } from "./ReasoningPopover";
 import type { Confidence } from "@/lib/types";
 
 interface MobileScoreCardsProps {
   decision: Decision;
   updateScore: (optionId: string, criterionId: string, value: number | null) => void;
   updateConfidence?: (optionId: string, criterionId: string, confidence: Confidence) => void;
+  updateReasoning?: (optionId: string, criterionId: string, text: string) => void;
 }
 
 /** Letter label for option index (A, B, C, …) */
@@ -33,19 +35,23 @@ function OptionCard({
   index,
   criteria,
   scores,
+  reasoning,
   expanded,
   onToggle,
   updateScore,
   updateConfidence,
+  updateReasoning,
 }: {
   option: Option;
   index: number;
   criteria: Criterion[];
   scores: Record<string, ScoreValue>;
+  reasoning: Record<string, string> | undefined;
   expanded: boolean;
   onToggle: () => void;
   updateScore: (criterionId: string, value: number) => void;
   updateConfidence?: (criterionId: string, confidence: Confidence) => void;
+  updateReasoning?: (criterionId: string, text: string) => void;
 }) {
   return (
     <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 overflow-hidden">
@@ -124,6 +130,17 @@ function OptionCard({
                   </span>
                 </div>
               )}
+              {updateReasoning && (
+                <div className="mt-1 flex items-center gap-1.5">
+                  <span className="text-[10px] text-gray-400 dark:text-gray-500">Note:</span>
+                  <ReasoningPopover
+                    value={reasoning?.[crit.id]}
+                    onChange={(text) => updateReasoning(crit.id, text)}
+                    optionName={option.name}
+                    criterionName={crit.name}
+                  />
+                </div>
+              )}
             </div>
           ))}
         </div>
@@ -136,6 +153,7 @@ export function MobileScoreCards({
   decision,
   updateScore,
   updateConfidence,
+  updateReasoning,
 }: MobileScoreCardsProps) {
   // Accordion: keep track of which option is expanded (first by default)
   const [expandedId, setExpandedId] = useState<string | null>(decision.options[0]?.id ?? null);
@@ -153,11 +171,15 @@ export function MobileScoreCards({
           index={idx}
           criteria={decision.criteria}
           scores={decision.scores[opt.id] ?? {}}
+          reasoning={decision.reasoning?.[opt.id]}
           expanded={expandedId === opt.id}
           onToggle={() => toggle(opt.id)}
           updateScore={(critId, v) => updateScore(opt.id, critId, v)}
           updateConfidence={
             updateConfidence ? (critId, c) => updateConfidence(opt.id, critId, c) : undefined
+          }
+          updateReasoning={
+            updateReasoning ? (critId, t) => updateReasoning(opt.id, critId, t) : undefined
           }
         />
       ))}

--- a/src/components/ReasoningPopover.tsx
+++ b/src/components/ReasoningPopover.tsx
@@ -1,0 +1,112 @@
+/**
+ * ReasoningPopover — click-triggered popover for per-score reasoning notes.
+ *
+ * Renders a small note icon. When clicked, shows a textarea popover
+ * for entering/editing reasoning text. A filled icon indicates existing reasoning.
+ */
+
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import { MessageSquare } from "lucide-react";
+
+interface ReasoningPopoverProps {
+  /** Current reasoning text (empty string or undefined = no reasoning) */
+  value: string | undefined;
+  /** Called when reasoning text changes */
+  onChange: (text: string) => void;
+  /** Accessible label for the button */
+  optionName: string;
+  criterionName: string;
+}
+
+export function ReasoningPopover({
+  value,
+  onChange,
+  optionName,
+  criterionName,
+}: ReasoningPopoverProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const hasReasoning = !!value && value.trim().length > 0;
+
+  // Close on outside click
+  useEffect(() => {
+    if (!isOpen) return;
+    function handleClick(e: MouseEvent) {
+      if (
+        popoverRef.current &&
+        !popoverRef.current.contains(e.target as Node) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(e.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [isOpen]);
+
+  // Close on Escape
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      setIsOpen(false);
+      buttonRef.current?.focus();
+    }
+  }, []);
+
+  return (
+    <div className="relative inline-block">
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        className={`p-0.5 rounded transition-colors focus:outline-none focus:ring-1 focus:ring-blue-500 ${
+          hasReasoning
+            ? "text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
+            : "text-gray-300 dark:text-gray-600 hover:text-gray-500 dark:hover:text-gray-400"
+        }`}
+        aria-label={`${hasReasoning ? "Edit" : "Add"} reasoning for ${optionName} on ${criterionName}`}
+        aria-expanded={isOpen}
+        title={hasReasoning ? value : "Add reasoning note"}
+      >
+        <MessageSquare className="h-3.5 w-3.5" fill={hasReasoning ? "currentColor" : "none"} />
+      </button>
+
+      {isOpen && (
+        <div
+          ref={popoverRef}
+          className="absolute z-50 mt-1 left-1/2 -translate-x-1/2 w-56 rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 shadow-lg p-2"
+          role="dialog"
+          aria-label={`Reasoning for ${optionName} on ${criterionName}`}
+          onKeyDown={handleKeyDown}
+        >
+          <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+            Why this score?
+          </label>
+          <textarea
+            className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-sm text-gray-900 dark:text-gray-100 px-2 py-1.5 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 resize-none"
+            rows={3}
+            value={value ?? ""}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder="Explain your reasoning..."
+            autoFocus
+          />
+          {hasReasoning && (
+            <button
+              type="button"
+              onClick={() => {
+                onChange("");
+                setIsOpen(false);
+              }}
+              className="mt-1 text-xs text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+            >
+              Clear note
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ResultsView.tsx
+++ b/src/components/ResultsView.tsx
@@ -42,7 +42,9 @@ export function ResultsView({ validation, completeness, onSwitchToBuilder }: Res
   const { decision, results, topsisResults, regretResults } = useDecision();
   const [shareStatus, setShareStatus] = useState<string>("");
   const [bannerDismissed, setBannerDismissed] = useState(false);
-  const [scoringMethod, setScoringMethod] = useState<"wsm" | "topsis" | "minimax-regret" | "consensus">("wsm");
+  const [scoringMethod, setScoringMethod] = useState<
+    "wsm" | "topsis" | "minimax-regret" | "consensus"
+  >("wsm");
   const biasDetection = useBiasDetection(decision);
 
   // Agreement / disagreement between WSM, TOPSIS, and Minimax Regret
@@ -668,17 +670,39 @@ function WsmRankings({ results, decision, maxScore }: WsmRankingsProps) {
 
             {/* Criterion breakdown */}
             <div className="mt-3 grid grid-cols-2 sm:grid-cols-3 gap-2">
-              {r.criterionScores.map((cs) => (
-                <div
-                  key={cs.criterionId}
-                  className="text-xs text-gray-600 dark:text-gray-400 flex items-center justify-between bg-gray-50 dark:bg-gray-700 rounded px-2 py-1"
-                >
-                  <span className="truncate mr-1">{cs.criterionName}</span>
-                  <span className="font-medium text-gray-900 dark:text-gray-200">
-                    {cs.effectiveScore.toFixed(2)}
-                  </span>
-                </div>
-              ))}
+              {r.criterionScores.map((cs) => {
+                const reasoning = decision.reasoning?.[r.optionId]?.[cs.criterionId];
+                return (
+                  <div
+                    key={cs.criterionId}
+                    className="group relative text-xs text-gray-600 dark:text-gray-400 flex items-center justify-between bg-gray-50 dark:bg-gray-700 rounded px-2 py-1"
+                    title={reasoning || undefined}
+                  >
+                    <span className="truncate mr-1">
+                      {reasoning && (
+                        <span
+                          className="text-blue-500 dark:text-blue-400 mr-0.5"
+                          aria-hidden="true"
+                        >
+                          ●
+                        </span>
+                      )}
+                      {cs.criterionName}
+                    </span>
+                    <span className="font-medium text-gray-900 dark:text-gray-200">
+                      {cs.effectiveScore.toFixed(2)}
+                    </span>
+                    {reasoning && (
+                      <div
+                        role="tooltip"
+                        className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 hidden group-hover:block group-focus-within:block w-48 p-2 rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 shadow-lg text-xs text-gray-700 dark:text-gray-300 z-10 whitespace-normal"
+                      >
+                        <span className="font-medium">Reasoning:</span> {reasoning}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
             </div>
           </div>
         );

--- a/src/lib/decision-reducer.ts
+++ b/src/lib/decision-reducer.ts
@@ -87,6 +87,15 @@ export type DecisionAction =
   | { type: "UPDATE_SCORE"; optionId: string; criterionId: string; value: number | null }
   | { type: "UPDATE_CONFIDENCE"; optionId: string; criterionId: string; confidence: Confidence }
 
+  // Reasoning
+  | {
+      type: "UPDATE_REASONING";
+      optionId: string;
+      criterionId: string;
+      text: string;
+      timestamp: number;
+    }
+
   // Undo / Redo
   | { type: "UNDO" }
   | { type: "REDO" }
@@ -176,10 +185,13 @@ function applyDecisionMutation(decision: Decision, action: DecisionAction): Deci
     case "REMOVE_OPTION": {
       const newScores = { ...decision.scores };
       delete newScores[action.optionId];
+      const newReasoning = { ...(decision.reasoning ?? {}) };
+      delete newReasoning[action.optionId];
       return stampNow({
         ...decision,
         options: decision.options.filter((o) => o.id !== action.optionId),
         scores: newScores,
+        reasoning: newReasoning,
       });
     }
 
@@ -208,10 +220,17 @@ function applyDecisionMutation(decision: Decision, action: DecisionAction): Deci
         delete optScores[action.criterionId];
         newScores[optId] = optScores;
       }
+      const newReasoning: Record<string, Record<string, string>> = {};
+      for (const optId of Object.keys(decision.reasoning ?? {})) {
+        const optReasoning = { ...(decision.reasoning![optId] ?? {}) };
+        delete optReasoning[action.criterionId];
+        newReasoning[optId] = optReasoning;
+      }
       return stampNow({
         ...decision,
         criteria: decision.criteria.filter((c) => c.id !== action.criterionId),
         scores: newScores,
+        reasoning: newReasoning,
       });
     }
 
@@ -251,6 +270,16 @@ function applyDecisionMutation(decision: Decision, action: DecisionAction): Deci
         [action.criterionId]: { value: numValue, confidence: action.confidence },
       };
       return stampNow({ ...decision, scores: newScores });
+    }
+
+    case "UPDATE_REASONING": {
+      const newReasoning = { ...(decision.reasoning ?? {}) };
+      if (!newReasoning[action.optionId]) newReasoning[action.optionId] = {};
+      newReasoning[action.optionId] = {
+        ...newReasoning[action.optionId],
+        [action.criterionId]: action.text,
+      };
+      return stampNow({ ...decision, reasoning: newReasoning });
     }
 
     default:
@@ -306,6 +335,12 @@ function classifyAction(
     case "UPDATE_SCORE":
     case "UPDATE_CONFIDENCE":
       return { type: "structural", timestamp: Date.now() };
+    case "UPDATE_REASONING":
+      return {
+        type: "text",
+        field: `reasoning:${action.optionId}:${action.criterionId}`,
+        timestamp: action.timestamp,
+      };
     default:
       return null;
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -57,6 +57,8 @@ export interface Decision {
   options: Option[];
   criteria: Criterion[];
   scores: ScoreMatrix;
+  /** Optional per-score reasoning notes: optionId → criterionId → text */
+  reasoning?: Record<string, Record<string, string>>;
   createdAt: string; // ISO 8601
   updatedAt: string; // ISO 8601
 }


### PR DESCRIPTION
## Summary

Implements per-score reasoning notes — users can now attach short textual explanations to any score in the decision matrix, answering "Why did I rate this option X on this criterion?"

## Changes

### Core Data Model
- **`src/lib/types.ts`**: Added `reasoning?: Record<string, Record<string, string>>` to `Decision` interface (maps optionId → criterionId → text)
- **`src/lib/decision-reducer.ts`**: Added `UPDATE_REASONING` action with text coalescing; cleanup on `REMOVE_OPTION` / `REMOVE_CRITERION`
- **`src/components/DecisionProvider.tsx`**: Exposed `updateReasoning` convenience wrapper in context

### UI Components
- **`src/components/ReasoningPopover.tsx`** *(new)*: Click-triggered popover with MessageSquare icon, textarea, clear button. Accessible with aria-label, aria-expanded, role="dialog", Escape-to-close
- **`src/components/DecisionBuilder.tsx`**: Integrated ReasoningPopover into desktop score matrix cells
- **`src/components/MobileScoreCards.tsx`**: Integrated ReasoningPopover into mobile score cards
- **`src/components/ResultsView.tsx`**: Added reasoning indicator (blue dot + tooltip) in WSM criterion breakdown pills

### Tests
- **`src/__tests__/components/ReasoningNotes.test.tsx`** *(new)*: 13 tests covering reducer logic (5) and component rendering (8)
- **`src/__tests__/components/DecisionBuilder.test.tsx`**: Increased timeout for 2 tests that are slow under full-suite concurrency

## Test Results
- 757 tests across 48 files — all passing
- TSC clean, ESLint clean, Prettier formatted

Closes #99
