### PR TITLE
feat(analysis): add what-if analysis sandbox

### DIFF
--- a/src/__tests__/components/WhatIfPanel.test.tsx
+++ b/src/__tests__/components/WhatIfPanel.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * Tests for WhatIfPanel component.
+ *
+ * @see https://github.com/ericsocrat/decision-os/issues/93
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { WhatIfPanel } from "@/components/WhatIfPanel";
+import { computeResults } from "@/lib/scoring";
+import type { Decision, DecisionResults } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeDecision(overrides: Partial<Decision> = {}): Decision {
+  return {
+    id: "test-1",
+    title: "Test Decision",
+    description: "",
+    options: [
+      { id: "o1", name: "Option A" },
+      { id: "o2", name: "Option B" },
+    ],
+    criteria: [
+      { id: "c1", name: "Cost", weight: 60, type: "cost" },
+      { id: "c2", name: "Quality", weight: 40, type: "benefit" },
+    ],
+    scores: {
+      o1: { c1: 3, c2: 8 },
+      o2: { c1: 7, c2: 5 },
+    },
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function setup(decision?: Decision) {
+  const d = decision ?? makeDecision();
+  const originalResults = computeResults(d);
+  const onApply = vi.fn();
+  const onClose = vi.fn();
+
+  const utils = render(
+    <WhatIfPanel
+      decision={d}
+      originalResults={originalResults}
+      onApply={onApply}
+      onClose={onClose}
+    />
+  );
+
+  return { ...utils, decision: d, originalResults, onApply, onClose };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("WhatIfPanel", () => {
+  it("renders the modal with dialog role", () => {
+    setup();
+    expect(screen.getByRole("dialog", { name: /what-if analysis/i })).toBeInTheDocument();
+  });
+
+  it("displays the panel title", () => {
+    setup();
+    expect(screen.getByText("What-If Analysis")).toBeInTheDocument();
+  });
+
+  it("renders weight sliders for each criterion", () => {
+    setup();
+    expect(screen.getByLabelText(/cost weight/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/quality weight/i)).toBeInTheDocument();
+  });
+
+  it("renders the score matrix with all options and criteria", () => {
+    setup();
+    const matrix = screen.getByTestId("whatif-score-matrix");
+    expect(within(matrix).getByText("Option A")).toBeInTheDocument();
+    expect(within(matrix).getByText("Option B")).toBeInTheDocument();
+    expect(within(matrix).getByText("Cost")).toBeInTheDocument();
+    expect(within(matrix).getByText("Quality")).toBeInTheDocument();
+  });
+
+  it("renders original and what-if ranking columns", () => {
+    setup();
+    const rankings = screen.getByTestId("whatif-rankings");
+    expect(within(rankings).getByText("Original")).toBeInTheDocument();
+    expect(within(rankings).getByText("What-If")).toBeInTheDocument();
+  });
+
+  it("shows both options in original rankings", () => {
+    setup();
+    const rankings = screen.getByTestId("whatif-rankings");
+    expect(within(rankings).getAllByText("Option A").length).toBeGreaterThanOrEqual(1);
+    expect(within(rankings).getAllByText("Option B").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("Apply button is disabled when no changes are made", () => {
+    setup();
+    const applyBtn = screen.getByTestId("whatif-apply");
+    expect(applyBtn).toBeDisabled();
+  });
+
+  it("Reset button is disabled when no changes are made", () => {
+    setup();
+    const resetBtn = screen.getByTestId("whatif-reset");
+    expect(resetBtn).toBeDisabled();
+  });
+
+  it("enables Apply and Reset after changing a weight", () => {
+    setup();
+    const costSlider = screen.getByLabelText(/cost weight/i);
+    fireEvent.change(costSlider, { target: { value: "80" } });
+
+    expect(screen.getByTestId("whatif-apply")).not.toBeDisabled();
+    expect(screen.getByTestId("whatif-reset")).not.toBeDisabled();
+  });
+
+  it("enables Apply after changing a score", () => {
+    setup();
+    const scoreInputs = screen.getAllByLabelText(/score$/i);
+    // Change first score input
+    fireEvent.change(scoreInputs[0], { target: { value: "5" } });
+
+    expect(screen.getByTestId("whatif-apply")).not.toBeDisabled();
+  });
+
+  it("calls onClose when close button is clicked", () => {
+    const { onClose } = setup();
+    fireEvent.click(screen.getByLabelText(/close what-if panel/i));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose when backdrop is clicked", () => {
+    const { onClose } = setup();
+    fireEvent.click(screen.getByTestId("whatif-panel"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose when Escape is pressed", () => {
+    const { onClose } = setup();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("calls onApply with modified weights and scores when Apply is clicked", () => {
+    const { onApply, decision } = setup();
+
+    // Change cost weight to 80
+    const costSlider = screen.getByLabelText(/cost weight/i);
+    fireEvent.change(costSlider, { target: { value: "80" } });
+
+    fireEvent.click(screen.getByTestId("whatif-apply"));
+
+    expect(onApply).toHaveBeenCalledOnce();
+    const [weights, scores] = onApply.mock.calls[0];
+    expect(weights[0]).toBe(80); // Cost weight changed
+    expect(weights[1]).toBe(40); // Quality weight unchanged
+    // Scores should be the original numeric values
+    expect(scores[decision.options[0].id][decision.criteria[0].id]).toBe(3);
+  });
+
+  it("resets to original values when Reset is clicked", () => {
+    setup();
+
+    // Change weight
+    const costSlider = screen.getByLabelText(/cost weight/i) as HTMLInputElement;
+    fireEvent.change(costSlider, { target: { value: "80" } });
+    expect(screen.getByTestId("whatif-apply")).not.toBeDisabled();
+
+    // Click reset
+    fireEvent.click(screen.getByTestId("whatif-reset"));
+
+    // Apply should be disabled again (no changes)
+    expect(screen.getByTestId("whatif-apply")).toBeDisabled();
+  });
+
+  it("shows rank change indicators when rankings differ", () => {
+    // Option A: great speed (9), great price (2, low cost = good)
+    // Option B: mediocre speed (5), bad price (8, high cost = bad)
+    // At equal weights both criteria matter => A wins
+    // Flip: set Speed=0, Price=100 => price dominates => still A wins on price
+    // Need a scenario where A wins originally but flips:
+    // A: speed=9, price=8 (expensive)  B: speed=5, price=2 (cheap)
+    // At speed=100, price=0: A wins (9 vs 5)
+    // At speed=0, price=100: B wins (cost effective: 10-2=8 vs 10-8=2)
+    const d = makeDecision({
+      criteria: [
+        { id: "c1", name: "Speed", weight: 100, type: "benefit" },
+        { id: "c2", name: "Price", weight: 0, type: "cost" },
+      ],
+      scores: {
+        o1: { c1: 9, c2: 8 }, // Great speed, expensive
+        o2: { c1: 5, c2: 2 }, // Mediocre speed, cheap
+      },
+    });
+
+    const originalResults = computeResults(d);
+    // Verify A wins originally
+    expect(originalResults.optionResults[0].optionId).toBe("o1");
+
+    const onApply = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <WhatIfPanel
+        decision={d}
+        originalResults={originalResults}
+        onApply={onApply}
+        onClose={onClose}
+      />
+    );
+
+    // Flip: Speed=0, Price=100 => B wins on price
+    const speedSlider = screen.getByLabelText(/speed weight/i);
+    fireEvent.change(speedSlider, { target: { value: "0" } });
+
+    const priceSlider = screen.getByLabelText(/price weight/i);
+    fireEvent.change(priceSlider, { target: { value: "100" } });
+
+    // Should show rank change arrows in the What-If column
+    const rankings = screen.getByTestId("whatif-rankings");
+    const arrows = within(rankings).getAllByLabelText(/up|down/i);
+    expect(arrows.length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/ResultsView.tsx
+++ b/src/components/ResultsView.tsx
@@ -16,6 +16,7 @@ import {
   AlertTriangle,
   X,
   Crosshair,
+  FlaskConical,
 } from "lucide-react";
 import { useState, lazy, Suspense, useMemo } from "react";
 import { buildShareLink } from "@/lib/share";
@@ -30,6 +31,7 @@ import { useBiasDetection } from "@/hooks/useBiasDetection";
 import { HybridResults } from "./HybridResults";
 import { QualityBar } from "./QualityBar";
 import { ConfidenceStrategySelector } from "./ConfidenceStrategySelector";
+import { WhatIfPanel } from "./WhatIfPanel";
 
 const ScoreChart = lazy(() => import("./ScoreChart").then((m) => ({ default: m.ScoreChart })));
 const ParetoChart = lazy(() => import("./ParetoChart").then((m) => ({ default: m.ParetoChart })));
@@ -41,9 +43,10 @@ interface ResultsViewProps {
 }
 
 export function ResultsView({ validation, completeness, onSwitchToBuilder }: ResultsViewProps) {
-  const { decision, results, topsisResults, regretResults, setConfidenceStrategy } = useDecision();
+  const { decision, results, topsisResults, regretResults, setConfidenceStrategy, updateCriterion, updateScore } = useDecision();
   const [shareStatus, setShareStatus] = useState<string>("");
   const [bannerDismissed, setBannerDismissed] = useState(false);
+  const [whatIfOpen, setWhatIfOpen] = useState(false);
   const [scoringMethod, setScoringMethod] = useState<
     "wsm" | "topsis" | "minimax-regret" | "consensus"
   >("wsm");
@@ -304,6 +307,15 @@ export function ResultsView({ validation, completeness, onSwitchToBuilder }: Res
             >
               <Link className="h-4 w-4" />
               <span className="hidden sm:inline">Share</span>
+            </button>
+            <button
+              onClick={() => setWhatIfOpen(true)}
+              className="inline-flex items-center gap-1 rounded-md border border-purple-300 dark:border-purple-600 px-3 py-1.5 text-sm font-medium text-purple-700 dark:text-purple-300 hover:bg-purple-50 dark:hover:bg-purple-900/30 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 transition-colors"
+              aria-label="Open what-if analysis"
+              data-testid="whatif-open-btn"
+            >
+              <FlaskConical className="h-4 w-4" />
+              <span className="hidden sm:inline">What-If</span>
             </button>
           </div>
         </div>
@@ -577,6 +589,29 @@ export function ResultsView({ validation, completeness, onSwitchToBuilder }: Res
           <NormalizedWeightsTable />
         </div>
       </section>
+
+      {/* What-If Analysis Panel */}
+      {whatIfOpen && (
+        <WhatIfPanel
+          decision={decision}
+          originalResults={results}
+          onApply={(weights, scores) => {
+            decision.criteria.forEach((c, i) => {
+              if (c.weight !== weights[i]) {
+                updateCriterion(c.id, { weight: weights[i] });
+              }
+            });
+            for (const opt of decision.options) {
+              for (const crit of decision.criteria) {
+                const newVal = scores[opt.id]?.[crit.id] ?? null;
+                updateScore(opt.id, crit.id, newVal);
+              }
+            }
+            setWhatIfOpen(false);
+          }}
+          onClose={() => setWhatIfOpen(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/WhatIfPanel.tsx
+++ b/src/components/WhatIfPanel.tsx
@@ -1,0 +1,423 @@
+/**
+ * What-If Analysis Panel
+ *
+ * A sandboxed overlay that lets users explore hypothetical changes to
+ * weights and scores without modifying the actual decision. Shows
+ * original vs what-if rankings side-by-side with rank change indicators.
+ *
+ * Architecture:
+ *   - Maintains local cloned state (weights + scores)
+ *   - Uses `computeResults()` for real-time recomputation
+ *   - Only writes to DecisionProvider on "Apply Changes"
+ *
+ * @see https://github.com/ericsocrat/decision-os/issues/93
+ */
+
+"use client";
+
+import {
+  useState,
+  useMemo,
+  useCallback,
+  useEffect,
+  useRef,
+  type ReactNode,
+} from "react";
+import {
+  X,
+  RotateCcw,
+  Check,
+  ArrowUp,
+  ArrowDown,
+  Minus,
+  FlaskConical,
+} from "lucide-react";
+import type { Decision, DecisionResults, OptionResult } from "@/lib/types";
+import { computeResults } from "@/lib/scoring";
+import { resolveScoreValue } from "@/lib/scoring";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface WhatIfPanelProps {
+  /** The current decision (read-only — cloned internally) */
+  decision: Decision;
+  /** Original results (for comparison) */
+  originalResults: DecisionResults;
+  /** Called when the user clicks "Apply Changes" */
+  onApply: (weights: number[], scores: Record<string, Record<string, number | null>>) => void;
+  /** Called when the panel is closed */
+  onClose: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function cloneWeights(decision: Decision): number[] {
+  return decision.criteria.map((c) => c.weight);
+}
+
+function cloneScores(
+  decision: Decision
+): Record<string, Record<string, number | null>> {
+  const out: Record<string, Record<string, number | null>> = {};
+  for (const opt of decision.options) {
+    out[opt.id] = {};
+    for (const crit of decision.criteria) {
+      const sv = decision.scores[opt.id]?.[crit.id];
+      out[opt.id][crit.id] = resolveScoreValue(sv);
+    }
+  }
+  return out;
+}
+
+/** Build a synthetic Decision from cloned weights and scores */
+function buildWhatIfDecision(
+  decision: Decision,
+  weights: number[],
+  scores: Record<string, Record<string, number | null>>
+): Decision {
+  return {
+    ...decision,
+    criteria: decision.criteria.map((c, i) => ({
+      ...c,
+      weight: weights[i],
+    })),
+    scores: Object.fromEntries(
+      Object.entries(scores).map(([optId, critScores]) => [
+        optId,
+        Object.fromEntries(
+          Object.entries(critScores).map(([critId, val]) => [critId, val])
+        ),
+      ])
+    ),
+  };
+}
+
+/** Rank delta badge */
+function RankDelta({ original, current }: { original: number; current: number }) {
+  const delta = original - current; // positive = moved up
+  if (delta === 0) {
+    return (
+      <span className="inline-flex items-center text-xs text-gray-400" aria-label="No change">
+        <Minus className="h-3 w-3" />
+      </span>
+    );
+  }
+  if (delta > 0) {
+    return (
+      <span
+        className="inline-flex items-center gap-0.5 text-xs font-medium text-green-600 dark:text-green-400"
+        aria-label={`Up ${delta}`}
+      >
+        <ArrowUp className="h-3 w-3" />
+        {delta}
+      </span>
+    );
+  }
+  return (
+    <span
+      className="inline-flex items-center gap-0.5 text-xs font-medium text-red-600 dark:text-red-400"
+      aria-label={`Down ${Math.abs(delta)}`}
+    >
+      <ArrowDown className="h-3 w-3" />
+      {Math.abs(delta)}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function WhatIfPanel({
+  decision,
+  originalResults,
+  onApply,
+  onClose,
+}: WhatIfPanelProps) {
+  // ── Local sandbox state ─────────────────────────────────
+  const [weights, setWeights] = useState(() => cloneWeights(decision));
+  const [scores, setScores] = useState(() => cloneScores(decision));
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // ── Recompute what-if results on each change ────────────
+  const whatIfDecision = useMemo(
+    () => buildWhatIfDecision(decision, weights, scores),
+    [decision, weights, scores]
+  );
+  const whatIfResults = useMemo(() => computeResults(whatIfDecision), [whatIfDecision]);
+
+  // ── Track whether changes were made ─────────────────────
+  const hasChanges = useMemo(() => {
+    const origWeights = cloneWeights(decision);
+    const origScores = cloneScores(decision);
+    if (weights.some((w, i) => w !== origWeights[i])) return true;
+    for (const optId of Object.keys(origScores)) {
+      for (const critId of Object.keys(origScores[optId])) {
+        if (scores[optId]?.[critId] !== origScores[optId][critId]) return true;
+      }
+    }
+    return false;
+  }, [decision, weights, scores]);
+
+  // ── Build rank lookup for comparison ────────────────────
+  const originalRankMap = useMemo(() => {
+    const map = new Map<string, number>();
+    originalResults.optionResults.forEach((r) => map.set(r.optionId, r.rank));
+    return map;
+  }, [originalResults]);
+
+  // ── Keyboard: Escape closes ─────────────────────────────
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  // ── Handlers ────────────────────────────────────────────
+  const handleWeightChange = useCallback(
+    (index: number, value: number) => {
+      setWeights((prev) => prev.map((w, i) => (i === index ? value : w)));
+    },
+    []
+  );
+
+  const handleScoreChange = useCallback(
+    (optionId: string, criterionId: string, value: number | null) => {
+      setScores((prev) => ({
+        ...prev,
+        [optionId]: {
+          ...prev[optionId],
+          [criterionId]: value,
+        },
+      }));
+    },
+    []
+  );
+
+  const handleReset = useCallback(() => {
+    setWeights(cloneWeights(decision));
+    setScores(cloneScores(decision));
+  }, [decision]);
+
+  const handleApply = useCallback(() => {
+    onApply(weights, scores);
+  }, [onApply, weights, scores]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="What-if analysis"
+      data-testid="whatif-panel"
+    >
+      <div
+        ref={panelRef}
+        className="bg-white dark:bg-gray-800 rounded-lg shadow-xl border border-gray-200 dark:border-gray-700 max-w-4xl w-full mx-4 max-h-[85vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* ── Header ─────────────────────────────────────── */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700 shrink-0">
+          <div className="flex items-center gap-2">
+            <FlaskConical className="h-5 w-5 text-purple-500" />
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+              What-If Analysis
+            </h2>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleReset}
+              disabled={!hasChanges}
+              className="inline-flex items-center gap-1 rounded-md border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              aria-label="Reset to original values"
+              data-testid="whatif-reset"
+            >
+              <RotateCcw className="h-3.5 w-3.5" />
+              Reset
+            </button>
+            <button
+              onClick={handleApply}
+              disabled={!hasChanges}
+              className="inline-flex items-center gap-1 rounded-md bg-purple-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-purple-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              aria-label="Apply changes to decision"
+              data-testid="whatif-apply"
+            >
+              <Check className="h-3.5 w-3.5" />
+              Apply Changes
+            </button>
+            <button
+              onClick={onClose}
+              className="rounded-md p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
+              aria-label="Close what-if panel"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+        </div>
+
+        {/* ── Body ───────────────────────────────────────── */}
+        <div className="overflow-y-auto flex-1 px-6 py-4 space-y-6">
+          {/* ── Weight Sliders ───────────────────────────── */}
+          <section>
+            <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
+              Criterion Weights
+            </h3>
+            <div className="space-y-3">
+              {decision.criteria.map((criterion, i) => (
+                <div key={criterion.id} className="flex items-center gap-3">
+                  <label
+                    className="text-sm text-gray-600 dark:text-gray-400 w-32 truncate shrink-0"
+                    htmlFor={`wi-weight-${criterion.id}`}
+                    title={criterion.name}
+                  >
+                    {criterion.name}
+                  </label>
+                  <input
+                    id={`wi-weight-${criterion.id}`}
+                    type="range"
+                    min={0}
+                    max={100}
+                    value={weights[i]}
+                    onChange={(e) => handleWeightChange(i, Number(e.target.value))}
+                    className="flex-1 accent-purple-600"
+                    aria-label={`${criterion.name} weight`}
+                  />
+                  <span className="text-sm font-mono text-gray-500 dark:text-gray-400 w-8 text-right">
+                    {weights[i]}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* ── Score Matrix ─────────────────────────────── */}
+          <section>
+            <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
+              Scores
+            </h3>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm" data-testid="whatif-score-matrix">
+                <thead>
+                  <tr className="border-b border-gray-200 dark:border-gray-700">
+                    <th className="text-left py-2 pr-3 text-gray-500 dark:text-gray-400 font-medium">
+                      Option
+                    </th>
+                    {decision.criteria.map((c) => (
+                      <th
+                        key={c.id}
+                        className="text-center py-2 px-2 text-gray-500 dark:text-gray-400 font-medium"
+                      >
+                        {c.name}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {decision.options.map((opt) => (
+                    <tr
+                      key={opt.id}
+                      className="border-b border-gray-100 dark:border-gray-700/50"
+                    >
+                      <td className="py-2 pr-3 text-gray-700 dark:text-gray-300 font-medium truncate max-w-[120px]">
+                        {opt.name}
+                      </td>
+                      {decision.criteria.map((crit) => {
+                        const val = scores[opt.id]?.[crit.id];
+                        return (
+                          <td key={crit.id} className="text-center py-2 px-2">
+                            <input
+                              type="number"
+                              min={0}
+                              max={10}
+                              value={val ?? ""}
+                              onChange={(e) => {
+                                const raw = e.target.value;
+                                if (raw === "") {
+                                  handleScoreChange(opt.id, crit.id, null);
+                                } else {
+                                  const n = Math.max(0, Math.min(10, Math.round(Number(raw))));
+                                  handleScoreChange(opt.id, crit.id, n);
+                                }
+                              }}
+                              className="w-14 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-2 py-1 text-center text-sm text-gray-800 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-purple-500"
+                              aria-label={`${opt.name} ${crit.name} score`}
+                            />
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          {/* ── Side-by-Side Rankings ────────────────────── */}
+          <section>
+            <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
+              Rankings Comparison
+            </h3>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4" data-testid="whatif-rankings">
+              {/* Original */}
+              <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+                <h4 className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
+                  Original
+                </h4>
+                <ol className="space-y-1">
+                  {originalResults.optionResults.map((r) => (
+                    <li
+                      key={r.optionId}
+                      className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300"
+                    >
+                      <span className="font-mono text-xs text-gray-400 w-5">
+                        #{r.rank}
+                      </span>
+                      <span className="flex-1 truncate">{r.optionName}</span>
+                      <span className="font-mono text-xs text-gray-500">
+                        {r.totalScore.toFixed(2)}
+                      </span>
+                    </li>
+                  ))}
+                </ol>
+              </div>
+
+              {/* What-If */}
+              <div className="rounded-lg border border-purple-200 dark:border-purple-700/50 bg-purple-50/50 dark:bg-purple-900/10 p-4">
+                <h4 className="text-xs font-semibold uppercase tracking-wide text-purple-600 dark:text-purple-400 mb-2">
+                  What-If
+                </h4>
+                <ol className="space-y-1">
+                  {whatIfResults.optionResults.map((r) => {
+                    const origRank = originalRankMap.get(r.optionId) ?? r.rank;
+                    return (
+                      <li
+                        key={r.optionId}
+                        className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300"
+                      >
+                        <span className="font-mono text-xs text-gray-400 w-5">
+                          #{r.rank}
+                        </span>
+                        <span className="flex-1 truncate">{r.optionName}</span>
+                        <RankDelta original={origRank} current={r.rank} />
+                        <span className="font-mono text-xs text-gray-500">
+                          {r.totalScore.toFixed(2)}
+                        </span>
+                      </li>
+                    );
+                  })}
+                </ol>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a sandboxed What-If Analysis panel that lets users explore hypothetical changes to criterion weights and scores without modifying their actual decision.

### Features

- **Sandbox Mode**: All changes are local — the real decision is untouched until "Apply Changes"
- **Weight Sliders**: Adjust each criterion's weight with range sliders
- **Score Matrix**: Edit scores in a tabular grid (0-10, clamped)
- **Side-by-Side Rankings**: Original vs What-If rankings displayed side-by-side
- **Rank Change Indicators**: Green arrows (up), red arrows (down), or dash (no change)
- **Reset**: Restores all values to the original decision state
- **Apply Changes**: Commits sandbox values to the actual decision via `updateCriterion` / `updateScore`
- **Keyboard Accessible**: Escape key closes the panel
- **Mobile Responsive**: Stacked layout on small screens via `grid-cols-1 sm:grid-cols-2`

### Architecture

- `WhatIfPanel` maintains its own cloned state (weights + scores)
- Uses existing `computeResults()` for real-time recomputation on every change
- Does NOT touch DecisionProvider state until "Apply"
- Integrated into ResultsView toolbar with a purple-themed "What-If" button

### New Files

- `src/components/WhatIfPanel.tsx` — Main panel component
- `src/__tests__/components/WhatIfPanel.test.tsx` — 16 component tests

### Tests

16 new component tests covering:
- Modal rendering and accessibility (dialog role, aria-modal)
- Weight sliders and score matrix rendering
- Apply/Reset button enable/disable states
- Close via button, backdrop click, and Escape key
- onApply callback with modified weights and scores
- Reset restoring original values
- Rank change indicators when rankings flip

**Test suite: 843 tests, all passing**

Closes #93
