### PR TITLE
feat(scoring): add confidence-adjusted scoring engine

### DIFF
--- a/src/__tests__/components/ConfidenceStrategySelector.test.tsx
+++ b/src/__tests__/components/ConfidenceStrategySelector.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Tests for ConfidenceStrategySelector component.
+ *
+ * @see https://github.com/ericsocrat/decision-os/issues/94
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ConfidenceStrategySelector } from "@/components/ConfidenceStrategySelector";
+import type { ConfidenceStrategy } from "@/lib/types";
+
+describe("ConfidenceStrategySelector", () => {
+  it("renders all three strategy options", () => {
+    render(<ConfidenceStrategySelector value="none" onChange={vi.fn()} />);
+    expect(screen.getByText("Display Only")).toBeInTheDocument();
+    expect(screen.getByText("Penalize")).toBeInTheDocument();
+    expect(screen.getByText("Widen Range")).toBeInTheDocument();
+  });
+
+  it("marks the current strategy as selected", () => {
+    render(<ConfidenceStrategySelector value="penalize" onChange={vi.fn()} />);
+    const penalizeBtn = screen.getByRole("radio", { name: /penalize/i });
+    expect(penalizeBtn).toHaveAttribute("aria-checked", "true");
+
+    const noneBtn = screen.getByRole("radio", { name: /display only/i });
+    expect(noneBtn).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("calls onChange when a strategy is clicked", () => {
+    const onChange = vi.fn();
+    render(<ConfidenceStrategySelector value="none" onChange={onChange} />);
+
+    fireEvent.click(screen.getByText("Penalize"));
+    expect(onChange).toHaveBeenCalledWith("penalize");
+  });
+
+  it("calls onChange with 'widen' when Widen Range is clicked", () => {
+    const onChange = vi.fn();
+    render(<ConfidenceStrategySelector value="none" onChange={onChange} />);
+
+    fireEvent.click(screen.getByText("Widen Range"));
+    expect(onChange).toHaveBeenCalledWith("widen");
+  });
+
+  it("calls onChange with 'none' when Display Only is clicked", () => {
+    const onChange = vi.fn();
+    render(<ConfidenceStrategySelector value="penalize" onChange={onChange} />);
+
+    fireEvent.click(screen.getByText("Display Only"));
+    expect(onChange).toHaveBeenCalledWith("none");
+  });
+
+  it("has proper radiogroup role and label", () => {
+    render(<ConfidenceStrategySelector value="none" onChange={vi.fn()} />);
+    const radiogroup = screen.getByRole("radiogroup", {
+      name: /confidence adjustment strategy/i,
+    });
+    expect(radiogroup).toBeInTheDocument();
+  });
+
+  it("renders the component container with test id", () => {
+    render(<ConfidenceStrategySelector value="none" onChange={vi.fn()} />);
+    expect(screen.getByTestId("confidence-strategy-selector")).toBeInTheDocument();
+  });
+
+  it("shows descriptions for each strategy", () => {
+    render(<ConfidenceStrategySelector value="none" onChange={vi.fn()} />);
+    expect(
+      screen.getByText(/confidence is shown but does not affect scores/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/low-confidence scores are reduced/i)).toBeInTheDocument();
+    expect(screen.getByText(/widens the range for sensitivity/i)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/confidence-scoring.test.ts
+++ b/src/__tests__/confidence-scoring.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Tests for confidence-adjusted scoring engine.
+ *
+ * Covers:
+ *   - confidenceMultiplier() pure function
+ *   - confidenceAdjustedScore() pure function
+ *   - scoreOption() integration with strategies
+ *   - computeResults() with decision-level strategy
+ *   - Reducer SET_CONFIDENCE_STRATEGY action
+ *
+ * @see https://github.com/ericsocrat/decision-os/issues/94
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  confidenceMultiplier,
+  confidenceAdjustedScore,
+  scoreOption,
+  computeResults,
+  normalizeWeights,
+  CONFIDENCE_MULTIPLIERS,
+} from "@/lib/scoring";
+import type { Confidence, ConfidenceStrategy, Decision, Criterion, ScoreMatrix } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeCriteria(count: number): Criterion[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `c${i + 1}`,
+    name: `Criterion ${i + 1}`,
+    weight: 50,
+    type: "benefit" as const,
+  }));
+}
+
+function makeDecision(overrides: Partial<Decision> = {}): Decision {
+  return {
+    id: "test-decision",
+    title: "Test",
+    description: "",
+    options: [
+      { id: "o1", name: "Option 1" },
+      { id: "o2", name: "Option 2" },
+    ],
+    criteria: makeCriteria(2),
+    scores: {
+      o1: {
+        c1: { value: 8, confidence: "high" },
+        c2: { value: 6, confidence: "low" },
+      },
+      o2: {
+        c1: { value: 7, confidence: "medium" },
+        c2: { value: 9, confidence: "high" },
+      },
+    },
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CONFIDENCE_MULTIPLIERS
+// ---------------------------------------------------------------------------
+
+describe("CONFIDENCE_MULTIPLIERS", () => {
+  it("has multiplier 1.0 for high confidence", () => {
+    expect(CONFIDENCE_MULTIPLIERS.high).toBe(1.0);
+  });
+
+  it("has multiplier 0.8 for medium confidence", () => {
+    expect(CONFIDENCE_MULTIPLIERS.medium).toBe(0.8);
+  });
+
+  it("has multiplier 0.5 for low confidence", () => {
+    expect(CONFIDENCE_MULTIPLIERS.low).toBe(0.5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// confidenceMultiplier()
+// ---------------------------------------------------------------------------
+
+describe("confidenceMultiplier", () => {
+  it("returns 1.0 for 'none' strategy regardless of confidence", () => {
+    expect(confidenceMultiplier("high", "none")).toBe(1.0);
+    expect(confidenceMultiplier("medium", "none")).toBe(1.0);
+    expect(confidenceMultiplier("low", "none")).toBe(1.0);
+  });
+
+  it("returns 1.0 for 'widen' strategy regardless of confidence", () => {
+    expect(confidenceMultiplier("high", "widen")).toBe(1.0);
+    expect(confidenceMultiplier("medium", "widen")).toBe(1.0);
+    expect(confidenceMultiplier("low", "widen")).toBe(1.0);
+  });
+
+  it("returns correct multipliers for 'penalize' strategy", () => {
+    expect(confidenceMultiplier("high", "penalize")).toBe(1.0);
+    expect(confidenceMultiplier("medium", "penalize")).toBe(0.8);
+    expect(confidenceMultiplier("low", "penalize")).toBe(0.5);
+  });
+
+  it("returns 1.0 when confidence is null", () => {
+    expect(confidenceMultiplier(null, "none")).toBe(1.0);
+    expect(confidenceMultiplier(null, "penalize")).toBe(1.0);
+    expect(confidenceMultiplier(null, "widen")).toBe(1.0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// confidenceAdjustedScore()
+// ---------------------------------------------------------------------------
+
+describe("confidenceAdjustedScore", () => {
+  it("returns unchanged score for 'none' strategy", () => {
+    expect(confidenceAdjustedScore(8, "low", "none")).toBe(8);
+  });
+
+  it("returns penalized score for 'penalize' + low", () => {
+    expect(confidenceAdjustedScore(8, "low", "penalize")).toBe(4); // 8 * 0.5
+  });
+
+  it("returns penalized score for 'penalize' + medium", () => {
+    expect(confidenceAdjustedScore(10, "medium", "penalize")).toBe(8); // 10 * 0.8
+  });
+
+  it("returns unchanged score for 'penalize' + high", () => {
+    expect(confidenceAdjustedScore(10, "high", "penalize")).toBe(10); // 10 * 1.0
+  });
+
+  it("returns unchanged score for 'widen' strategy", () => {
+    expect(confidenceAdjustedScore(8, "low", "widen")).toBe(8);
+  });
+
+  it("handles null confidence (defaults to 1.0 multiplier)", () => {
+    expect(confidenceAdjustedScore(7, null, "penalize")).toBe(7);
+  });
+
+  it("handles zero score", () => {
+    expect(confidenceAdjustedScore(0, "low", "penalize")).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scoreOption() with confidence strategies
+// ---------------------------------------------------------------------------
+
+describe("scoreOption with confidence strategies", () => {
+  const criteria = makeCriteria(1);
+  const normalizedW = normalizeWeights([50]);
+
+  it("returns unmodified scores with 'none' strategy", () => {
+    const scores: ScoreMatrix = {
+      o1: { c1: { value: 8, confidence: "low" } },
+    };
+    const result = scoreOption("o1", "Option 1", criteria, scores, normalizedW, "none");
+    // effectiveScore(8, benefit) = 8, mult = 1.0
+    expect(result.criterionScores[0].confidenceMultiplier).toBe(1.0);
+    expect(result.totalScore).toBeCloseTo(8, 1);
+  });
+
+  it("penalizes low-confidence scores with 'penalize' strategy", () => {
+    const scores: ScoreMatrix = {
+      o1: { c1: { value: 8, confidence: "low" } },
+    };
+    const result = scoreOption("o1", "Option 1", criteria, scores, normalizedW, "penalize");
+    // effectiveScore(8, benefit) = 8, mult = 0.5, adjusted = 4
+    expect(result.criterionScores[0].confidenceMultiplier).toBe(0.5);
+    expect(result.totalScore).toBeCloseTo(4, 1);
+  });
+
+  it("penalizes medium-confidence scores with 'penalize' strategy", () => {
+    const scores: ScoreMatrix = {
+      o1: { c1: { value: 10, confidence: "medium" } },
+    };
+    const result = scoreOption("o1", "Option 1", criteria, scores, normalizedW, "penalize");
+    // effectiveScore(10, benefit) = 10, mult = 0.8, adjusted = 8
+    expect(result.criterionScores[0].confidenceMultiplier).toBe(0.8);
+    expect(result.totalScore).toBeCloseTo(8, 1);
+  });
+
+  it("does not penalize high-confidence scores", () => {
+    const scores: ScoreMatrix = {
+      o1: { c1: { value: 10, confidence: "high" } },
+    };
+    const result = scoreOption("o1", "Option 1", criteria, scores, normalizedW, "penalize");
+    expect(result.criterionScores[0].confidenceMultiplier).toBe(1.0);
+    expect(result.totalScore).toBeCloseTo(10, 1);
+  });
+
+  it("treats plain numeric scores as high confidence", () => {
+    const scores: ScoreMatrix = {
+      o1: { c1: 7 },
+    };
+    const result = scoreOption("o1", "Option 1", criteria, scores, normalizedW, "penalize");
+    // plain number → resolveConfidence → "high" → mult 1.0
+    expect(result.criterionScores[0].confidence).toBe("high");
+    expect(result.criterionScores[0].confidenceMultiplier).toBe(1.0);
+    expect(result.totalScore).toBeCloseTo(7, 1);
+  });
+
+  it("includes confidence in criterion score output", () => {
+    const scores: ScoreMatrix = {
+      o1: { c1: { value: 5, confidence: "medium" } },
+    };
+    const result = scoreOption("o1", "Option 1", criteria, scores, normalizedW, "penalize");
+    expect(result.criterionScores[0].confidence).toBe("medium");
+  });
+
+  it("'widen' strategy does not alter scores", () => {
+    const scores: ScoreMatrix = {
+      o1: { c1: { value: 8, confidence: "low" } },
+    };
+    const result = scoreOption("o1", "Option 1", criteria, scores, normalizedW, "widen");
+    expect(result.criterionScores[0].confidenceMultiplier).toBe(1.0);
+    expect(result.totalScore).toBeCloseTo(8, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeResults() with confidence strategy
+// ---------------------------------------------------------------------------
+
+describe("computeResults with confidence strategy", () => {
+  it("uses 'none' strategy by default", () => {
+    const decision = makeDecision();
+    // No confidenceStrategy set → defaults to "none"
+    const results = computeResults(decision);
+    // All multipliers should be 1.0
+    results.optionResults.forEach((or) => {
+      or.criterionScores.forEach((cs) => {
+        expect(cs.confidenceMultiplier).toBe(1.0);
+      });
+    });
+  });
+
+  it("applies penalize strategy when set on decision", () => {
+    const decision = makeDecision({ confidenceStrategy: "penalize" });
+    const results = computeResults(decision);
+
+    // o1.c2 has low confidence → mult = 0.5
+    const o1c2 = results.optionResults
+      .find((r) => r.optionId === "o1")
+      ?.criterionScores.find((cs) => cs.criterionId === "c2");
+    expect(o1c2?.confidenceMultiplier).toBe(0.5);
+    expect(o1c2?.confidence).toBe("low");
+
+    // o2.c1 has medium confidence → mult = 0.8
+    const o2c1 = results.optionResults
+      .find((r) => r.optionId === "o2")
+      ?.criterionScores.find((cs) => cs.criterionId === "c1");
+    expect(o2c1?.confidenceMultiplier).toBe(0.8);
+    expect(o2c1?.confidence).toBe("medium");
+  });
+
+  it("penalize strategy changes ranking vs none strategy", () => {
+    // Construct a decision where low-confidence high scores lose to
+    // high-confidence moderate scores under penalize
+    const decision = makeDecision({
+      criteria: [{ id: "c1", name: "C1", weight: 100, type: "benefit" }],
+      scores: {
+        o1: { c1: { value: 10, confidence: "low" } },  // penalized: 10*0.5=5
+        o2: { c1: { value: 7, confidence: "high" } },   // penalized: 7*1.0=7
+      },
+      confidenceStrategy: "penalize",
+    });
+    const results = computeResults(decision);
+    // o2 should rank higher under penalize
+    expect(results.optionResults[0].optionId).toBe("o2");
+    expect(results.optionResults[1].optionId).toBe("o1");
+  });
+
+  it("widen strategy does not change scores", () => {
+    const noneDecision = makeDecision({ confidenceStrategy: undefined });
+    const widenDecision = makeDecision({ confidenceStrategy: "widen" });
+    const noneResults = computeResults(noneDecision);
+    const widenResults = computeResults(widenDecision);
+
+    expect(noneResults.optionResults.map((r) => r.totalScore)).toEqual(
+      widenResults.optionResults.map((r) => r.totalScore)
+    );
+  });
+});

--- a/src/__tests__/decision-reducer.test.ts
+++ b/src/__tests__/decision-reducer.test.ts
@@ -362,6 +362,47 @@ describe("UI-only actions", () => {
 });
 
 // ---------------------------------------------------------------------------
+// SET_CONFIDENCE_STRATEGY (decision mutation with undo)
+// ---------------------------------------------------------------------------
+
+describe("SET_CONFIDENCE_STRATEGY", () => {
+  it("sets confidenceStrategy on the decision", () => {
+    const state = init();
+    const next = dispatch(state, { type: "SET_CONFIDENCE_STRATEGY", strategy: "penalize" });
+    expect(next.decision.confidenceStrategy).toBe("penalize");
+  });
+
+  it("marks state as dirty", () => {
+    const state = init();
+    const next = dispatch(state, { type: "SET_CONFIDENCE_STRATEGY", strategy: "penalize" });
+    expect(next.isDirty).toBe(true);
+  });
+
+  it("creates an undo snapshot", () => {
+    const state = init();
+    const next = dispatch(state, { type: "SET_CONFIDENCE_STRATEGY", strategy: "penalize" });
+    expect(next.canUndo).toBe(true);
+  });
+
+  it("can be undone", () => {
+    const state = init();
+    const s1 = dispatch(state, { type: "SET_CONFIDENCE_STRATEGY", strategy: "penalize" });
+    expect(s1.decision.confidenceStrategy).toBe("penalize");
+    const s2 = dispatch(s1, { type: "UNDO" });
+    expect(s2.decision.confidenceStrategy).toBeUndefined();
+  });
+
+  it("switches between strategies", () => {
+    const state = init();
+    let s = dispatch(state, { type: "SET_CONFIDENCE_STRATEGY", strategy: "penalize" });
+    s = dispatch(s, { type: "SET_CONFIDENCE_STRATEGY", strategy: "widen" });
+    expect(s.decision.confidenceStrategy).toBe("widen");
+    s = dispatch(s, { type: "SET_CONFIDENCE_STRATEGY", strategy: "none" });
+    expect(s.decision.confidenceStrategy).toBe("none");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Undo / Redo
 // ---------------------------------------------------------------------------
 

--- a/src/components/ConfidenceStrategySelector.tsx
+++ b/src/components/ConfidenceStrategySelector.tsx
@@ -1,0 +1,110 @@
+/**
+ * Confidence Strategy Selector
+ *
+ * Lets users choose how per-score confidence levels affect the final rankings.
+ * Three strategies:
+ *   - "none"     — confidence is displayed only, no effect on scoring
+ *   - "penalize" — low/medium confidence scores receive a multiplier penalty
+ *   - "widen"    — confidence is stored for downstream Monte Carlo / sensitivity
+ *
+ * @see https://github.com/ericsocrat/decision-os/issues/94
+ */
+
+"use client";
+
+import { ShieldCheck, ShieldAlert, Activity } from "lucide-react";
+import type { ConfidenceStrategy } from "@/lib/types";
+
+interface ConfidenceStrategySelectorProps {
+  /** Current strategy */
+  value: ConfidenceStrategy;
+  /** Called when the user selects a strategy */
+  onChange: (strategy: ConfidenceStrategy) => void;
+}
+
+const STRATEGIES: {
+  key: ConfidenceStrategy;
+  label: string;
+  description: string;
+  icon: typeof ShieldCheck;
+}[] = [
+  {
+    key: "none",
+    label: "Display Only",
+    description: "Confidence is shown but does not affect scores",
+    icon: ShieldCheck,
+  },
+  {
+    key: "penalize",
+    label: "Penalize",
+    description: "Low-confidence scores are reduced (×0.5 low, ×0.8 med)",
+    icon: ShieldAlert,
+  },
+  {
+    key: "widen",
+    label: "Widen Range",
+    description: "Confidence widens the range for sensitivity analysis",
+    icon: Activity,
+  },
+];
+
+export function ConfidenceStrategySelector({
+  value,
+  onChange,
+}: ConfidenceStrategySelectorProps) {
+  return (
+    <div
+      className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
+      data-testid="confidence-strategy-selector"
+    >
+      <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
+        Confidence Adjustment
+      </h3>
+      <div
+        className="grid grid-cols-1 sm:grid-cols-3 gap-2"
+        role="radiogroup"
+        aria-label="Confidence adjustment strategy"
+      >
+        {STRATEGIES.map(({ key, label, description, icon: Icon }) => {
+          const selected = value === key;
+          return (
+            <button
+              key={key}
+              role="radio"
+              aria-checked={selected}
+              onClick={() => onChange(key)}
+              className={`flex items-start gap-2 rounded-md border p-3 text-left transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                selected
+                  ? "border-blue-500 bg-blue-50 dark:bg-blue-900/30 dark:border-blue-400"
+                  : "border-gray-200 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700"
+              }`}
+            >
+              <Icon
+                className={`h-4 w-4 mt-0.5 shrink-0 ${
+                  selected
+                    ? "text-blue-600 dark:text-blue-400"
+                    : "text-gray-400 dark:text-gray-500"
+                }`}
+                aria-hidden
+              />
+              <div>
+                <span
+                  className={`block text-sm font-medium ${
+                    selected
+                      ? "text-blue-800 dark:text-blue-200"
+                      : "text-gray-700 dark:text-gray-300"
+                  }`}
+                >
+                  {label}
+                </span>
+                <span className="block text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                  {description}
+                </span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/DecisionProvider.tsx
+++ b/src/components/DecisionProvider.tsx
@@ -30,7 +30,7 @@ import {
   type ReactNode,
   type Dispatch,
 } from "react";
-import type { Confidence, Criterion, Decision, DecisionResults, Option } from "@/lib/types";
+import type { Confidence, ConfidenceStrategy, Criterion, Decision, DecisionResults, Option } from "@/lib/types";
 import type { TopsisResults } from "@/lib/topsis";
 import type { RegretResults } from "@/lib/regret";
 import type { SensitivityAnalysis } from "@/lib/types";
@@ -94,6 +94,7 @@ export interface DecisionContextValue extends DecisionStateValue {
   undo: () => void;
   redo: () => void;
   setSwingPercent: (value: number) => void;
+  setConfidenceStrategy: (strategy: ConfidenceStrategy) => void;
   loadDecision: (id: string) => void;
   createNewDecision: () => void;
   removeDecision: (id: string) => void;
@@ -248,6 +249,11 @@ export function DecisionProvider({ children }: { children: ReactNode }) {
     [dispatch]
   );
 
+  const setConfidenceStrategy = useCallback(
+    (strategy: ConfidenceStrategy) => dispatch({ type: "SET_CONFIDENCE_STRATEGY", strategy }),
+    [dispatch]
+  );
+
   // ── Navigation actions (side effects + dispatch) ─────────
 
   const loadDecision = useCallback(
@@ -340,6 +346,7 @@ export function DecisionProvider({ children }: { children: ReactNode }) {
       undo,
       redo,
       setSwingPercent,
+      setConfidenceStrategy,
       loadDecision,
       createNewDecision,
       removeDecision,
@@ -362,6 +369,7 @@ export function DecisionProvider({ children }: { children: ReactNode }) {
       undo,
       redo,
       setSwingPercent,
+      setConfidenceStrategy,
       loadDecision,
       createNewDecision,
       removeDecision,

--- a/src/components/ResultsView.tsx
+++ b/src/components/ResultsView.tsx
@@ -22,13 +22,14 @@ import { buildShareLink } from "@/lib/share";
 import { normalizeWeights } from "@/lib/scoring";
 import type { TopsisResults } from "@/lib/topsis";
 import type { RegretResults } from "@/lib/regret";
-import type { Decision, DecisionResults } from "@/lib/types";
+import type { Decision, DecisionResults, ConfidenceStrategy } from "@/lib/types";
 import type { ValidationResult } from "@/hooks/useValidation";
 import type { CompletenessResult } from "@/lib/completeness";
 import { BiasWarnings } from "./BiasWarnings";
 import { useBiasDetection } from "@/hooks/useBiasDetection";
 import { HybridResults } from "./HybridResults";
 import { QualityBar } from "./QualityBar";
+import { ConfidenceStrategySelector } from "./ConfidenceStrategySelector";
 
 const ScoreChart = lazy(() => import("./ScoreChart").then((m) => ({ default: m.ScoreChart })));
 const ParetoChart = lazy(() => import("./ParetoChart").then((m) => ({ default: m.ParetoChart })));
@@ -40,7 +41,7 @@ interface ResultsViewProps {
 }
 
 export function ResultsView({ validation, completeness, onSwitchToBuilder }: ResultsViewProps) {
-  const { decision, results, topsisResults, regretResults } = useDecision();
+  const { decision, results, topsisResults, regretResults, setConfidenceStrategy } = useDecision();
   const [shareStatus, setShareStatus] = useState<string>("");
   const [bannerDismissed, setBannerDismissed] = useState(false);
   const [scoringMethod, setScoringMethod] = useState<
@@ -164,6 +165,12 @@ export function ResultsView({ validation, completeness, onSwitchToBuilder }: Res
     <div className="space-y-6">
       {/* Decision quality dashboard */}
       <QualityBar decision={decision} />
+
+      {/* Confidence adjustment strategy */}
+      <ConfidenceStrategySelector
+        value={decision.confidenceStrategy ?? "none"}
+        onChange={setConfidenceStrategy}
+      />
 
       {/* Non-blocking validation warnings */}
       {validation.warnings.length > 0 && (

--- a/src/lib/decision-reducer.ts
+++ b/src/lib/decision-reducer.ts
@@ -13,7 +13,7 @@
  * @see https://github.com/ericsocrat/decision-os/issues/77
  */
 
-import type { Confidence, Criterion, Decision, Option, ScoreMatrix, ScoreValue } from "./types";
+import type { Confidence, ConfidenceStrategy, Criterion, Decision, Option, ScoreMatrix, ScoreValue } from "./types";
 import { generateId } from "./utils";
 import { resolveScoreValue } from "./scoring";
 
@@ -102,6 +102,7 @@ export type DecisionAction =
 
   // UI state
   | { type: "SET_SWING_PERCENT"; value: number }
+  | { type: "SET_CONFIDENCE_STRATEGY"; strategy: ConfidenceStrategy }
   | { type: "MARK_CLEAN" }
   | { type: "SET_LOADING"; loading: boolean }
   | { type: "REFRESH_DECISIONS"; decisions: Decision[] };
@@ -282,6 +283,9 @@ function applyDecisionMutation(decision: Decision, action: DecisionAction): Deci
       return stampNow({ ...decision, reasoning: newReasoning });
     }
 
+    case "SET_CONFIDENCE_STRATEGY":
+      return stampNow({ ...decision, confidenceStrategy: action.strategy });
+
     default:
       return null;
   }
@@ -334,6 +338,7 @@ function classifyAction(
     case "REMOVE_CRITERION":
     case "UPDATE_SCORE":
     case "UPDATE_CONFIDENCE":
+    case "SET_CONFIDENCE_STRATEGY":
       return { type: "structural", timestamp: Date.now() };
     case "UPDATE_REASONING":
       return {

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -14,6 +14,7 @@
 
 import type {
   Confidence,
+  ConfidenceStrategy,
   Criterion,
   CriterionScore,
   Decision,
@@ -100,6 +101,42 @@ export function readScoreOrZero(
 // ---------------------------------------------------------------------------
 
 /**
+ * Confidence-level multiplier map.
+ * Used by the "penalize" strategy to scale effective scores.
+ */
+export const CONFIDENCE_MULTIPLIERS: Record<Confidence, number> = {
+  high: 1.0,
+  medium: 0.8,
+  low: 0.5,
+};
+
+/**
+ * Return the multiplier for a given confidence and strategy.
+ * - `none` → always 1.0 (no adjustment)
+ * - `penalize` → CONFIDENCE_MULTIPLIERS lookup
+ * - `widen` → 1.0 (handled elsewhere in MC distribution)
+ */
+export function confidenceMultiplier(
+  confidence: Confidence | null,
+  strategy: ConfidenceStrategy
+): number {
+  if (strategy !== "penalize" || !confidence) return 1.0;
+  return CONFIDENCE_MULTIPLIERS[confidence];
+}
+
+/**
+ * Compute a confidence-adjusted effective score.
+ * Applies the multiplier to an already-computed effective score.
+ */
+export function confidenceAdjustedScore(
+  effectiveScoreValue: number,
+  confidence: Confidence | null,
+  strategy: ConfidenceStrategy
+): number {
+  return effectiveScoreValue * confidenceMultiplier(confidence, strategy);
+}
+
+/**
  * Normalize an array of raw weights so they sum to 1.0.
  * If all weights are 0, returns equal weights (1/n each).
  * Guarantees: no NaN, no Infinity, all values ≥ 0.
@@ -152,27 +189,32 @@ export function scoreOption(
   optionName: string,
   criteria: Criterion[],
   scores: ScoreMatrix,
-  normalizedWeights: number[]
+  normalizedWeights: number[],
+  strategy: ConfidenceStrategy = "none"
 ): OptionResult {
   const criterionScores: CriterionScore[] = criteria.map((criterion, i) => {
     const raw = readScore(scores, optionId, criterion.id);
     const numericRaw = raw ?? 0;
     const eff = effectiveScore(numericRaw, criterion.type);
     const nw = normalizedWeights[i];
+    const conf = resolveConfidence(scores[optionId]?.[criterion.id]);
+    const mult = confidenceMultiplier(conf, strategy);
+    const adjusted = eff * mult;
 
     return {
       criterionId: criterion.id,
       criterionName: criterion.name,
       rawScore: numericRaw,
       normalizedWeight: nw,
-      effectiveScore: roundDisplay(eff * nw),
+      effectiveScore: roundDisplay(adjusted * nw),
       criterionType: criterion.type,
       isNull: raw === null,
+      confidence: conf ?? undefined,
+      confidenceMultiplier: mult,
     };
   });
 
   // Accumulate only scored criteria; normalize by their weight sum
-  // Formula: score_i = Σ(w_j · e_ij) / Σ(w_j) for j ∈ scored
   let scoredWeightSum = 0;
   let weightedSum = 0;
 
@@ -180,20 +222,20 @@ export function scoreOption(
     const raw = readScore(scores, optionId, criterion.id);
     if (raw !== null) {
       const eff = effectiveScore(raw, criterion.type);
-      weightedSum += eff * normalizedWeights[i];
+      const conf = resolveConfidence(scores[optionId]?.[criterion.id]);
+      const mult = confidenceMultiplier(conf, strategy);
+      weightedSum += eff * mult * normalizedWeights[i];
       scoredWeightSum += normalizedWeights[i];
     }
   });
 
-  // When all scored: scoredWeightSum ≈ 1.0, so result = weightedSum (unchanged)
-  // When partially scored: divide by scoredWeightSum to re-normalize
   const totalScore = roundDisplay(scoredWeightSum > 0 ? weightedSum / scoredWeightSum : 0);
 
   return {
     optionId,
     optionName,
     totalScore,
-    rank: 0, // assigned after sorting
+    rank: 0,
     criterionScores,
   };
 }
@@ -204,6 +246,7 @@ export function scoreOption(
  */
 export function computeResults(decision: Decision): DecisionResults {
   const { criteria, options, scores } = decision;
+  const strategy = decision.confidenceStrategy ?? "none";
 
   if (criteria.length === 0 || options.length === 0) {
     return {
@@ -218,7 +261,7 @@ export function computeResults(decision: Decision): DecisionResults {
 
   // Score each option
   const results: OptionResult[] = options.map((opt) =>
-    scoreOption(opt.id, opt.name, criteria, scores, nw)
+    scoreOption(opt.id, opt.name, criteria, scores, nw, strategy)
   );
 
   // Sort descending by totalScore; stable sort preserves insertion order for ties

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -27,6 +27,14 @@ export interface Option {
 /** Confidence level for a per-cell score */
 export type Confidence = "high" | "medium" | "low";
 
+/**
+ * Strategy for how confidence affects scoring:
+ * - `none`    — display only, no effect on results (default)
+ * - `penalize` — multiply effective score by confidence multiplier
+ * - `widen`   — affects Monte Carlo distribution spread
+ */
+export type ConfidenceStrategy = "none" | "penalize" | "widen";
+
 /** A score cell with an explicit confidence annotation */
 export interface ScoredCell {
   value: number;
@@ -59,6 +67,8 @@ export interface Decision {
   scores: ScoreMatrix;
   /** Optional per-score reasoning notes: optionId → criterionId → text */
   reasoning?: Record<string, Record<string, string>>;
+  /** Strategy for how per-score confidence affects results (default: "none") */
+  confidenceStrategy?: ConfidenceStrategy;
   createdAt: string; // ISO 8601
   updatedAt: string; // ISO 8601
 }
@@ -82,6 +92,10 @@ export interface CriterionScore {
   criterionType: CriterionType;
   /** True when the score cell was null (not yet scored) */
   isNull?: boolean;
+  /** Confidence level for this score (if available) */
+  confidence?: Confidence;
+  /** Multiplier applied based on confidence strategy (1.0 when strategy is "none") */
+  confidenceMultiplier?: number;
 }
 
 /** Full results for a decision */


### PR DESCRIPTION
## Summary

Implements configurable confidence adjustment strategies that optionally affect scoring results, building on the existing per-score confidence infrastructure (#76).

### Three Strategies

| Strategy | Effect | Multipliers |
|----------|--------|-------------|
| **Display Only** (default) | Confidence shown but does not affect scores | All 1.0 |
| **Penalize** | Low/medium confidence scores receive a penalty | High: 1.0, Medium: 0.8, Low: 0.5 |
| **Widen Range** | Confidence stored for future Monte Carlo / sensitivity analysis | All 1.0 |

### Changes

**Types** (`src/lib/types.ts`):
- New `ConfidenceStrategy` type: `"none" | "penalize" | "widen"`
- `Decision.confidenceStrategy` optional field
- `CriterionScore.confidence` and `CriterionScore.confidenceMultiplier` fields

**Scoring Engine** (`src/lib/scoring.ts`):
- `CONFIDENCE_MULTIPLIERS` constant
- `confidenceMultiplier()` and `confidenceAdjustedScore()` pure functions
- `scoreOption()` accepts optional strategy parameter
- `computeResults()` reads strategy from decision

**State Management**:
- `SET_CONFIDENCE_STRATEGY` reducer action with undo support
- `setConfidenceStrategy()` convenience wrapper in DecisionProvider

**UI**:
- `ConfidenceStrategySelector` radio-card component with descriptions and icons
- Integrated in ResultsView below QualityBar

### Tests

38 new tests:
- 25 unit tests for multiplier functions, scoreOption integration, and computeResults
- 8 component tests for ConfidenceStrategySelector
- 5 reducer tests for SET_CONFIDENCE_STRATEGY action

**Test suite: 827 tests, all passing**

Closes #94
