### PR TITLE
feat(confidence): add composite confidence model unifying all signals

### DIFF
--- a/src/__tests__/components/CompositeConfidence.test.tsx
+++ b/src/__tests__/components/CompositeConfidence.test.tsx
@@ -1,0 +1,342 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  computeCompositeConfidence,
+  computeScoreConfidence,
+  computeStructuralQuality,
+  classifyLevel,
+  DEFAULT_WEIGHTS,
+  type ConfidenceWeights,
+} from "@/lib/composite-confidence";
+import { assessDecisionQuality } from "@/lib/decision-quality";
+import { computeConsensus } from "@/lib/consensus";
+import { computeResults } from "@/lib/scoring";
+import { computeTopsisResults } from "@/lib/topsis";
+import { computeRegretResults } from "@/lib/regret";
+import { CompositeConfidenceIndicator } from "@/components/CompositeConfidenceIndicator";
+import type { Decision } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+//  Helpers
+// ---------------------------------------------------------------------------
+
+function makeDecision(
+  options: { id: string; name: string }[],
+  criteria: {
+    id: string;
+    name: string;
+    weight: number;
+    type: "benefit" | "cost";
+  }[],
+  scores: Record<
+    string,
+    Record<string, number | { value: number; confidence: "high" | "medium" | "low" }>
+  >
+): Decision {
+  return {
+    id: "test",
+    title: "Test",
+    options,
+    criteria,
+    scores,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function simpleDecision(): Decision {
+  return makeDecision(
+    [
+      { id: "a", name: "Alpha" },
+      { id: "b", name: "Beta" },
+      { id: "c", name: "Gamma" },
+    ],
+    [
+      { id: "c1", name: "Quality", weight: 60, type: "benefit" },
+      { id: "c2", name: "Speed", weight: 40, type: "benefit" },
+    ],
+    {
+      a: { c1: 9, c2: 5 },
+      b: { c1: 6, c2: 8 },
+      c: { c1: 4, c2: 3 },
+    }
+  );
+}
+
+function lowConfidenceDecision(): Decision {
+  return makeDecision(
+    [
+      { id: "a", name: "Alpha" },
+      { id: "b", name: "Beta" },
+    ],
+    [{ id: "c1", name: "Q", weight: 100, type: "benefit" }],
+    {
+      a: { c1: { value: 7, confidence: "low" } },
+      b: { c1: { value: 5, confidence: "low" } },
+    }
+  );
+}
+
+function mixedConfidenceDecision(): Decision {
+  return makeDecision(
+    [
+      { id: "a", name: "Alpha" },
+      { id: "b", name: "Beta" },
+    ],
+    [
+      { id: "c1", name: "Q", weight: 50, type: "benefit" },
+      { id: "c2", name: "S", weight: 50, type: "benefit" },
+    ],
+    {
+      a: { c1: { value: 9, confidence: "high" }, c2: { value: 5, confidence: "low" } },
+      b: { c1: { value: 6, confidence: "medium" }, c2: { value: 8, confidence: "high" } },
+    }
+  );
+}
+
+function dominantDecision(): Decision {
+  return makeDecision(
+    [
+      { id: "a", name: "Alpha" },
+      { id: "b", name: "Beta" },
+      { id: "c", name: "Gamma" },
+    ],
+    [
+      { id: "c1", name: "Quality", weight: 50, type: "benefit" },
+      { id: "c2", name: "Speed", weight: 50, type: "benefit" },
+    ],
+    {
+      a: { c1: 10, c2: 10 },
+      b: { c1: 5, c2: 5 },
+      c: { c1: 2, c2: 2 },
+    }
+  );
+}
+
+// ---------------------------------------------------------------------------
+//  Unit tests — computeScoreConfidence
+// ---------------------------------------------------------------------------
+
+describe("computeScoreConfidence", () => {
+  it("returns 1.0 for all plain numeric scores (implicit high)", () => {
+    expect(computeScoreConfidence(simpleDecision())).toBe(1.0);
+  });
+
+  it("returns 0.4 for all low-confidence scores", () => {
+    expect(computeScoreConfidence(lowConfidenceDecision())).toBeCloseTo(0.4, 5);
+  });
+
+  it("returns a value between 0.4 and 1.0 for mixed confidence", () => {
+    const conf = computeScoreConfidence(mixedConfidenceDecision());
+    expect(conf).toBeGreaterThan(0.4);
+    expect(conf).toBeLessThan(1.0);
+  });
+
+  it("returns 1.0 for decision with no scores", () => {
+    const d = makeDecision(
+      [{ id: "a", name: "A" }],
+      [{ id: "c1", name: "Q", weight: 100, type: "benefit" }],
+      {}
+    );
+    expect(computeScoreConfidence(d)).toBe(1.0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+//  Unit tests — computeStructuralQuality
+// ---------------------------------------------------------------------------
+
+describe("computeStructuralQuality", () => {
+  it("maps quality overall score to 0–1", () => {
+    const quality = assessDecisionQuality(simpleDecision());
+    const result = computeStructuralQuality(quality);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(1);
+  });
+
+  it("returns 1 for a perfect quality score", () => {
+    expect(computeStructuralQuality({ indicators: [], overallScore: 100 })).toBe(1);
+  });
+
+  it("returns 0 for zero quality score", () => {
+    expect(computeStructuralQuality({ indicators: [], overallScore: 0 })).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+//  Unit tests — classifyLevel
+// ---------------------------------------------------------------------------
+
+describe("classifyLevel", () => {
+  it("classifies >= 0.7 as high", () => {
+    expect(classifyLevel(0.7)).toBe("high");
+    expect(classifyLevel(1.0)).toBe("high");
+  });
+
+  it("classifies 0.4–0.69 as moderate", () => {
+    expect(classifyLevel(0.4)).toBe("moderate");
+    expect(classifyLevel(0.69)).toBe("moderate");
+  });
+
+  it("classifies < 0.4 as low", () => {
+    expect(classifyLevel(0.39)).toBe("low");
+    expect(classifyLevel(0)).toBe("low");
+  });
+});
+
+// ---------------------------------------------------------------------------
+//  Unit tests — computeCompositeConfidence
+// ---------------------------------------------------------------------------
+
+describe("computeCompositeConfidence", () => {
+  it("returns a result with composite between 0 and 1", () => {
+    const result = computeCompositeConfidence(simpleDecision());
+    expect(result.breakdown.composite).toBeGreaterThanOrEqual(0);
+    expect(result.breakdown.composite).toBeLessThanOrEqual(1);
+  });
+
+  it("uses DEFAULT_WEIGHTS when none provided", () => {
+    const result = computeCompositeConfidence(simpleDecision());
+    expect(result.weights).toEqual(DEFAULT_WEIGHTS);
+  });
+
+  it("accepts custom weights", () => {
+    const custom: ConfidenceWeights = {
+      algorithmAgreement: 0.25,
+      scoreConfidence: 0.25,
+      dataConfidence: 0.25,
+      structuralQuality: 0.25,
+    };
+    const result = computeCompositeConfidence(simpleDecision(), null, null, 0, custom);
+    expect(result.weights).toEqual(custom);
+  });
+
+  it("uses provided consensus result instead of recomputing", () => {
+    const consensus = computeConsensus(simpleDecision());
+    const result = computeCompositeConfidence(simpleDecision(), consensus);
+    expect(result.breakdown.algorithmAgreement).toBe(consensus.overallAgreement);
+  });
+
+  it("produces high level for dominant decision", () => {
+    const result = computeCompositeConfidence(dominantDecision());
+    // Dominant: agreement = 1.0, scores all numeric (1.0 confidence)
+    expect(result.level).toBe("high");
+  });
+
+  it("includes a label and suggestion", () => {
+    const result = computeCompositeConfidence(simpleDecision());
+    expect(result.label.length).toBeGreaterThan(5);
+    expect(result.suggestion.length).toBeGreaterThan(5);
+  });
+
+  it("data confidence defaults to 0 when not provided", () => {
+    const result = computeCompositeConfidence(simpleDecision());
+    expect(result.breakdown.dataConfidence).toBe(0);
+  });
+
+  it("includes data confidence when provided", () => {
+    const result = computeCompositeConfidence(simpleDecision(), null, null, 0.8);
+    expect(result.breakdown.dataConfidence).toBe(0.8);
+    // Composite should be higher with data confidence
+    const resultNoData = computeCompositeConfidence(simpleDecision(), null, null, 0);
+    expect(result.breakdown.composite).toBeGreaterThan(resultNoData.breakdown.composite);
+  });
+
+  it("lower score confidence reduces composite", () => {
+    const highConf = computeCompositeConfidence(simpleDecision());
+    const lowConf = computeCompositeConfidence(lowConfidenceDecision());
+    expect(lowConf.breakdown.scoreConfidence).toBeLessThan(highConf.breakdown.scoreConfidence);
+  });
+
+  it("handles single-option decision gracefully", () => {
+    const d = makeDecision(
+      [{ id: "a", name: "Solo" }],
+      [{ id: "c1", name: "Q", weight: 100, type: "benefit" }],
+      { a: { c1: 8 } }
+    );
+    const result = computeCompositeConfidence(d);
+    expect(result.breakdown.composite).toBeGreaterThanOrEqual(0);
+    expect(result.breakdown.composite).toBeLessThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+//  Component tests — CompositeConfidenceIndicator
+// ---------------------------------------------------------------------------
+
+describe("CompositeConfidenceIndicator — component", () => {
+  it("renders the confidence indicator", () => {
+    render(<CompositeConfidenceIndicator decision={simpleDecision()} />);
+    expect(screen.getByTestId("composite-confidence")).toBeDefined();
+  });
+
+  it("shows confidence label", () => {
+    render(<CompositeConfidenceIndicator decision={simpleDecision()} />);
+    const label = screen.getByTestId("confidence-label");
+    expect(label).toBeDefined();
+    expect(label.textContent!.length).toBeGreaterThan(5);
+  });
+
+  it("shows confidence score as percentage", () => {
+    render(<CompositeConfidenceIndicator decision={simpleDecision()} />);
+    const score = screen.getByTestId("confidence-score");
+    expect(score).toBeDefined();
+    expect(score.textContent).toMatch(/\d+%/);
+  });
+
+  it("shows suggestion text", () => {
+    render(<CompositeConfidenceIndicator decision={simpleDecision()} />);
+    const suggestion = screen.getByTestId("confidence-suggestion");
+    expect(suggestion).toBeDefined();
+    expect(suggestion.textContent!.length).toBeGreaterThan(10);
+  });
+
+  it("toggles breakdown details", async () => {
+    const user = userEvent.setup();
+    render(<CompositeConfidenceIndicator decision={simpleDecision()} />);
+
+    // Initially hidden
+    expect(screen.queryByTestId("confidence-breakdown")).toBeNull();
+
+    // Show
+    await user.click(screen.getByTestId("toggle-breakdown"));
+    const breakdown = screen.getByTestId("confidence-breakdown");
+    expect(breakdown).toBeDefined();
+
+    // Should show all 4 signals
+    expect(breakdown.textContent).toContain("Algorithm agreement");
+    expect(breakdown.textContent).toContain("Score confidence");
+    expect(breakdown.textContent).toContain("Data confidence");
+    expect(breakdown.textContent).toContain("Structural quality");
+
+    // Has progress bars
+    const progressBars = within(breakdown).getAllByRole("progressbar");
+    expect(progressBars.length).toBe(4);
+
+    // Hide
+    await user.click(screen.getByTestId("toggle-breakdown"));
+    expect(screen.queryByTestId("confidence-breakdown")).toBeNull();
+  });
+
+  it("uses pre-computed consensus when provided", () => {
+    const d = simpleDecision();
+    const consensus = computeConsensus(d);
+    render(<CompositeConfidenceIndicator decision={d} consensus={consensus} />);
+    expect(screen.getByTestId("composite-confidence")).toBeDefined();
+  });
+
+  it("renders different styles for high vs low confidence", () => {
+    const { unmount } = render(<CompositeConfidenceIndicator decision={dominantDecision()} />);
+    const highContainer = screen.getByTestId("composite-confidence");
+    const highClasses = highContainer.className;
+    unmount();
+
+    render(<CompositeConfidenceIndicator decision={lowConfidenceDecision()} />);
+    const lowContainer = screen.getByTestId("composite-confidence");
+    const lowClasses = lowContainer.className;
+
+    // Classes should differ (different border/bg colors)
+    expect(highClasses).not.toBe(lowClasses);
+  });
+});

--- a/src/components/CompositeConfidenceIndicator.tsx
+++ b/src/components/CompositeConfidenceIndicator.tsx
@@ -1,0 +1,172 @@
+/**
+ * CompositeConfidenceIndicator — traffic-light indicator with expandable breakdown.
+ *
+ * Shows the composite confidence level (high/moderate/low) with a colored badge
+ * and an expandable section showing individual signal contributions.
+ *
+ * @see https://github.com/ericsocrat/decision-os/issues/118
+ */
+
+"use client";
+
+import { useMemo, useState } from "react";
+import type { Decision } from "@/lib/types";
+import {
+  computeCompositeConfidence,
+  type CompositeConfidenceResult,
+} from "@/lib/composite-confidence";
+import type { ConsensusResult } from "@/lib/consensus";
+import type { QualityAssessment } from "@/lib/decision-quality";
+
+// ---------------------------------------------------------------------------
+//  Styling
+// ---------------------------------------------------------------------------
+
+const LEVEL_STYLES = {
+  high: {
+    bg: "bg-green-50 dark:bg-green-900/20",
+    border: "border-green-200 dark:border-green-800",
+    text: "text-green-700 dark:text-green-300",
+    badge: "bg-green-100 dark:bg-green-900/40 text-green-800 dark:text-green-200",
+    dot: "bg-green-500",
+  },
+  moderate: {
+    bg: "bg-yellow-50 dark:bg-yellow-900/20",
+    border: "border-yellow-200 dark:border-yellow-800",
+    text: "text-yellow-700 dark:text-yellow-300",
+    badge: "bg-yellow-100 dark:bg-yellow-900/40 text-yellow-800 dark:text-yellow-200",
+    dot: "bg-yellow-500",
+  },
+  low: {
+    bg: "bg-red-50 dark:bg-red-900/20",
+    border: "border-red-200 dark:border-red-800",
+    text: "text-red-700 dark:text-red-300",
+    badge: "bg-red-100 dark:bg-red-900/40 text-red-800 dark:text-red-200",
+    dot: "bg-red-500",
+  },
+};
+
+// ---------------------------------------------------------------------------
+//  Signal display config
+// ---------------------------------------------------------------------------
+
+interface SignalConfig {
+  key: keyof Omit<import("@/lib/composite-confidence").ConfidenceBreakdown, "composite">;
+  label: string;
+  weightKey: keyof import("@/lib/composite-confidence").ConfidenceWeights;
+}
+
+const SIGNAL_CONFIGS: SignalConfig[] = [
+  { key: "algorithmAgreement", label: "Algorithm agreement", weightKey: "algorithmAgreement" },
+  { key: "scoreConfidence", label: "Score confidence", weightKey: "scoreConfidence" },
+  { key: "dataConfidence", label: "Data confidence", weightKey: "dataConfidence" },
+  { key: "structuralQuality", label: "Structural quality", weightKey: "structuralQuality" },
+];
+
+// ---------------------------------------------------------------------------
+//  Component
+// ---------------------------------------------------------------------------
+
+interface CompositeConfidenceIndicatorProps {
+  decision: Decision;
+  consensus?: ConsensusResult | null;
+  quality?: QualityAssessment | null;
+}
+
+export function CompositeConfidenceIndicator({
+  decision,
+  consensus,
+  quality,
+}: CompositeConfidenceIndicatorProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const result = useMemo(
+    (): CompositeConfidenceResult => computeCompositeConfidence(decision, consensus, quality),
+    [decision, consensus, quality]
+  );
+
+  const style = LEVEL_STYLES[result.level];
+
+  return (
+    <div
+      className={`rounded-lg border ${style.border} ${style.bg} px-4 py-3`}
+      data-testid="composite-confidence"
+    >
+      {/* Header row */}
+      <div className="flex flex-wrap items-center gap-3">
+        {/* Traffic light dot */}
+        <span className={`inline-block w-3 h-3 rounded-full ${style.dot}`} aria-hidden="true" />
+
+        {/* Label */}
+        <span className={`text-sm font-semibold ${style.text}`} data-testid="confidence-label">
+          {result.label}
+        </span>
+
+        {/* Score badge */}
+        <span
+          className={`text-xs px-2 py-0.5 rounded-full font-medium ${style.badge}`}
+          data-testid="confidence-score"
+        >
+          {(result.breakdown.composite * 100).toFixed(0)}%
+        </span>
+
+        {/* Toggle breakdown */}
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className={`text-xs ${style.text} hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 rounded ml-auto`}
+          aria-expanded={expanded}
+          data-testid="toggle-breakdown"
+        >
+          {expanded ? "Hide details" : "Show details"}
+        </button>
+      </div>
+
+      {/* Suggestion */}
+      <p className={`text-xs mt-1 ${style.text} opacity-80`} data-testid="confidence-suggestion">
+        {result.suggestion}
+      </p>
+
+      {/* Expanded breakdown */}
+      {expanded && (
+        <div className="mt-3 space-y-2" data-testid="confidence-breakdown">
+          {SIGNAL_CONFIGS.map((signal) => {
+            const value = result.breakdown[signal.key];
+            const weight = result.weights[signal.weightKey];
+            const barPct = Math.round(value * 100);
+            const barColor =
+              value >= 0.7
+                ? "bg-green-400 dark:bg-green-600"
+                : value >= 0.4
+                  ? "bg-yellow-400 dark:bg-yellow-600"
+                  : "bg-red-400 dark:bg-red-600";
+
+            return (
+              <div key={signal.key}>
+                <div className="flex items-center justify-between text-xs mb-0.5">
+                  <span className="text-gray-600 dark:text-gray-400">
+                    {signal.label}{" "}
+                    <span className="text-gray-400 dark:text-gray-500">
+                      ({(weight * 100).toFixed(0)}%)
+                    </span>
+                  </span>
+                  <span className="font-medium text-gray-700 dark:text-gray-300">{barPct}%</span>
+                </div>
+                <div className="h-1.5 rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden">
+                  <div
+                    className={`h-full rounded-full ${barColor} transition-all`}
+                    style={{ width: `${barPct}%` }}
+                    role="progressbar"
+                    aria-valuenow={barPct}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-label={`${signal.label}: ${barPct}%`}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ResultsView.tsx
+++ b/src/components/ResultsView.tsx
@@ -33,6 +33,7 @@ import { QualityBar } from "./QualityBar";
 import { ConfidenceStrategySelector } from "./ConfidenceStrategySelector";
 import { WhatIfPanel } from "./WhatIfPanel";
 import { FrameworkComparison } from "./FrameworkComparison";
+import { CompositeConfidenceIndicator } from "./CompositeConfidenceIndicator";
 
 const ScoreChart = lazy(() => import("./ScoreChart").then((m) => ({ default: m.ScoreChart })));
 const ParetoChart = lazy(() => import("./ParetoChart").then((m) => ({ default: m.ParetoChart })));
@@ -169,6 +170,9 @@ export function ResultsView({ validation, completeness, onSwitchToBuilder }: Res
     <div className="space-y-6">
       {/* Decision quality dashboard */}
       <QualityBar decision={decision} />
+
+      {/* Composite confidence indicator */}
+      <CompositeConfidenceIndicator decision={decision} />
 
       {/* Confidence adjustment strategy */}
       <ConfidenceStrategySelector

--- a/src/lib/composite-confidence.ts
+++ b/src/lib/composite-confidence.ts
@@ -1,0 +1,231 @@
+/**
+ * Composite Confidence Model
+ *
+ * Unifies four confidence signals into a single actionable metric:
+ *   1. **Score confidence** — Average per-score confidence from user annotations
+ *   2. **Algorithm agreement** — Kendall's W from the consensus engine
+ *   3. **Structural quality** — Overall score from decision quality indicators
+ *   4. **Data confidence** — Average data tier confidence (placeholder for future enrichment)
+ *
+ * Default weights: algorithm agreement (40%) + score confidence (25%)
+ *   + data confidence (20%) + structural quality (15%).
+ *
+ * @see https://github.com/ericsocrat/decision-os/issues/118
+ */
+
+import type { Confidence, Decision } from "./types";
+import { resolveConfidence } from "./scoring";
+import { computeConsensus, type ConsensusResult } from "./consensus";
+import { assessDecisionQuality, type QualityAssessment } from "./decision-quality";
+
+// ---------------------------------------------------------------------------
+//  Types
+// ---------------------------------------------------------------------------
+
+/** Breakdown of each confidence signal contributing to the composite. */
+export interface ConfidenceBreakdown {
+  /** Average per-score confidence mapped to 0–1 (high=1, medium=0.7, low=0.4). */
+  scoreConfidence: number;
+  /** Kendall's W from multi-algorithm consensus (0–1). */
+  algorithmAgreement: number;
+  /** Decision quality overall score mapped to 0–1. */
+  structuralQuality: number;
+  /** Average data tier confidence (0–1). Defaults to 0 when no enrichment data is present. */
+  dataConfidence: number;
+  /** Weighted composite of all signals (0–1). */
+  composite: number;
+}
+
+/** Weights for each confidence signal component. Must sum to 1. */
+export interface ConfidenceWeights {
+  algorithmAgreement: number;
+  scoreConfidence: number;
+  dataConfidence: number;
+  structuralQuality: number;
+}
+
+/** Traffic-light confidence level derived from composite score. */
+export type ConfidenceLevel = "high" | "moderate" | "low";
+
+/** Full composite confidence result. */
+export interface CompositeConfidenceResult {
+  breakdown: ConfidenceBreakdown;
+  level: ConfidenceLevel;
+  label: string;
+  suggestion: string;
+  weights: ConfidenceWeights;
+}
+
+// ---------------------------------------------------------------------------
+//  Defaults
+// ---------------------------------------------------------------------------
+
+/** Default weights per the issue spec. */
+export const DEFAULT_WEIGHTS: ConfidenceWeights = {
+  algorithmAgreement: 0.4,
+  scoreConfidence: 0.25,
+  dataConfidence: 0.2,
+  structuralQuality: 0.15,
+};
+
+// ---------------------------------------------------------------------------
+//  Confidence mapping
+// ---------------------------------------------------------------------------
+
+const CONFIDENCE_TO_NUMERIC: Record<Confidence, number> = {
+  high: 1.0,
+  medium: 0.7,
+  low: 0.4,
+};
+
+// ---------------------------------------------------------------------------
+//  Signal computation
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute average score confidence from all score cells in a decision.
+ * Cells without explicit confidence default to "high" (1.0).
+ * Returns 1.0 if no scores exist.
+ */
+export function computeScoreConfidence(decision: Decision): number {
+  const scores = decision.scores;
+  if (!scores) return 1.0;
+
+  let total = 0;
+  let count = 0;
+
+  for (const optionId of Object.keys(scores)) {
+    const optionScores = scores[optionId];
+    if (!optionScores) continue;
+    for (const criterionId of Object.keys(optionScores)) {
+      const sv = optionScores[criterionId];
+      const confidence = resolveConfidence(sv);
+      total += confidence ? CONFIDENCE_TO_NUMERIC[confidence] : 1.0;
+      count++;
+    }
+  }
+
+  return count > 0 ? total / count : 1.0;
+}
+
+/**
+ * Derive structural quality signal from the quality assessment's overall score.
+ * Maps 0–100 to 0–1.
+ */
+export function computeStructuralQuality(quality: QualityAssessment): number {
+  return Math.min(1, Math.max(0, quality.overallScore / 100));
+}
+
+// ---------------------------------------------------------------------------
+//  Core: computeCompositeConfidence
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the composite confidence score unifying all available signals.
+ *
+ * @param decision — The decision to analyze.
+ * @param consensus — Pre-computed consensus result (optional; computed if omitted).
+ * @param quality — Pre-computed quality assessment (optional; computed if omitted).
+ * @param dataConfidence — External data confidence (0–1). Defaults to 0 when no enrichment.
+ * @param weights — Custom signal weights. Defaults to DEFAULT_WEIGHTS.
+ * @returns Full composite confidence result with breakdown and suggestions.
+ */
+export function computeCompositeConfidence(
+  decision: Decision,
+  consensus?: ConsensusResult | null,
+  quality?: QualityAssessment | null,
+  dataConfidence: number = 0,
+  weights: ConfidenceWeights = DEFAULT_WEIGHTS
+): CompositeConfidenceResult {
+  // Compute signals
+  const scoreConf = computeScoreConfidence(decision);
+
+  const effectiveConsensus =
+    consensus ?? (decision.options.length >= 2 ? computeConsensus(decision) : null);
+  const algoAgreement = effectiveConsensus?.overallAgreement ?? 1.0;
+
+  const effectiveQuality = quality ?? assessDecisionQuality(decision);
+  const structQuality = computeStructuralQuality(effectiveQuality);
+
+  const dataConf = Math.min(1, Math.max(0, dataConfidence));
+
+  // Weighted composite
+  const composite =
+    weights.algorithmAgreement * algoAgreement +
+    weights.scoreConfidence * scoreConf +
+    weights.dataConfidence * dataConf +
+    weights.structuralQuality * structQuality;
+
+  // Clamp to [0, 1]
+  const clampedComposite = Math.min(1, Math.max(0, composite));
+
+  const breakdown: ConfidenceBreakdown = {
+    scoreConfidence: scoreConf,
+    algorithmAgreement: algoAgreement,
+    structuralQuality: structQuality,
+    dataConfidence: dataConf,
+    composite: clampedComposite,
+  };
+
+  // Traffic light level
+  const level = classifyLevel(clampedComposite);
+  const label = levelLabel(level);
+  const suggestion = levelSuggestion(level, breakdown);
+
+  return { breakdown, level, label, suggestion, weights };
+}
+
+// ---------------------------------------------------------------------------
+//  Level classification
+// ---------------------------------------------------------------------------
+
+/** Classify composite score into a traffic-light level. */
+export function classifyLevel(composite: number): ConfidenceLevel {
+  if (composite >= 0.7) return "high";
+  if (composite >= 0.4) return "moderate";
+  return "low";
+}
+
+function levelLabel(level: ConfidenceLevel): string {
+  switch (level) {
+    case "high":
+      return "High confidence recommendation";
+    case "moderate":
+      return "Moderate confidence — consider reviewing low-confidence scores";
+    case "low":
+      return "Low confidence — significant uncertainty in this decision";
+  }
+}
+
+function levelSuggestion(level: ConfidenceLevel, breakdown: ConfidenceBreakdown): string {
+  if (level === "high") {
+    return "This decision has strong supporting evidence across multiple signals.";
+  }
+
+  // Identify weakest signal
+  const signals: { name: string; value: number; advice: string }[] = [
+    {
+      name: "Score confidence",
+      value: breakdown.scoreConfidence,
+      advice: "annotate scores with confidence levels",
+    },
+    {
+      name: "Algorithm agreement",
+      value: breakdown.algorithmAgreement,
+      advice: "review criteria weights to reduce algorithmic divergence",
+    },
+    {
+      name: "Data confidence",
+      value: breakdown.dataConfidence,
+      advice: "add data-backed evidence where possible",
+    },
+    {
+      name: "Structural quality",
+      value: breakdown.structuralQuality,
+      advice: "add more options/criteria and fill all score cells",
+    },
+  ];
+
+  const weakest = signals.sort((a, b) => a.value - b.value)[0];
+  return `To improve confidence, ${weakest.advice}. (${weakest.name}: ${(weakest.value * 100).toFixed(0)}%)`;
+}


### PR DESCRIPTION
## Summary

Adds a composite confidence model that unifies four confidence signals into a single actionable metric with a traffic-light UI indicator.

## Changes

### New: `src/lib/composite-confidence.ts`
Core computation module:
- **`computeScoreConfidence(decision)`** — Average per-score confidence mapped to 0–1
- **`computeStructuralQuality(quality)`** — Maps quality assessment score to 0–1
- **`classifyLevel(composite)`** — Traffic-light classification: high/moderate/low
- **`computeCompositeConfidence(decision, consensus?, quality?, dataConfidence?, weights?)`** — Main entry point compositing 4 signals:
  - Algorithm agreement (40%) — Kendall's W from consensus engine (#116)
  - Score confidence (25%) — Average per-score confidence annotations (#94)
  - Data confidence (20%) — External data tier (placeholder, defaults to 0)
  - Structural quality (15%) — Decision quality indicators (#95)

All weights are customizable. Outputs a `CompositeConfidenceResult` with breakdown, level, label, and improvement suggestion targeting the weakest signal.

### New: `src/components/CompositeConfidenceIndicator.tsx`
Traffic-light UI component:
- Colored indicator dot + label + percentage badge
- Improvement suggestion text
- Expandable breakdown showing each signal with progress bars and weight annotations
- Green (≥ 70%), Yellow (40–69%), Red (< 40%) styling

### Modified: `src/components/ResultsView.tsx`
- Integrated `CompositeConfidenceIndicator` between QualityBar and ConfidenceStrategySelector

### New: `src/__tests__/components/CompositeConfidence.test.tsx`
27 tests covering:
- `computeScoreConfidence`: plain scores, low confidence, mixed, empty
- `computeStructuralQuality`: mapping, boundaries
- `classifyLevel`: all three thresholds
- `computeCompositeConfidence`: default weights, custom weights, pre-computed consensus, dominant decision, data confidence, single option
- Component: rendering, label, score badge, suggestion, breakdown toggle, pre-computed consensus, style differentiation

## Acceptance Criteria
- [x] Composites 4 confidence signals
- [x] Customizable weights per signal
- [x] Traffic light UI indicator
- [x] Breakdown view showing individual signal contributions
- [x] Suggestions to improve confidence
- [x] ≥ 8 unit tests (16 delivered)
- [x] ≥ 4 component tests (7 delivered)

Closes #118
