### PR TITLE
feat(scoring): add guided scoring prompts for structured evaluation

### DIFF
--- a/src/__tests__/components/ScoringPrompt.test.tsx
+++ b/src/__tests__/components/ScoringPrompt.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * Tests for guided scoring prompts (issue #92).
+ *
+ * Tests the ScoringPrompt component and the buildCalibrationLabel helper.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ScoringPrompt, buildCalibrationLabel } from "@/components/ScoringPrompt";
+import type { CalibrationData } from "@/components/ScoringPrompt";
+
+// ---------------------------------------------------------------------------
+// Pure logic tests — buildCalibrationLabel
+// ---------------------------------------------------------------------------
+
+describe("buildCalibrationLabel", () => {
+  it("returns null when no other scores exist", () => {
+    const data: CalibrationData = { allScores: [5], currentScore: 5 };
+    expect(buildCalibrationLabel(data)).toBeNull();
+  });
+
+  it("returns calibration string with average when other scores exist", () => {
+    const data: CalibrationData = { allScores: [3, 7, 9], currentScore: 3 };
+    const label = buildCalibrationLabel(data)!;
+    expect(label).toContain("Other scores:");
+    expect(label).toContain("7, 9");
+    expect(label).toContain("avg 8.0");
+  });
+
+  it("returns null when allScores is empty", () => {
+    const data: CalibrationData = { allScores: [], currentScore: null };
+    expect(buildCalibrationLabel(data)).toBeNull();
+  });
+
+  it("handles null currentScore (shows all as others)", () => {
+    const data: CalibrationData = { allScores: [4, 6], currentScore: null };
+    const label = buildCalibrationLabel(data)!;
+    expect(label).toContain("4, 6");
+    expect(label).toContain("avg 5.0");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Component tests — ScoringPrompt
+// ---------------------------------------------------------------------------
+
+describe("ScoringPrompt", () => {
+  it("renders a tooltip with the provided id", () => {
+    render(<ScoringPrompt criterionType="benefit" promptId="test-prompt-1" />);
+    const tooltip = screen.getByRole("tooltip");
+    expect(tooltip).toHaveAttribute("id", "test-prompt-1");
+  });
+
+  it("shows benefit-specific question for benefit criteria", () => {
+    render(<ScoringPrompt criterionType="benefit" promptId="p1" />);
+    expect(screen.getByText(/worst case.*ideal outcome/i)).toBeInTheDocument();
+  });
+
+  it("shows cost-specific question for cost criteria", () => {
+    render(<ScoringPrompt criterionType="cost" promptId="p2" />);
+    expect(screen.getByText(/total cost.*budget/i)).toBeInTheDocument();
+  });
+
+  it("shows anchor labels for benefit criteria", () => {
+    render(<ScoringPrompt criterionType="benefit" promptId="p3" />);
+    expect(screen.getByText(/deal-breaker/i)).toBeInTheDocument();
+    expect(screen.getByText(/acceptable/i)).toBeInTheDocument();
+    expect(screen.getByText(/exceptional/i)).toBeInTheDocument();
+  });
+
+  it("shows anchor labels for cost criteria", () => {
+    render(<ScoringPrompt criterionType="cost" promptId="p4" />);
+    expect(screen.getByText(/over budget/i)).toBeInTheDocument();
+    expect(screen.getByText(/within budget/i)).toBeInTheDocument();
+    expect(screen.getByText(/under budget/i)).toBeInTheDocument();
+  });
+
+  it("shows calibration data when provided", () => {
+    const calibration: CalibrationData = {
+      allScores: [2, 5, 8],
+      currentScore: 2,
+    };
+    render(<ScoringPrompt criterionType="benefit" promptId="p5" calibration={calibration} />);
+    expect(screen.getByText(/Other scores:.*5, 8.*avg 6\.5/)).toBeInTheDocument();
+  });
+
+  it("does not show calibration when no other scores", () => {
+    const calibration: CalibrationData = {
+      allScores: [5],
+      currentScore: 5,
+    };
+    render(<ScoringPrompt criterionType="benefit" promptId="p6" calibration={calibration} />);
+    expect(screen.queryByText(/Other scores/)).not.toBeInTheDocument();
+  });
+
+  it("does not show calibration when calibration prop omitted", () => {
+    render(<ScoringPrompt criterionType="cost" promptId="p7" />);
+    expect(screen.queryByText(/Other scores/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/DecisionBuilder.tsx
+++ b/src/components/DecisionBuilder.tsx
@@ -29,6 +29,8 @@ import { CompletionRing } from "./CompletionRing";
 import { WeightSlider } from "./WeightSlider";
 import { WeightDistributionBar } from "./WeightDistributionBar";
 import { ReasoningPopover } from "./ReasoningPopover";
+import { ScoringPrompt } from "./ScoringPrompt";
+import type { CalibrationData } from "./ScoringPrompt";
 import { BiasWarnings } from "./BiasWarnings";
 import { useBiasDetection } from "@/hooks/useBiasDetection";
 import { MobileScoreCards } from "./MobileScoreCards";
@@ -61,6 +63,26 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
   const completeness = useMemo(() => computeCompleteness(decision), [decision]);
   const [autoNormalize, setAutoNormalize] = useState(false);
   const biasDetection = useBiasDetection(decision);
+
+  /** Track which score cell is focused (for guided scoring prompt) */
+  const [focusedCell, setFocusedCell] = useState<{
+    optionId: string;
+    criterionId: string;
+  } | null>(null);
+
+  /** Build calibration data for the focused cell */
+  const focusedCalibration = useMemo<CalibrationData | undefined>(() => {
+    if (!focusedCell) return undefined;
+    const allScores: number[] = [];
+    for (const opt of decision.options) {
+      const s = readScore(decision.scores, opt.id, focusedCell.criterionId);
+      if (s !== null) allScores.push(s);
+    }
+    return {
+      allScores,
+      currentScore: readScore(decision.scores, focusedCell.optionId, focusedCell.criterionId),
+    };
+  }, [focusedCell, decision.options, decision.scores]);
 
   /** Track which option/criterion descriptions are expanded */
   const [expandedDescs, setExpandedDescs] = useState<Set<string>>(() => {
@@ -622,6 +644,9 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
                     const cellValue = readScore(decision.scores, opt.id, crit.id);
                     const isNull = cellValue === null;
                     const confidence = resolveConfidence(decision.scores[opt.id]?.[crit.id]);
+                    const isFocused =
+                      focusedCell?.optionId === opt.id && focusedCell?.criterionId === crit.id;
+                    const promptId = `scoring-prompt-${opt.id}-${crit.id}`;
                     return (
                       <td
                         key={crit.id}
@@ -646,6 +671,10 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
                                 }
                               }
                             }}
+                            onFocus={() =>
+                              setFocusedCell({ optionId: opt.id, criterionId: crit.id })
+                            }
+                            onBlur={() => setFocusedCell(null)}
                             onKeyDown={(e) => handleGridKeyDown(e, rowIdx, colIdx)}
                             data-grid-row={rowIdx}
                             data-grid-col={colIdx}
@@ -655,7 +684,9 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
                                 : "border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
                             }`}
                             aria-label={`Score for ${opt.name} on ${crit.name}${isNull ? " (not scored)" : ""}`}
-                            aria-describedby="score-range-desc"
+                            aria-describedby={
+                              isFocused ? `score-range-desc ${promptId}` : "score-range-desc"
+                            }
                           />
                           {confidence && (
                             <ConfidenceDot
@@ -670,6 +701,13 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
                             criterionName={crit.name}
                           />
                         </div>
+                        {isFocused && (
+                          <ScoringPrompt
+                            criterionType={crit.type}
+                            promptId={promptId}
+                            calibration={focusedCalibration}
+                          />
+                        )}
                       </td>
                     );
                   })}

--- a/src/components/MobileScoreCards.tsx
+++ b/src/components/MobileScoreCards.tsx
@@ -15,6 +15,7 @@ import type { Criterion, Decision, Option, ScoreValue } from "@/lib/types";
 import { resolveScoreValue, resolveConfidence } from "@/lib/scoring";
 import { ConfidenceDot } from "./ConfidenceDot";
 import { ReasoningPopover } from "./ReasoningPopover";
+import { ScoringPrompt } from "./ScoringPrompt";
 import type { Confidence } from "@/lib/types";
 
 interface MobileScoreCardsProps {
@@ -116,6 +117,10 @@ function OptionCard({
                 value={resolveScoreValue(scores[crit.id]) ?? 0}
                 onChange={(v) => updateScore(crit.id, v)}
                 label={`Score for ${option.name} on ${crit.name}`}
+              />
+              <ScoringPrompt
+                criterionType={crit.type}
+                promptId={`mobile-prompt-${option.id}-${crit.id}`}
               />
               {resolveConfidence(scores[crit.id]) && updateConfidence && (
                 <div className="mt-1 flex items-center gap-1.5">

--- a/src/components/ScoringPrompt.tsx
+++ b/src/components/ScoringPrompt.tsx
@@ -1,0 +1,97 @@
+/**
+ * ScoringPrompt — focus-triggered contextual scoring guidance.
+ *
+ * Renders beneath a score input when focused, showing criterion-appropriate
+ * prompts that guide users toward consistent, calibrated scoring. Includes
+ * reference anchors (1/5/10) and optional relative calibration showing how
+ * the current score compares to other scores for the same criterion.
+ */
+
+"use client";
+
+import type { CriterionType } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Prompt data
+// ---------------------------------------------------------------------------
+
+interface AnchorSet {
+  question: string;
+  low: string;
+  mid: string;
+  high: string;
+}
+
+const PROMPTS: Record<CriterionType, AnchorSet> = {
+  cost: {
+    question: "How does the total cost compare to your budget?",
+    low: "1 = far over budget",
+    mid: "5 = within budget",
+    high: "10 = well under budget",
+  },
+  benefit: {
+    question: "Rate this from worst case to ideal outcome.",
+    low: "1 = deal-breaker",
+    mid: "5 = acceptable",
+    high: "10 = exceptional",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Calibration helpers
+// ---------------------------------------------------------------------------
+
+export interface CalibrationData {
+  /** All non-null scores for the same criterion across options */
+  allScores: number[];
+  /** The current score (null if un-scored) */
+  currentScore: number | null;
+}
+
+/**
+ * Builds a short calibration label, e.g. "Your other scores: 3, 7, 9 — avg 6.3"
+ */
+export function buildCalibrationLabel(data: CalibrationData): string | null {
+  const others = data.allScores.filter((s) => s !== data.currentScore);
+  if (others.length === 0) return null;
+  const avg = others.reduce((a, b) => a + b, 0) / others.length;
+  return `Other scores: ${others.join(", ")} — avg ${avg.toFixed(1)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface ScoringPromptProps {
+  /** Criterion type determines which prompt set to show */
+  criterionType: CriterionType;
+  /** Unique id for aria-describedby */
+  promptId: string;
+  /** Optional calibration data */
+  calibration?: CalibrationData;
+}
+
+export function ScoringPrompt({ criterionType, promptId, calibration }: ScoringPromptProps) {
+  const anchors = PROMPTS[criterionType];
+  const calibrationLabel = calibration ? buildCalibrationLabel(calibration) : null;
+
+  return (
+    <div
+      id={promptId}
+      role="tooltip"
+      className="mt-1.5 rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 px-3 py-2 text-xs text-gray-600 dark:text-gray-400 shadow-sm animate-in fade-in duration-150"
+    >
+      <p className="font-medium text-gray-700 dark:text-gray-300 mb-1">{anchors.question}</p>
+      <div className="flex items-center gap-3 text-[11px]">
+        <span className="text-red-500 dark:text-red-400">{anchors.low}</span>
+        <span className="text-yellow-600 dark:text-yellow-400">{anchors.mid}</span>
+        <span className="text-green-600 dark:text-green-400">{anchors.high}</span>
+      </div>
+      {calibrationLabel && (
+        <p className="mt-1.5 text-[11px] text-blue-600 dark:text-blue-400 italic">
+          {calibrationLabel}
+        </p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implements guided scoring prompts that show contextual evaluation guidance when users focus on score inputs, addressing scoring bias (anchoring, central tendency) and inconsistent evaluations.

## Changes

### New Component
- **`src/components/ScoringPrompt.tsx`**: Focus-triggered scoring guidance with:
  - Criterion-type-aware prompts (cost vs benefit)
  - Reference anchors with color coding (1 = red/low, 5 = yellow/mid, 10 = green/high)
  - Optional relative calibration showing how other options score on the same criterion
  - `buildCalibrationLabel()` pure helper for calibration text

### Integration
- **`src/components/DecisionBuilder.tsx`**: 
  - Added `focusedCell` state tracking which score input is focused
  - Added `focusedCalibration` memoized calibration data
  - Added `onFocus`/`onBlur` handlers to score inputs
  - Renders `ScoringPrompt` beneath focused cells
  - Wired `aria-describedby` to link prompts to inputs
- **`src/components/MobileScoreCards.tsx`**: Static `ScoringPrompt` below each score slider (always visible since mobile cards have vertical space)

### Tests
- **`src/__tests__/components/ScoringPrompt.test.tsx`**: 12 tests (4 calibration logic + 8 component rendering)

## Acceptance Criteria
- [x] Prompts appear on score cell focus, dismiss on blur
- [x] Different prompts for cost vs benefit criteria
- [x] Accessible: announced via aria-describedby
- [x] Does not obstruct adjacent cells on mobile
- [x] >= 5 component tests (12 total)

## Test Results
- 769 tests across 49 files — all passing
- TSC clean, ESLint clean, Prettier formatted

Closes #92
