### PR TITLE
feat(analysis): add multi-algorithm consensus engine with Kendall W and Borda count

### DIFF
--- a/src/__tests__/consensus.test.ts
+++ b/src/__tests__/consensus.test.ts
@@ -1,0 +1,449 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeConsensus,
+  kendallW,
+  spearmanCorrelation,
+  ALL_ALGORITHMS,
+  type AlgorithmId,
+  type ConsensusResult,
+} from "@/lib/consensus";
+import type { Decision } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+//  Helpers
+// ---------------------------------------------------------------------------
+
+function makeDecision(
+  options: { id: string; name: string }[],
+  criteria: {
+    id: string;
+    name: string;
+    weight: number;
+    type: "benefit" | "cost";
+  }[],
+  scores: Record<string, Record<string, number>>
+): Decision {
+  return {
+    id: "test",
+    title: "Test Decision",
+    options,
+    criteria,
+    scores,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+/** Simple 3-option, 2-criterion decision. */
+function simpleDecision(): Decision {
+  return makeDecision(
+    [
+      { id: "a", name: "Alpha" },
+      { id: "b", name: "Beta" },
+      { id: "c", name: "Gamma" },
+    ],
+    [
+      { id: "c1", name: "Quality", weight: 60, type: "benefit" },
+      { id: "c2", name: "Speed", weight: 40, type: "benefit" },
+    ],
+    {
+      a: { c1: 9, c2: 5 },
+      b: { c1: 6, c2: 8 },
+      c: { c1: 4, c2: 3 },
+    }
+  );
+}
+
+/** Decision where algorithms strongly agree: one option dominates. */
+function dominantDecision(): Decision {
+  return makeDecision(
+    [
+      { id: "a", name: "Alpha" },
+      { id: "b", name: "Beta" },
+    ],
+    [
+      { id: "c1", name: "Quality", weight: 50, type: "benefit" },
+      { id: "c2", name: "Speed", weight: 50, type: "benefit" },
+    ],
+    {
+      a: { c1: 10, c2: 10 },
+      b: { c1: 2, c2: 2 },
+    }
+  );
+}
+
+// ---------------------------------------------------------------------------
+//  kendallW
+// ---------------------------------------------------------------------------
+
+describe("kendallW", () => {
+  it("returns 1 for perfect agreement among rankers", () => {
+    // All 3 rankers agree: option 0 is 1st, option 1 is 2nd, option 2 is 3rd
+    const matrix = [
+      [1, 2, 3],
+      [1, 2, 3],
+      [1, 2, 3],
+    ];
+    expect(kendallW(matrix)).toBe(1);
+  });
+
+  it("returns 0 for maximally balanced disagreement", () => {
+    // 3 rankers × 3 objects with each rank-sum identical
+    // Latin square: each object gets rank 1+2+3 = 6
+    const matrix = [
+      [1, 2, 3],
+      [2, 3, 1],
+      [3, 1, 2],
+    ];
+    expect(kendallW(matrix)).toBeCloseTo(0, 10);
+  });
+
+  it("returns value between 0 and 1 for partial agreement", () => {
+    const matrix = [
+      [1, 2, 3],
+      [1, 3, 2],
+      [2, 1, 3],
+    ];
+    const w = kendallW(matrix);
+    expect(w).toBeGreaterThan(0);
+    expect(w).toBeLessThan(1);
+  });
+
+  it("returns 1 for a single ranker", () => {
+    expect(kendallW([[1, 2, 3]])).toBe(1);
+  });
+
+  it("returns 1 for a single object", () => {
+    expect(kendallW([[1], [1], [1]])).toBe(1);
+  });
+
+  it("returns 1 for empty input", () => {
+    expect(kendallW([])).toBe(1);
+  });
+
+  it("handles two rankers with perfect disagreement", () => {
+    const matrix = [
+      [1, 2],
+      [2, 1],
+    ];
+    expect(kendallW(matrix)).toBeCloseTo(0, 10);
+  });
+
+  it("handles two rankers with perfect agreement", () => {
+    const matrix = [
+      [1, 2],
+      [1, 2],
+    ];
+    expect(kendallW(matrix)).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+//  spearmanCorrelation
+// ---------------------------------------------------------------------------
+
+describe("spearmanCorrelation", () => {
+  it("returns 1 for identical rank vectors", () => {
+    expect(spearmanCorrelation([1, 2, 3], [1, 2, 3])).toBe(1);
+  });
+
+  it("returns 0 for perfectly reversed rank vectors", () => {
+    expect(spearmanCorrelation([1, 2, 3], [3, 2, 1])).toBeCloseTo(0, 10);
+  });
+
+  it("returns 0.5 for orthogonal ranks", () => {
+    // With ρ = 0 → mapped = 0.5
+    // For 5 objects: [1,2,3,4,5] vs [2,4,1,3,5] → ρ = 0.3 → mapped ≈ 0.65
+    // Hard to construct exact ρ=0, so test a partial case
+    const result = spearmanCorrelation([1, 2, 3, 4, 5], [1, 2, 3, 4, 5]);
+    expect(result).toBe(1);
+  });
+
+  it("returns 1 for a single element", () => {
+    expect(spearmanCorrelation([1], [1])).toBe(1);
+  });
+
+  it("throws for unequal-length vectors", () => {
+    expect(() => spearmanCorrelation([1, 2], [1])).toThrow("Rank vectors must have equal length");
+  });
+
+  it("handles partial agreement", () => {
+    const result = spearmanCorrelation([1, 2, 3, 4], [1, 3, 2, 4]);
+    expect(result).toBeGreaterThan(0.5);
+    expect(result).toBeLessThan(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+//  computeConsensus
+// ---------------------------------------------------------------------------
+
+describe("computeConsensus", () => {
+  it("produces consensus rankings for a simple decision", () => {
+    const result = computeConsensus(simpleDecision());
+
+    expect(result.rankings.length).toBe(3);
+    expect(result.algorithmResults.length).toBe(3);
+    expect(result.algorithmCount).toBe(3);
+    expect(result.rankings[0].consensusRank).toBe(1);
+  });
+
+  it("assigns correct Borda scores", () => {
+    const result = computeConsensus(simpleDecision());
+
+    // 3 options, 3 algorithms. Max Borda per algorithm = 2 (n-1), summed across 3
+    // Total Borda pool = 3 * (0+1+2) = 9
+    const totalBorda = result.rankings.reduce((s, r) => s + r.bordaScore, 0);
+    expect(totalBorda).toBe(9);
+  });
+
+  it("includes all algorithm ranks per option", () => {
+    const result = computeConsensus(simpleDecision());
+
+    for (const ranking of result.rankings) {
+      expect(ranking.algorithmRanks).toHaveProperty("wsm");
+      expect(ranking.algorithmRanks).toHaveProperty("topsis");
+      expect(ranking.algorithmRanks).toHaveProperty("minimax-regret");
+    }
+  });
+
+  it("reports high agreement when one option dominates", () => {
+    const result = computeConsensus(dominantDecision());
+
+    expect(result.overallAgreement).toBe(1);
+    expect(result.rankings[0].consensusRank).toBe(1);
+    expect(result.rankings[0].optionId).toBe("a");
+    expect(result.divergentOptions.length).toBe(0);
+  });
+
+  it("marks divergent options correctly", () => {
+    // Create a decision where algorithms might rank differently
+    const d = makeDecision(
+      [
+        { id: "a", name: "Alpha" },
+        { id: "b", name: "Beta" },
+        { id: "c", name: "Gamma" },
+        { id: "d", name: "Delta" },
+      ],
+      [
+        { id: "c1", name: "Quality", weight: 70, type: "benefit" },
+        { id: "c2", name: "Cost", weight: 30, type: "cost" },
+      ],
+      {
+        a: { c1: 9, c2: 8 }, // Great quality, very expensive
+        b: { c1: 5, c2: 2 }, // Mid quality, cheap
+        c: { c1: 3, c2: 5 }, // Low quality, mid cost
+        d: { c1: 7, c2: 9 }, // Good quality, very expensive
+      }
+    );
+
+    const result = computeConsensus(d);
+
+    // Verify divergentOptions only contains options with spread >= 2
+    for (const divId of result.divergentOptions) {
+      const ranking = result.rankings.find((r) => r.optionId === divId);
+      expect(ranking).toBeDefined();
+      const ranks = Object.values(ranking!.algorithmRanks);
+      const spread = Math.max(...ranks) - Math.min(...ranks);
+      expect(spread).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it("provides pairwise correlations between algorithms", () => {
+    const result = computeConsensus(simpleDecision());
+
+    // 3 algorithms → 3 pairs: wsm-topsis, wsm-regret, topsis-regret
+    expect(result.pairwiseCorrelations.length).toBe(3);
+
+    for (const pc of result.pairwiseCorrelations) {
+      expect(pc.correlation).toBeGreaterThanOrEqual(0);
+      expect(pc.correlation).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("gracefully handles empty options", () => {
+    const d = makeDecision([], [{ id: "c1", name: "Q", weight: 100, type: "benefit" }], {});
+    const result = computeConsensus(d);
+
+    expect(result.rankings).toHaveLength(0);
+    expect(result.overallAgreement).toBe(1);
+    expect(result.divergentOptions).toHaveLength(0);
+    expect(result.pairwiseCorrelations).toHaveLength(0);
+  });
+
+  it("gracefully handles a single option", () => {
+    const d = makeDecision(
+      [{ id: "a", name: "Alpha" }],
+      [{ id: "c1", name: "Q", weight: 100, type: "benefit" }],
+      { a: { c1: 8 } }
+    );
+    const result = computeConsensus(d);
+
+    expect(result.rankings).toHaveLength(1);
+    expect(result.rankings[0].consensusRank).toBe(1);
+    expect(result.overallAgreement).toBe(1);
+  });
+
+  it("works with a subset of algorithms", () => {
+    const result = computeConsensus(simpleDecision(), ["wsm", "topsis"]);
+
+    expect(result.algorithmCount).toBe(2);
+    expect(result.algorithmResults.length).toBe(2);
+    expect(result.pairwiseCorrelations.length).toBe(1);
+
+    // Each option should only have wsm and topsis ranks
+    for (const ranking of result.rankings) {
+      expect(ranking.algorithmRanks).toHaveProperty("wsm");
+      expect(ranking.algorithmRanks).toHaveProperty("topsis");
+    }
+  });
+
+  it("gracefully degrades with a single algorithm", () => {
+    const result = computeConsensus(simpleDecision(), ["wsm"]);
+
+    expect(result.algorithmCount).toBe(1);
+    expect(result.overallAgreement).toBe(1);
+    expect(result.pairwiseCorrelations.length).toBe(0);
+    expect(result.divergentOptions.length).toBe(0);
+    expect(result.rankings.length).toBe(3);
+  });
+
+  it("consensus ranks are 1-based and contiguous", () => {
+    const result = computeConsensus(simpleDecision());
+
+    const ranks = result.rankings.map((r) => r.consensusRank);
+    expect(Math.min(...ranks)).toBe(1);
+    // Not all ranks need to be unique (ties possible), but they should be >= 1
+    for (const rank of ranks) {
+      expect(rank).toBeGreaterThanOrEqual(1);
+      expect(rank).toBeLessThanOrEqual(result.rankings.length);
+    }
+  });
+
+  it("handles ties in Borda score by assigning same rank", () => {
+    // Directly test tie-handling: manually verify that if Borda scores happen
+    // to be equal, the consensus engine assigns the same rank.
+    // With identical single-criterion scores, algorithms may still break ties
+    // by array order, so to test rank-tie logic we verify the rank assignment
+    // invariant: options with equal Borda scores must share the same consensus rank.
+    const d = makeDecision(
+      [
+        { id: "a", name: "Alpha" },
+        { id: "b", name: "Beta" },
+      ],
+      [{ id: "c1", name: "Q", weight: 100, type: "benefit" }],
+      {
+        a: { c1: 7 },
+        b: { c1: 7 },
+      }
+    );
+    const result = computeConsensus(d);
+
+    // Verify the invariant: same Borda score → same consensus rank
+    const grouped = new Map<number, number[]>();
+    for (const r of result.rankings) {
+      const ranks = grouped.get(r.bordaScore) ?? [];
+      ranks.push(r.consensusRank);
+      grouped.set(r.bordaScore, ranks);
+    }
+    for (const [, ranks] of grouped) {
+      const unique = new Set(ranks);
+      expect(unique.size).toBe(1);
+    }
+  });
+
+  it("agreement scores are between 0 and 1", () => {
+    const result = computeConsensus(simpleDecision());
+
+    for (const ranking of result.rankings) {
+      expect(ranking.agreementScore).toBeGreaterThanOrEqual(0);
+      expect(ranking.agreementScore).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("agreement score is 1 when all algorithms agree on rank", () => {
+    const result = computeConsensus(dominantDecision());
+
+    // With only 2 options and a dominant option, all algorithms should agree
+    for (const ranking of result.rankings) {
+      expect(ranking.agreementScore).toBe(1);
+    }
+  });
+
+  it("returns correct algorithm IDs in results", () => {
+    const result = computeConsensus(simpleDecision());
+
+    const algoIds = result.algorithmResults.map((ar) => ar.algorithmId);
+    expect(algoIds).toContain("wsm");
+    expect(algoIds).toContain("topsis");
+    expect(algoIds).toContain("minimax-regret");
+  });
+
+  it("each algorithm result has rankings for all options", () => {
+    const decision = simpleDecision();
+    const result = computeConsensus(decision);
+
+    for (const ar of result.algorithmResults) {
+      expect(ar.rankings.length).toBe(decision.options.length);
+      const optionIds = ar.rankings.map((r) => r.optionId);
+      for (const opt of decision.options) {
+        expect(optionIds).toContain(opt.id);
+      }
+    }
+  });
+
+  it("uses custom divergence threshold", () => {
+    const d = simpleDecision();
+
+    // With threshold 1, more options may be divergent
+    const resultLow = computeConsensus(d, [...ALL_ALGORITHMS], 1);
+    // With threshold 100, no options should be divergent
+    const resultHigh = computeConsensus(d, [...ALL_ALGORITHMS], 100);
+
+    expect(resultHigh.divergentOptions.length).toBe(0);
+    expect(resultLow.divergentOptions.length).toBeGreaterThanOrEqual(
+      resultHigh.divergentOptions.length
+    );
+  });
+
+  it("overallAgreement reflects inter-algorithm concordance", () => {
+    // Perfect agreement: dominant option
+    const dominant = computeConsensus(dominantDecision());
+    // Potential disagreement: conflicting criteria
+    const conflicting = computeConsensus(
+      makeDecision(
+        [
+          { id: "a", name: "A" },
+          { id: "b", name: "B" },
+          { id: "c", name: "C" },
+          { id: "d", name: "D" },
+        ],
+        [
+          { id: "c1", name: "Q", weight: 50, type: "benefit" },
+          { id: "c2", name: "Cost", weight: 50, type: "cost" },
+        ],
+        {
+          a: { c1: 10, c2: 10 }, // Best quality, worst cost
+          b: { c1: 1, c2: 1 }, // Worst quality, best cost
+          c: { c1: 7, c2: 5 },
+          d: { c1: 4, c2: 7 },
+        }
+      )
+    );
+
+    expect(dominant.overallAgreement).toBeGreaterThanOrEqual(conflicting.overallAgreement);
+  });
+});
+
+// ---------------------------------------------------------------------------
+//  Module exports
+// ---------------------------------------------------------------------------
+
+describe("module exports", () => {
+  it("exports ALL_ALGORITHMS with 3 entries", () => {
+    expect(ALL_ALGORITHMS).toHaveLength(3);
+    expect(ALL_ALGORITHMS).toContain("wsm");
+    expect(ALL_ALGORITHMS).toContain("topsis");
+    expect(ALL_ALGORITHMS).toContain("minimax-regret");
+  });
+});

--- a/src/lib/consensus.ts
+++ b/src/lib/consensus.ts
@@ -1,0 +1,386 @@
+/**
+ * Multi-Algorithm Consensus Engine
+ *
+ * Runs multiple MCDA algorithms (WSM, TOPSIS, Minimax Regret) on a Decision
+ * and produces a unified consensus ranking using Borda count with formal
+ * agreement measurement via Kendall's W coefficient of concordance.
+ *
+ * Key concepts:
+ *   - **Borda Count**: Each algorithm awards (n − rank) points per option.
+ *     Summed across algorithms to produce a consensus ranking.
+ *   - **Kendall's W** (coefficient of concordance): Measures agreement among
+ *     multiple rankers (0 = no agreement, 1 = perfect agreement).
+ *   - **Divergent Options**: Options where the rank spread across algorithms
+ *     exceeds a threshold (default: 2), indicating algorithmic disagreement.
+ *
+ * @see Kendall, M.G. & Smith, B.B. (1939). The Problem of m Rankings.
+ * @see Borda, J.-C. de (1781). Mémoire sur les élections au scrutin.
+ */
+
+import type { Decision, DecisionResults, OptionResult } from "./types";
+import { computeResults } from "./scoring";
+import { computeTopsisResults, type TopsisResults, type TopsisOptionResult } from "./topsis";
+import { computeRegretResults, type RegretResults, type RegretOptionResult } from "./regret";
+
+// ---------------------------------------------------------------------------
+//  Algorithm identifiers
+// ---------------------------------------------------------------------------
+
+/** Supported algorithms for consensus computation. */
+export type AlgorithmId = "wsm" | "topsis" | "minimax-regret";
+
+/** All available algorithms. */
+export const ALL_ALGORITHMS: readonly AlgorithmId[] = ["wsm", "topsis", "minimax-regret"] as const;
+
+// ---------------------------------------------------------------------------
+//  Types
+// ---------------------------------------------------------------------------
+
+/** Ranking produced by an individual algorithm. */
+export interface AlgorithmResult {
+  algorithmId: AlgorithmId;
+  /** Per-option ranking data, sorted by rank ascending. */
+  rankings: AlgorithmRanking[];
+}
+
+/** Single option's position within an algorithm's result. */
+export interface AlgorithmRanking {
+  optionId: string;
+  /** 1-based rank produced by this algorithm. */
+  rank: number;
+  /** Algorithm-specific score (WSM total, TOPSIS closeness, regret maxRegret). */
+  score: number;
+}
+
+/** A single option's consensus ranking entry. */
+export interface ConsensusRanking {
+  optionId: string;
+  optionName: string;
+  /** 1-based consensus rank derived from Borda count. */
+  consensusRank: number;
+  /** Borda score: sum of (n − rank) across all algorithms. 0-based, higher = better. */
+  bordaScore: number;
+  /** Per-algorithm agreement: 0 (high disagreement) to 1 (perfect agreement).
+   *  Defined as 1 − (rankSpread / (n − 1)) where n = number of options. */
+  agreementScore: number;
+  /** Individual ranks from each algorithm, keyed by AlgorithmId. */
+  algorithmRanks: Record<AlgorithmId, number>;
+}
+
+/** Full result of the consensus engine. */
+export interface ConsensusResult {
+  /** Options ranked by consensus (Borda count), ascending by consensusRank. */
+  rankings: ConsensusRanking[];
+  /** Per-algorithm detailed results. */
+  algorithmResults: AlgorithmResult[];
+  /** Kendall's W coefficient of concordance: 0 (no agreement) to 1 (perfect). */
+  overallAgreement: number;
+  /** Option IDs where algorithms disagree significantly (rank spread >= divergenceThreshold). */
+  divergentOptions: string[];
+  /** Pairwise Spearman rank correlations between algorithms (mapped to [0,1]). */
+  pairwiseCorrelations: PairwiseCorrelation[];
+  /** How many algorithms participated. */
+  algorithmCount: number;
+}
+
+/** Pairwise correlation between two algorithms. */
+export interface PairwiseCorrelation {
+  algorithmA: AlgorithmId;
+  algorithmB: AlgorithmId;
+  /** Spearman ρ mapped to [0,1]: 0 = perfect disagreement, 1 = perfect agreement. */
+  correlation: number;
+}
+
+// ---------------------------------------------------------------------------
+//  Kendall's W
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute Kendall's W coefficient of concordance.
+ *
+ * Given m rankers (algorithms) each producing a ranking of n objects (options),
+ * W measures the degree of agreement among the rankers.
+ *
+ *   W = 12 S / (m² (n³ − n))
+ *
+ * where S = Σᵢ(Rᵢ − R̄)² and Rᵢ is the sum of ranks for option i across
+ * all algorithms.
+ *
+ * @param rankMatrix - m×n matrix: rankMatrix[rankerIdx][objectIdx] = rank (1-based).
+ * @returns W ∈ [0, 1]. Returns 1 for trivial cases (n ≤ 1 or m ≤ 1).
+ */
+export function kendallW(rankMatrix: number[][]): number {
+  const m = rankMatrix.length; // number of rankers (algorithms)
+  if (m <= 1) return 1;
+
+  const n = rankMatrix[0]?.length ?? 0; // number of objects (options)
+  if (n <= 1) return 1;
+
+  // Compute rank sums per object
+  const rankSums: number[] = new Array(n).fill(0);
+  for (let j = 0; j < n; j++) {
+    for (let i = 0; i < m; i++) {
+      rankSums[j] += rankMatrix[i][j];
+    }
+  }
+
+  // Mean rank sum
+  const meanRankSum = rankSums.reduce((a, b) => a + b, 0) / n;
+
+  // S = sum of squared deviations from the mean
+  const S = rankSums.reduce((acc, rs) => acc + (rs - meanRankSum) ** 2, 0);
+
+  // W = 12S / (m²(n³ − n))
+  const denominator = m * m * (n * n * n - n);
+  if (denominator === 0) return 1;
+
+  const W = (12 * S) / denominator;
+
+  // Clamp to [0, 1] to handle floating point
+  return Math.min(1, Math.max(0, W));
+}
+
+// ---------------------------------------------------------------------------
+//  Spearman Rank Correlation
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute Spearman's ρ between two rank vectors and map to [0, 1].
+ *
+ * ρ = 1 − (6 Σ dᵢ²) / (n(n²−1))
+ * Mapped: (ρ + 1) / 2  →  0 = perfect disagreement, 1 = perfect agreement
+ *
+ * @param ranksA - 1-based ranks for ranker A, indexed by object.
+ * @param ranksB - 1-based ranks for ranker B, indexed by object.
+ * @returns Mapped correlation ∈ [0, 1]. Returns 1 for trivial cases.
+ */
+export function spearmanCorrelation(ranksA: number[], ranksB: number[]): number {
+  const n = ranksA.length;
+  if (n <= 1) return 1;
+  if (ranksA.length !== ranksB.length) {
+    throw new Error("Rank vectors must have equal length");
+  }
+
+  let sumD2 = 0;
+  for (let i = 0; i < n; i++) {
+    const d = ranksA[i] - ranksB[i];
+    sumD2 += d * d;
+  }
+
+  const rho = 1 - (6 * sumD2) / (n * (n * n - 1));
+
+  // Map [-1, 1] → [0, 1]
+  return Math.min(1, Math.max(0, (rho + 1) / 2));
+}
+
+// ---------------------------------------------------------------------------
+//  Borda Count
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute Borda scores from multiple rank vectors.
+ *
+ * Each ranker awards (n − rank) points per object. Summed across rankers.
+ *
+ * @param rankMatrix - m×n matrix of 1-based ranks.
+ * @param n - number of objects.
+ * @returns Array of Borda scores indexed by object.
+ */
+function bordaScores(rankMatrix: number[][], n: number): number[] {
+  const scores = new Array(n).fill(0);
+  for (const rankerRanks of rankMatrix) {
+    for (let j = 0; j < n; j++) {
+      scores[j] += n - rankerRanks[j]; // (n − rank), higher = better
+    }
+  }
+  return scores;
+}
+
+// ---------------------------------------------------------------------------
+//  Algorithm Runners
+// ---------------------------------------------------------------------------
+
+function runWSM(decision: Decision): AlgorithmResult {
+  const results: DecisionResults = computeResults(decision);
+  return {
+    algorithmId: "wsm",
+    rankings: results.optionResults.map((r: OptionResult) => ({
+      optionId: r.optionId,
+      rank: r.rank,
+      score: r.totalScore,
+    })),
+  };
+}
+
+function runTopsis(decision: Decision): AlgorithmResult {
+  const results: TopsisResults = computeTopsisResults(decision);
+  return {
+    algorithmId: "topsis",
+    rankings: results.rankings.map((r: TopsisOptionResult) => ({
+      optionId: r.optionId,
+      rank: r.rank,
+      score: r.closenessCoefficient,
+    })),
+  };
+}
+
+function runRegret(decision: Decision): AlgorithmResult {
+  const results: RegretResults = computeRegretResults(decision);
+  return {
+    algorithmId: "minimax-regret",
+    rankings: results.rankings.map((r: RegretOptionResult) => ({
+      optionId: r.optionId,
+      rank: r.rank,
+      // Negate maxRegret so higher = better (consistent with other algos)
+      score: -r.maxRegret,
+    })),
+  };
+}
+
+const RUNNERS: Record<AlgorithmId, (d: Decision) => AlgorithmResult> = {
+  wsm: runWSM,
+  topsis: runTopsis,
+  "minimax-regret": runRegret,
+};
+
+// ---------------------------------------------------------------------------
+//  Core: computeConsensus
+// ---------------------------------------------------------------------------
+
+/** Threshold: rank spread >= this marks an option as divergent. */
+const DEFAULT_DIVERGENCE_THRESHOLD = 2;
+
+/**
+ * Run multiple algorithms on a decision and produce a unified consensus ranking.
+ *
+ * @param decision - The decision to analyze.
+ * @param algorithms - Which algorithms to run. Defaults to all three.
+ * @param divergenceThreshold - Rank spread threshold for divergent options (default: 2).
+ * @returns Full consensus result with Borda count, Kendall's W, and pairwise correlations.
+ */
+export function computeConsensus(
+  decision: Decision,
+  algorithms: AlgorithmId[] = [...ALL_ALGORITHMS],
+  divergenceThreshold: number = DEFAULT_DIVERGENCE_THRESHOLD
+): ConsensusResult {
+  const n = decision.options.length;
+
+  // Graceful degradation: no options
+  if (n === 0) {
+    return {
+      rankings: [],
+      algorithmResults: [],
+      overallAgreement: 1,
+      divergentOptions: [],
+      pairwiseCorrelations: [],
+      algorithmCount: algorithms.length,
+    };
+  }
+
+  // Graceful degradation: single algorithm
+  const effectiveAlgorithms = algorithms.length === 0 ? [...ALL_ALGORITHMS] : algorithms;
+
+  // Run each algorithm
+  const algorithmResults: AlgorithmResult[] = effectiveAlgorithms.map((algoId) => {
+    const runner = RUNNERS[algoId];
+    if (!runner) {
+      throw new Error(`Unknown algorithm: ${algoId}`);
+    }
+    return runner(decision);
+  });
+
+  // Build stable option ordering based on decision.options
+  const optionIds = decision.options.map((o) => o.id);
+  const optionNames = new Map(decision.options.map((o) => [o.id, o.name]));
+  const optionIndex = new Map(optionIds.map((id, i) => [id, i]));
+
+  // Build rank matrix: algorithmResults[m][n] → rank for option n by algorithm m
+  const m = algorithmResults.length;
+  const rankMatrix: number[][] = algorithmResults.map((ar) => {
+    const ranks = new Array(n).fill(n); // default to last rank
+    for (const r of ar.rankings) {
+      const idx = optionIndex.get(r.optionId);
+      if (idx !== undefined) {
+        ranks[idx] = r.rank;
+      }
+    }
+    return ranks;
+  });
+
+  // Compute Borda scores
+  const borda = bordaScores(rankMatrix, n);
+
+  // Build per-option algorithm rank map
+  const perOptionRanks: Record<string, Record<AlgorithmId, number>> = {};
+  for (const optId of optionIds) {
+    const idx = optionIndex.get(optId)!;
+    const ranks: Record<string, number> = {};
+    for (let a = 0; a < m; a++) {
+      ranks[effectiveAlgorithms[a]] = rankMatrix[a][idx];
+    }
+    perOptionRanks[optId] = ranks as Record<AlgorithmId, number>;
+  }
+
+  // Rank by Borda score (descending), break ties by original order
+  const bordaRanked = optionIds
+    .map((id, i) => ({ id, bordaScore: borda[i] }))
+    .sort((a, b) => b.bordaScore - a.bordaScore);
+
+  // Assign 1-based consensus ranks (handle ties: same Borda score → same rank)
+  const consensusRankMap = new Map<string, number>();
+  let currentRank = 1;
+  for (let i = 0; i < bordaRanked.length; i++) {
+    if (i > 0 && bordaRanked[i].bordaScore < bordaRanked[i - 1].bordaScore) {
+      currentRank = i + 1;
+    }
+    consensusRankMap.set(bordaRanked[i].id, currentRank);
+  }
+
+  // Compute per-option agreement score: 1 − (rankSpread / (n − 1))
+  const divergentOptions: string[] = [];
+  const rankings: ConsensusRanking[] = bordaRanked.map(({ id, bordaScore }) => {
+    const ranks = perOptionRanks[id];
+    const rankValues = Object.values(ranks);
+    const rankSpread =
+      rankValues.length > 0 ? Math.max(...rankValues) - Math.min(...rankValues) : 0;
+
+    const agreementScore = n > 1 ? Math.max(0, 1 - rankSpread / (n - 1)) : 1;
+
+    if (rankSpread >= divergenceThreshold) {
+      divergentOptions.push(id);
+    }
+
+    return {
+      optionId: id,
+      optionName: optionNames.get(id) ?? id,
+      consensusRank: consensusRankMap.get(id)!,
+      bordaScore,
+      agreementScore,
+      algorithmRanks: ranks,
+    };
+  });
+
+  // Kendall's W
+  const overallAgreement = kendallW(rankMatrix);
+
+  // Pairwise Spearman correlations
+  const pairwiseCorrelations: PairwiseCorrelation[] = [];
+  for (let a = 0; a < m; a++) {
+    for (let b = a + 1; b < m; b++) {
+      pairwiseCorrelations.push({
+        algorithmA: effectiveAlgorithms[a],
+        algorithmB: effectiveAlgorithms[b],
+        correlation: spearmanCorrelation(rankMatrix[a], rankMatrix[b]),
+      });
+    }
+  }
+
+  return {
+    rankings,
+    algorithmResults,
+    overallAgreement,
+    divergentOptions,
+    pairwiseCorrelations,
+    algorithmCount: m,
+  };
+}


### PR DESCRIPTION
## Summary

Adds a multi-algorithm consensus engine that runs WSM, TOPSIS, and Minimax Regret algorithms on a decision and produces a unified consensus ranking using formal statistical methods.

## Changes

### New: `src/lib/consensus.ts`
- **`kendallW(rankMatrix)`** — Kendall's W coefficient of concordance measuring inter-algorithm agreement (0 = no agreement, 1 = perfect)
- **`spearmanCorrelation(ranksA, ranksB)`** — Pairwise Spearman ρ mapped to [0,1] for algorithm comparison
- **`computeConsensus(decision, algorithms?, divergenceThreshold?)`** — Core engine that:
  - Runs selected algorithms (default: all three)
  - Computes Borda count consensus ranking (higher = better)
  - Handles rank ties (same Borda score → same consensus rank)
  - Computes per-option agreement scores based on rank spread
  - Identifies divergent options where algorithms disagree significantly
  - Returns pairwise correlations between all algorithm pairs

### New: `src/__tests__/consensus.test.ts`
- 33 tests covering:
  - Kendall's W: perfect agreement, total disagreement, partial agreement, edge cases
  - Spearman correlation: identical, reversed, partial, single element, error handling
  - `computeConsensus`: full integration with real algorithm outputs, Borda score correctness, divergent option detection, subset algorithms, single algorithm, empty/single option, ties, custom thresholds

## Types Exported
- `AlgorithmId`, `AlgorithmResult`, `AlgorithmRanking`
- `ConsensusRanking`, `ConsensusResult`, `PairwiseCorrelation`
- `ALL_ALGORITHMS`

## Test Results
- 33 new tests, all passing
- 896 total tests passing (4 pre-existing visual screenshot failures)

Closes #116
