### PR TITLE
feat(journal): add outcome tracking and prediction comparison

### DIFF
--- a/src/__tests__/components/OutcomeTracker.test.tsx
+++ b/src/__tests__/components/OutcomeTracker.test.tsx
@@ -1,0 +1,316 @@
+/**
+ * Tests for outcome tracking logic and OutcomeTracker component.
+ *
+ * Logic tests: CRUD operations, prediction comparison, timeline generation.
+ * Component tests: rendering, interactions, journal integration.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+
+// ── Logic imports ──────────────────────────────────────────────────────
+
+import {
+  recordChoice,
+  recordImplementation,
+  recordOutcome,
+  addFollowUp,
+  getOutcome,
+  deleteOutcome,
+  comparePrediction,
+  getOutcomeTimeline,
+  findPredictedScore,
+} from "@/lib/outcome-tracking";
+import { getEntries } from "@/lib/journal";
+import type { Decision, DecisionResults } from "@/lib/types";
+
+// ── Component imports ──────────────────────────────────────────────────
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { OutcomeTracker } from "@/components/OutcomeTracker";
+
+// ── Test helpers ───────────────────────────────────────────────────────
+
+function makeDecision(overrides: Partial<Decision> = {}): Decision {
+  const now = new Date().toISOString();
+  return {
+    id: "dec-1",
+    title: "Test Decision",
+    options: [
+      { id: "o1", name: "Option A" },
+      { id: "o2", name: "Option B" },
+      { id: "o3", name: "Option C" },
+    ],
+    criteria: [{ id: "c1", name: "Speed", weight: 50, type: "benefit" }],
+    scores: { o1: { c1: 8 }, o2: { c1: 5 }, o3: { c1: 3 } },
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function makeResults(): DecisionResults {
+  return {
+    decisionId: "dec-1",
+    optionResults: [
+      { optionId: "o1", optionName: "Option A", totalScore: 8, rank: 1, criterionScores: [] },
+      { optionId: "o2", optionName: "Option B", totalScore: 5, rank: 2, criterionScores: [] },
+      { optionId: "o3", optionName: "Option C", totalScore: 3, rank: 3, criterionScores: [] },
+    ],
+    topDrivers: [],
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// UNIT TESTS — outcome-tracking.ts logic
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("recordChoice", () => {
+  it("creates an outcome record with chosen option", () => {
+    const decision = makeDecision();
+    const { outcome } = recordChoice(decision, "o1", 8);
+
+    expect(outcome.decisionId).toBe("dec-1");
+    expect(outcome.chosenOptionId).toBe("o1");
+    expect(outcome.chosenOptionName).toBe("Option A");
+    expect(outcome.decidedAt).toBeTruthy();
+    expect(outcome.predictedScore).toBe(8);
+  });
+
+  it("auto-creates a journal entry of type outcome", () => {
+    const decision = makeDecision();
+    const { journalEntry } = recordChoice(decision, "o2");
+
+    expect(journalEntry.type).toBe("outcome");
+    expect(journalEntry.content).toContain("Option B");
+    expect(journalEntry.decisionId).toBe("dec-1");
+  });
+
+  it("persists to localStorage", () => {
+    const decision = makeDecision();
+    recordChoice(decision, "o1");
+
+    const loaded = getOutcome("dec-1");
+    expect(loaded).toBeDefined();
+    expect(loaded!.chosenOptionId).toBe("o1");
+  });
+});
+
+describe("recordImplementation", () => {
+  it("sets implementation date on existing outcome", () => {
+    const decision = makeDecision();
+    recordChoice(decision, "o1");
+
+    const implDate = "2025-06-15T00:00:00.000Z";
+    const updated = recordImplementation("dec-1", implDate);
+
+    expect(updated).toBeDefined();
+    expect(updated!.implementedAt).toBe(implDate);
+  });
+
+  it("returns undefined for unknown decision", () => {
+    expect(recordImplementation("nonexistent", "2025-01-01")).toBeUndefined();
+  });
+
+  it("creates a journal entry", () => {
+    const decision = makeDecision();
+    recordChoice(decision, "o1");
+    recordImplementation("dec-1", "2025-06-15T00:00:00.000Z");
+
+    const entries = getEntries("dec-1", { type: "outcome" });
+    // 2 entries: recordChoice + recordImplementation
+    expect(entries.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("recordOutcome", () => {
+  it("records rating clamped to 1-10", () => {
+    const decision = makeDecision();
+    recordChoice(decision, "o1");
+
+    recordOutcome("dec-1", 15);
+    expect(getOutcome("dec-1")!.outcomeRating).toBe(10);
+
+    recordOutcome("dec-1", -3);
+    expect(getOutcome("dec-1")!.outcomeRating).toBe(1);
+
+    recordOutcome("dec-1", 7, "Working well");
+    const outcome = getOutcome("dec-1")!;
+    expect(outcome.outcomeRating).toBe(7);
+    expect(outcome.outcomeNotes).toBe("Working well");
+  });
+});
+
+describe("addFollowUp", () => {
+  it("appends follow-up check-in", () => {
+    const decision = makeDecision();
+    recordChoice(decision, "o1");
+
+    addFollowUp("dec-1", 8, "Still happy");
+    addFollowUp("dec-1", 6);
+
+    const outcome = getOutcome("dec-1")!;
+    expect(outcome.followUps).toHaveLength(2);
+    expect(outcome.followUps[0].satisfaction).toBe(8);
+    expect(outcome.followUps[0].notes).toBe("Still happy");
+    expect(outcome.followUps[1].satisfaction).toBe(6);
+  });
+
+  it("creates a retrospective journal entry", () => {
+    const decision = makeDecision();
+    recordChoice(decision, "o1");
+    addFollowUp("dec-1", 7);
+
+    const entries = getEntries("dec-1", { type: "retrospective" });
+    expect(entries).toHaveLength(1);
+    expect(entries[0].content).toContain("satisfaction 7/10");
+  });
+});
+
+describe("deleteOutcome", () => {
+  it("removes an outcome", () => {
+    recordChoice(makeDecision(), "o1");
+    expect(deleteOutcome("dec-1")).toBe(true);
+    expect(getOutcome("dec-1")).toBeUndefined();
+  });
+
+  it("returns false for nonexistent", () => {
+    expect(deleteOutcome("nonexistent")).toBe(false);
+  });
+});
+
+describe("comparePrediction", () => {
+  it("computes delta and accuracy", () => {
+    const decision = makeDecision();
+    recordChoice(decision, "o1", 8);
+    recordOutcome("dec-1", 7);
+
+    const comparison = comparePrediction("dec-1");
+    expect(comparison).toBeDefined();
+    expect(comparison!.predictedScore).toBe(8);
+    expect(comparison!.actualRating).toBe(7);
+    expect(comparison!.delta).toBe(-1);
+    expect(comparison!.accuracy).toBe(0.9);
+  });
+
+  it("returns undefined when no outcome rating", () => {
+    recordChoice(makeDecision(), "o1", 8);
+    expect(comparePrediction("dec-1")).toBeUndefined();
+  });
+
+  it("returns undefined for unknown decision", () => {
+    expect(comparePrediction("nonexistent")).toBeUndefined();
+  });
+});
+
+describe("getOutcomeTimeline", () => {
+  it("builds milestones in chronological order", () => {
+    const decision = makeDecision();
+    recordChoice(decision, "o1", 8);
+    recordImplementation("dec-1", new Date(Date.now() + 1000).toISOString());
+    recordOutcome("dec-1", 7);
+    addFollowUp("dec-1", 8);
+
+    const timeline = getOutcomeTimeline("dec-1", decision);
+    expect(timeline.length).toBeGreaterThanOrEqual(4);
+    expect(timeline[0].type).toBe("decision"); // decision creation
+    expect(timeline.some((m) => m.type === "implementation")).toBe(true);
+    expect(timeline.some((m) => m.type === "outcome")).toBe(true);
+    expect(timeline.some((m) => m.type === "follow-up")).toBe(true);
+  });
+
+  it("returns only decision creation when no outcome exists", () => {
+    const decision = makeDecision();
+    const timeline = getOutcomeTimeline("dec-1", decision);
+    expect(timeline).toHaveLength(1);
+    expect(timeline[0].label).toBe("Decision Created");
+  });
+});
+
+describe("findPredictedScore", () => {
+  it("extracts total score for an option", () => {
+    const results = makeResults().optionResults;
+    expect(findPredictedScore("o1", results)).toBe(8);
+    expect(findPredictedScore("o2", results)).toBe(5);
+  });
+
+  it("returns undefined for unknown option", () => {
+    expect(findPredictedScore("nonexistent", makeResults().optionResults)).toBeUndefined();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// COMPONENT TESTS — OutcomeTracker.tsx
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("OutcomeTracker component", () => {
+  it("renders option chooser when no outcome exists", () => {
+    render(<OutcomeTracker decision={makeDecision()} results={makeResults()} />);
+
+    expect(screen.getByText("Which option did you decide on?")).toBeInTheDocument();
+    expect(screen.getByText("Option A")).toBeInTheDocument();
+    expect(screen.getByText("Option B")).toBeInTheDocument();
+    expect(screen.getByText("Option C")).toBeInTheDocument();
+  });
+
+  it("records choice when option button is clicked", () => {
+    render(<OutcomeTracker decision={makeDecision()} results={makeResults()} />);
+
+    fireEvent.click(screen.getByText("Option A"));
+
+    // After clicking, the option chooser is replaced by the chosen badge
+    expect(screen.queryByText("Which option did you decide on?")).not.toBeInTheDocument();
+    expect(screen.getByText("Option A")).toBeInTheDocument(); // shown in chosen badge
+  });
+
+  it("shows implementation date input after choosing", () => {
+    render(<OutcomeTracker decision={makeDecision()} results={makeResults()} />);
+    fireEvent.click(screen.getByText("Option B"));
+
+    expect(screen.getByLabelText("Implementation date")).toBeInTheDocument();
+  });
+
+  it("shows outcome rating slider after choosing", () => {
+    render(<OutcomeTracker decision={makeDecision()} results={makeResults()} />);
+    fireEvent.click(screen.getByText("Option A"));
+
+    expect(screen.getByLabelText("Outcome rating")).toBeInTheDocument();
+    expect(screen.getByText("Save Outcome")).toBeInTheDocument();
+  });
+
+  it("shows outcome tracker heading", () => {
+    render(<OutcomeTracker decision={makeDecision()} results={makeResults()} />);
+    expect(screen.getByText("Outcome Tracker")).toBeInTheDocument();
+  });
+
+  it("displays timeline after recording outcome", () => {
+    const decision = makeDecision();
+    // Pre-record a choice via the lib
+    recordChoice(decision, "o1", 8);
+
+    render(<OutcomeTracker decision={decision} results={makeResults()} />);
+
+    // Timeline should be visible
+    expect(screen.getByTestId("timeline")).toBeInTheDocument();
+    expect(screen.getByText("Decision Timeline")).toBeInTheDocument();
+  });
+
+  it("renders the component with aria-label", () => {
+    render(<OutcomeTracker decision={makeDecision()} results={makeResults()} />);
+    expect(screen.getByLabelText("Outcome Tracker")).toBeInTheDocument();
+  });
+
+  it("shows follow-up section after outcome is rated", () => {
+    const decision = makeDecision();
+    recordChoice(decision, "o1", 8);
+    recordOutcome("dec-1", 7);
+
+    render(<OutcomeTracker decision={decision} results={makeResults()} />);
+
+    expect(screen.getByTestId("follow-up")).toBeInTheDocument();
+    expect(screen.getByText("Add Follow-up")).toBeInTheDocument();
+  });
+});

--- a/src/components/OutcomeTracker.tsx
+++ b/src/components/OutcomeTracker.tsx
@@ -1,0 +1,377 @@
+/**
+ * OutcomeTracker component — records post-decision outcomes and
+ * compares them to predicted scores.
+ *
+ * Renders:
+ * - option chooser (which option was picked)
+ * - implementation date input
+ * - outcome rating (1–10 slider)
+ * - notes text area
+ * - prediction vs actual comparison bar
+ * - milestone timeline
+ * - follow-up survey
+ */
+
+"use client";
+
+import { useState, useMemo } from "react";
+import { CheckCircle2, Clock, Star, MessageSquare, TrendingUp, TrendingDown, Minus, Plus } from "lucide-react";
+import type { Decision, DecisionResults } from "@/lib/types";
+import {
+  recordChoice,
+  recordImplementation,
+  recordOutcome as recordOutcomeFn,
+  addFollowUp,
+  getOutcome,
+  comparePrediction,
+  getOutcomeTimeline,
+  findPredictedScore,
+} from "@/lib/outcome-tracking";
+import type { PredictionComparison, TimelineMilestone } from "@/lib/outcome-tracking";
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface OutcomeTrackerProps {
+  decision: Decision;
+  results: DecisionResults;
+}
+
+// ---------------------------------------------------------------------------
+// Milestone type → style mapping
+// ---------------------------------------------------------------------------
+
+const MILESTONE_STYLES: Record<
+  TimelineMilestone["type"],
+  { bg: string; border: string; icon: string }
+> = {
+  decision:       { bg: "bg-blue-100 dark:bg-blue-900/30",   border: "border-blue-400", icon: "📋" },
+  implementation: { bg: "bg-yellow-100 dark:bg-yellow-900/30", border: "border-yellow-400", icon: "🚀" },
+  outcome:        { bg: "bg-green-100 dark:bg-green-900/30",  border: "border-green-400", icon: "✅" },
+  "follow-up":    { bg: "bg-purple-100 dark:bg-purple-900/30", border: "border-purple-400", icon: "🔁" },
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function OutcomeTracker({ decision, results }: Readonly<OutcomeTrackerProps>) {
+  // Reactive state that refreshes when we mutate localStorage
+  const [revision, setRevision] = useState(0);
+  const bump = () => setRevision((r) => r + 1);
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- revision triggers re-read from localStorage
+  const outcome = useMemo(() => getOutcome(decision.id), [decision.id, revision]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const comparison = useMemo(() => comparePrediction(decision.id), [decision.id, revision]);
+  const timeline = useMemo(
+    () => getOutcomeTimeline(decision.id, decision),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- revision triggers re-read from localStorage
+    [decision, revision],
+  );
+
+  // ── Local form state ──────────────────────────────────────────────────
+  const [ratingInput, setRatingInput] = useState<number>(outcome?.outcomeRating ?? 5);
+  const [notesInput, setNotesInput] = useState(outcome?.outcomeNotes ?? "");
+  const [implDate, setImplDate] = useState(
+    outcome?.implementedAt ? outcome.implementedAt.slice(0, 10) : "",
+  );
+  const [followUpSat, setFollowUpSat] = useState(5);
+  const [followUpNotes, setFollowUpNotes] = useState("");
+
+  // ── Handlers ──────────────────────────────────────────────────────────
+
+  const handleChooseOption = (optionId: string) => {
+    const predicted = findPredictedScore(optionId, results.optionResults);
+    recordChoice(decision, optionId, predicted);
+    bump();
+  };
+
+  const handleRecordImplementation = () => {
+    if (!implDate) return;
+    recordImplementation(decision.id, new Date(implDate).toISOString());
+    bump();
+  };
+
+  const handleRecordOutcome = () => {
+    recordOutcomeFn(decision.id, ratingInput, notesInput || undefined);
+    bump();
+  };
+
+  const handleAddFollowUp = () => {
+    addFollowUp(decision.id, followUpSat, followUpNotes || undefined);
+    setFollowUpNotes("");
+    bump();
+  };
+
+  // ── Render ────────────────────────────────────────────────────────────
+
+  return (
+    <section
+      className="space-y-6 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-5"
+      aria-label="Outcome Tracker"
+    >
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
+        <CheckCircle2 className="h-5 w-5 text-green-600" />
+        Outcome Tracker
+      </h3>
+
+      {/* ── Step 1: Choose option ───────────────────────────────────── */}
+      {!outcome && (
+        <div className="space-y-2" data-testid="choose-option">
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            Which option did you decide on?
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {decision.options.map((opt) => (
+              <button
+                key={opt.id}
+                onClick={() => handleChooseOption(opt.id)}
+                className="rounded-md border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-blue-50 dark:hover:bg-blue-900/20 hover:border-blue-400 transition-colors"
+              >
+                {opt.name}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* ── After option is chosen ─────────────────────────────────── */}
+      {outcome && (
+        <>
+          {/* Chosen option badge */}
+          <div className="flex items-center gap-2 text-sm">
+            <span className="text-gray-500 dark:text-gray-400">Chose:</span>
+            <span className="inline-flex items-center gap-1 rounded-full bg-green-100 dark:bg-green-900/30 px-3 py-0.5 text-green-800 dark:text-green-300 font-medium">
+              <CheckCircle2 className="h-3.5 w-3.5" />
+              {outcome.chosenOptionName}
+            </span>
+          </div>
+
+          {/* ── Implementation date ──────────────────────────────── */}
+          <div className="space-y-2" data-testid="implementation-date">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300 flex items-center gap-1.5">
+              <Clock className="h-4 w-4" />
+              Implementation Date
+            </label>
+            <div className="flex gap-2">
+              <input
+                type="date"
+                value={implDate}
+                onChange={(e) => setImplDate(e.target.value)}
+                className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-1.5 text-sm text-gray-900 dark:text-gray-100"
+                aria-label="Implementation date"
+              />
+              <button
+                onClick={handleRecordImplementation}
+                disabled={!implDate}
+                className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                Save
+              </button>
+            </div>
+            {outcome.implementedAt && (
+              <p className="text-xs text-green-600 dark:text-green-400">
+                Implemented on {new Date(outcome.implementedAt).toLocaleDateString()}
+              </p>
+            )}
+          </div>
+
+          {/* ── Outcome rating ───────────────────────────────────── */}
+          <div className="space-y-2" data-testid="outcome-rating">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300 flex items-center gap-1.5">
+              <Star className="h-4 w-4" />
+              Outcome Rating
+            </label>
+            <div className="flex items-center gap-3">
+              <input
+                type="range"
+                min={1}
+                max={10}
+                value={ratingInput}
+                onChange={(e) => setRatingInput(Number(e.target.value))}
+                className="flex-1 accent-blue-600"
+                aria-label="Outcome rating"
+              />
+              <span className="text-lg font-bold text-gray-900 dark:text-white min-w-[2ch] text-center">
+                {ratingInput}
+              </span>
+              <span className="text-xs text-gray-500 dark:text-gray-400">/10</span>
+            </div>
+            <textarea
+              value={notesInput}
+              onChange={(e) => setNotesInput(e.target.value)}
+              placeholder="Notes about the outcome..."
+              rows={2}
+              className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400"
+              aria-label="Outcome notes"
+            />
+            <button
+              onClick={handleRecordOutcome}
+              className="rounded-md bg-green-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-green-700 transition-colors"
+            >
+              Save Outcome
+            </button>
+          </div>
+
+          {/* ── Prediction vs Actual comparison ──────────────────── */}
+          {comparison && <PredictionComparisonCard comparison={comparison} />}
+
+          {/* ── Follow-up survey ─────────────────────────────────── */}
+          {outcome.outcomeRating !== undefined && (
+            <div className="space-y-2 border-t border-gray-200 dark:border-gray-700 pt-4" data-testid="follow-up">
+              <label className="text-sm font-medium text-gray-700 dark:text-gray-300 flex items-center gap-1.5">
+                <MessageSquare className="h-4 w-4" />
+                Follow-up Check-in
+              </label>
+              <div className="flex items-center gap-3">
+                <button
+                  onClick={() => setFollowUpSat((s) => Math.max(1, s - 1))}
+                  className="rounded p-0.5 hover:bg-gray-100 dark:hover:bg-gray-800"
+                  aria-label="Decrease satisfaction"
+                >
+                  <Minus className="h-4 w-4" />
+                </button>
+                <span className="text-lg font-bold min-w-[2ch] text-center">{followUpSat}</span>
+                <button
+                  onClick={() => setFollowUpSat((s) => Math.min(10, s + 1))}
+                  className="rounded p-0.5 hover:bg-gray-100 dark:hover:bg-gray-800"
+                  aria-label="Increase satisfaction"
+                >
+                  <Plus className="h-4 w-4" />
+                </button>
+                <span className="text-xs text-gray-500">/10 satisfaction</span>
+              </div>
+              <textarea
+                value={followUpNotes}
+                onChange={(e) => setFollowUpNotes(e.target.value)}
+                placeholder="What changed since the decision?"
+                rows={2}
+                className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400"
+                aria-label="Follow-up notes"
+              />
+              <button
+                onClick={handleAddFollowUp}
+                className="rounded-md bg-purple-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-purple-700 transition-colors"
+              >
+                Add Follow-up
+              </button>
+            </div>
+          )}
+        </>
+      )}
+
+      {/* ── Timeline ─────────────────────────────────────────────── */}
+      {timeline.length > 0 && (
+        <div className="border-t border-gray-200 dark:border-gray-700 pt-4" data-testid="timeline">
+          <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
+            Decision Timeline
+          </h4>
+          <div className="relative space-y-3 pl-6">
+            {/* Vertical line */}
+            <div className="absolute left-2.5 top-0 bottom-0 w-px bg-gray-300 dark:bg-gray-600" />
+
+            {timeline.map((m, i) => {
+              const style = MILESTONE_STYLES[m.type];
+              return (
+                <div key={`${m.date}-${i}`} className="relative flex gap-3">
+                  {/* Dot */}
+                  <div
+                    className={`absolute -left-3.5 top-1 h-3 w-3 rounded-full border-2 ${style.border} ${style.bg}`}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium text-gray-800 dark:text-gray-200">
+                      {style.icon} {m.label}
+                    </p>
+                    {m.detail && (
+                      <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                        {m.detail}
+                      </p>
+                    )}
+                    <p className="text-xs text-gray-400 dark:text-gray-500">
+                      {new Date(m.date).toLocaleDateString()}
+                    </p>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-component: PredictionComparisonCard
+// ---------------------------------------------------------------------------
+
+function PredictionComparisonCard({ comparison }: Readonly<{ comparison: PredictionComparison }>) {
+  let deltaIcon: React.ReactNode = null;
+  if (comparison.delta > 0.5) {
+    deltaIcon = <TrendingUp className="h-4 w-4 text-green-600" />;
+  } else if (comparison.delta < -0.5) {
+    deltaIcon = <TrendingDown className="h-4 w-4 text-red-600" />;
+  }
+
+  let accuracyColor = "text-red-600 dark:text-red-400";
+  if (comparison.accuracy >= 0.8) {
+    accuracyColor = "text-green-600 dark:text-green-400";
+  } else if (comparison.accuracy >= 0.5) {
+    accuracyColor = "text-yellow-600 dark:text-yellow-400";
+  }
+
+  return (
+    <div
+      className="rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 p-4 space-y-3"
+      data-testid="prediction-comparison"
+    >
+      <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+        Predicted vs Actual
+      </h4>
+
+      {/* Dual bars */}
+      <div className="space-y-2">
+        <div>
+          <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400 mb-0.5">
+            <span>Predicted</span>
+            <span>{comparison.predictedScore}/10</span>
+          </div>
+          <div className="h-2 rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden">
+            <div
+              className="h-full rounded-full bg-blue-500"
+              style={{ width: `${comparison.predictedScore * 10}%` }}
+            />
+          </div>
+        </div>
+        <div>
+          <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400 mb-0.5">
+            <span>Actual</span>
+            <span>{comparison.actualRating}/10</span>
+          </div>
+          <div className="h-2 rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden">
+            <div
+              className="h-full rounded-full bg-green-500"
+              style={{ width: `${comparison.actualRating * 10}%` }}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Delta & accuracy */}
+      <div className="flex items-center gap-4 text-sm">
+        <span className="flex items-center gap-1">
+          {deltaIcon}
+          <span className="text-gray-600 dark:text-gray-400">
+            Delta: {comparison.delta > 0 ? "+" : ""}
+            {comparison.delta}
+          </span>
+        </span>
+        <span className={`font-medium ${accuracyColor}`}>
+          {Math.round(comparison.accuracy * 100)}% accuracy
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ResultsView.tsx
+++ b/src/components/ResultsView.tsx
@@ -34,6 +34,7 @@ import { ConfidenceStrategySelector } from "./ConfidenceStrategySelector";
 import { WhatIfPanel } from "./WhatIfPanel";
 import { FrameworkComparison } from "./FrameworkComparison";
 import { CompositeConfidenceIndicator } from "./CompositeConfidenceIndicator";
+import { OutcomeTracker } from "./OutcomeTracker";
 
 const ScoreChart = lazy(() => import("./ScoreChart").then((m) => ({ default: m.ScoreChart })));
 const ParetoChart = lazy(() => import("./ParetoChart").then((m) => ({ default: m.ParetoChart })));
@@ -636,6 +637,9 @@ export function ResultsView({ validation, completeness, onSwitchToBuilder }: Res
           onClose={() => setWhatIfOpen(false)}
         />
       )}
+
+      {/* Outcome Tracker */}
+      <OutcomeTracker decision={decision} results={results} />
     </div>
   );
 }

--- a/src/lib/outcome-tracking.ts
+++ b/src/lib/outcome-tracking.ts
@@ -1,0 +1,347 @@
+/**
+ * Outcome tracking — records post-decision results and compares to predictions.
+ *
+ * Each decision can have at most one `DecisionOutcome` which captures:
+ * - which option was chosen
+ * - when it was implemented
+ * - actual outcome rating (1–10)
+ * - notes about the outcome
+ * - optional follow-up satisfaction ratings
+ *
+ * Outcomes are stored in localStorage under a separate key and integrate
+ * with the journal module by auto-creating journal entries.
+ *
+ * @module outcome-tracking
+ */
+
+import type { Decision, OptionResult } from "./types";
+import { safeJsonParse } from "./utils";
+import { addEntry } from "./journal";
+import type { JournalEntry } from "./journal";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A single follow-up check-in */
+export interface FollowUp {
+  date: string; // ISO 8601
+  satisfaction: number; // 1–10
+  notes?: string;
+}
+
+/** Outcome data for a single decision */
+export interface DecisionOutcome {
+  decisionId: string;
+  chosenOptionId: string;
+  chosenOptionName: string;
+  decidedAt: string; // ISO 8601 — when the decision was finalized
+  implementedAt?: string; // ISO 8601
+  outcomeRating?: number; // 1–10
+  outcomeNotes?: string;
+  followUps: FollowUp[];
+  /** Predicted score (WSM total score) for the chosen option at decision time */
+  predictedScore?: number;
+}
+
+/** Comparison between predicted score and actual outcome */
+export interface PredictionComparison {
+  chosenOptionName: string;
+  predictedScore: number; // normalized 0–10
+  actualRating: number; // 1–10
+  delta: number; // actual - predicted (positive = better than expected)
+  accuracy: number; // 0–1, how close prediction was to actual
+}
+
+/** Timeline milestone for visualizing decision lifecycle */
+export interface TimelineMilestone {
+  date: string;
+  label: string;
+  type: "decision" | "implementation" | "outcome" | "follow-up";
+  detail?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Storage
+// ---------------------------------------------------------------------------
+
+const OUTCOME_STORAGE_KEY = "decision-os:outcomes";
+
+type OutcomeMap = Record<string, DecisionOutcome>;
+
+function loadOutcomes(): OutcomeMap {
+  if (globalThis.window === undefined) return {};
+  try {
+    const raw = localStorage.getItem(OUTCOME_STORAGE_KEY);
+    if (!raw) return {};
+    return safeJsonParse<OutcomeMap>(raw, {});
+  } catch {
+    return {};
+  }
+}
+
+function persistOutcomes(outcomes: OutcomeMap): void {
+  if (globalThis.window === undefined) return;
+  try {
+    localStorage.setItem(OUTCOME_STORAGE_KEY, JSON.stringify(outcomes));
+  } catch {
+    // quota exceeded or private-browsing — fail silently
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CRUD operations
+// ---------------------------------------------------------------------------
+
+/**
+ * Record which option was chosen for a decision.
+ * Creates or overwrites the outcome record and auto-creates a journal entry.
+ *
+ * @returns The created/updated outcome and the auto-generated journal entry
+ */
+export function recordChoice(
+  decision: Decision,
+  chosenOptionId: string,
+  predictedScore?: number,
+): { outcome: DecisionOutcome; journalEntry: JournalEntry } {
+  const option = decision.options.find((o) => o.id === chosenOptionId);
+  const optionName = option?.name ?? chosenOptionId;
+  const now = new Date().toISOString();
+
+  const outcomes = loadOutcomes();
+  const existing = outcomes[decision.id];
+
+  const outcome: DecisionOutcome = {
+    decisionId: decision.id,
+    chosenOptionId,
+    chosenOptionName: optionName,
+    decidedAt: now,
+    followUps: existing?.followUps ?? [],
+    ...(predictedScore === undefined ? {} : { predictedScore }),
+    // Preserve existing outcome data if updating the choice
+    ...(existing?.implementedAt ? { implementedAt: existing.implementedAt } : {}),
+    ...(existing?.outcomeRating === undefined ? {} : { outcomeRating: existing.outcomeRating }),
+    ...(existing?.outcomeNotes ? { outcomeNotes: existing.outcomeNotes } : {}),
+  };
+
+  outcomes[decision.id] = outcome;
+  persistOutcomes(outcomes);
+
+  const journalEntry = addEntry(decision.id, {
+    type: "outcome",
+    content: `Chose "${optionName}" for this decision.`,
+    metadata: { mood: "confident" },
+  });
+
+  return { outcome, journalEntry };
+}
+
+/**
+ * Record the implementation date for a decision outcome.
+ */
+export function recordImplementation(
+  decisionId: string,
+  implementedAt: string,
+): DecisionOutcome | undefined {
+  const outcomes = loadOutcomes();
+  const outcome = outcomes[decisionId];
+  if (!outcome) return undefined;
+
+  outcome.implementedAt = implementedAt;
+  outcomes[decisionId] = outcome;
+  persistOutcomes(outcomes);
+
+  addEntry(decisionId, {
+    type: "outcome",
+    content: `Implemented decision on ${new Date(implementedAt).toLocaleDateString()}.`,
+  });
+
+  return outcome;
+}
+
+/**
+ * Record an outcome rating and optional notes.
+ */
+export function recordOutcome(
+  decisionId: string,
+  rating: number,
+  notes?: string,
+): DecisionOutcome | undefined {
+  const outcomes = loadOutcomes();
+  const outcome = outcomes[decisionId];
+  if (!outcome) return undefined;
+
+  outcome.outcomeRating = Math.max(1, Math.min(10, Math.round(rating)));
+  if (notes !== undefined) outcome.outcomeNotes = notes;
+  outcomes[decisionId] = outcome;
+  persistOutcomes(outcomes);
+
+  addEntry(decisionId, {
+    type: "outcome",
+    content: `Rated outcome ${outcome.outcomeRating}/10.` + (notes ? ` ${notes}` : ""),
+  });
+
+  return outcome;
+}
+
+/**
+ * Add a follow-up check-in to an existing outcome.
+ */
+export function addFollowUp(
+  decisionId: string,
+  satisfaction: number,
+  notes?: string,
+): DecisionOutcome | undefined {
+  const outcomes = loadOutcomes();
+  const outcome = outcomes[decisionId];
+  if (!outcome) return undefined;
+
+  const followUp: FollowUp = {
+    date: new Date().toISOString(),
+    satisfaction: Math.max(1, Math.min(10, Math.round(satisfaction))),
+    ...(notes ? { notes } : {}),
+  };
+
+  outcome.followUps.push(followUp);
+  outcomes[decisionId] = outcome;
+  persistOutcomes(outcomes);
+
+  addEntry(decisionId, {
+    type: "retrospective",
+    content: `Follow-up check-in: satisfaction ${followUp.satisfaction}/10.` + (notes ? ` ${notes}` : ""),
+  });
+
+  return outcome;
+}
+
+/**
+ * Get the outcome for a decision (or undefined).
+ */
+export function getOutcome(decisionId: string): DecisionOutcome | undefined {
+  return loadOutcomes()[decisionId];
+}
+
+/**
+ * Delete the outcome for a decision.
+ */
+export function deleteOutcome(decisionId: string): boolean {
+  const outcomes = loadOutcomes();
+  if (!outcomes[decisionId]) return false;
+  delete outcomes[decisionId];
+  persistOutcomes(outcomes);
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Prediction comparison
+// ---------------------------------------------------------------------------
+
+/**
+ * Compare predicted score to actual outcome rating.
+ * Returns undefined if either predicted score or outcome rating is missing.
+ */
+export function comparePrediction(
+  decisionId: string,
+): PredictionComparison | undefined {
+  const outcome = getOutcome(decisionId);
+  if (!outcome) return undefined;
+  if (outcome.predictedScore === undefined || outcome.outcomeRating === undefined) {
+    return undefined;
+  }
+
+  // Normalize predicted score to 0–10 scale (it's already on that scale from WSM)
+  const predicted = Math.max(0, Math.min(10, outcome.predictedScore));
+  const actual = outcome.outcomeRating;
+  const delta = actual - predicted;
+  // Accuracy: 1 - (|delta| / 10), clamped to [0, 1]
+  const accuracy = Math.max(0, 1 - Math.abs(delta) / 10);
+
+  return {
+    chosenOptionName: outcome.chosenOptionName,
+    predictedScore: Math.round(predicted * 100) / 100,
+    actualRating: actual,
+    delta: Math.round(delta * 100) / 100,
+    accuracy: Math.round(accuracy * 100) / 100,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Timeline
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a timeline of milestones for a decision's lifecycle.
+ */
+export function getOutcomeTimeline(
+  decisionId: string,
+  decision?: Decision,
+): TimelineMilestone[] {
+  const milestones: TimelineMilestone[] = [];
+
+  // Decision creation
+  if (decision) {
+    milestones.push({
+      date: decision.createdAt,
+      label: "Decision Created",
+      type: "decision",
+      detail: decision.title,
+    });
+  }
+
+  const outcome = getOutcome(decisionId);
+  if (!outcome) return milestones;
+
+  // Choice made
+  milestones.push({
+    date: outcome.decidedAt,
+    label: "Option Chosen",
+    type: "decision",
+    detail: `Chose "${outcome.chosenOptionName}"`,
+  });
+
+  // Implementation
+  if (outcome.implementedAt) {
+    milestones.push({
+      date: outcome.implementedAt,
+      label: "Implemented",
+      type: "implementation",
+    });
+  }
+
+  // Outcome recorded
+  if (outcome.outcomeRating !== undefined) {
+    milestones.push({
+      date: outcome.implementedAt ?? outcome.decidedAt,
+      label: "Outcome Rated",
+      type: "outcome",
+      detail: `${outcome.outcomeRating}/10` + (outcome.outcomeNotes ? ` — ${outcome.outcomeNotes}` : ""),
+    });
+  }
+
+  // Follow-ups
+  for (const fu of outcome.followUps) {
+    milestones.push({
+      date: fu.date,
+      label: "Follow-up",
+      type: "follow-up",
+      detail: `Satisfaction: ${fu.satisfaction}/10` + (fu.notes ? ` — ${fu.notes}` : ""),
+    });
+  }
+
+  // Sort chronologically
+  return milestones.sort(
+    (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
+  );
+}
+
+/**
+ * Find the predicted score for a specific option from decision results.
+ * Useful for passing to `recordChoice`.
+ */
+export function findPredictedScore(
+  optionId: string,
+  results: OptionResult[],
+): number | undefined {
+  const match = results.find((r) => r.optionId === optionId);
+  return match?.totalScore;
+}


### PR DESCRIPTION
## Summary

Adds outcome tracking that lets users record post-decision results, compare them to predicted scores, and track the decision lifecycle.

## Changes

### New: `src/lib/outcome-tracking.ts` (280 lines)
- **Types**: `DecisionOutcome`, `FollowUp`, `PredictionComparison`, `TimelineMilestone`
- **CRUD**: `recordChoice()`, `recordImplementation()`, `recordOutcome()`, `addFollowUp()`, `getOutcome()`, `deleteOutcome()`
- **Analysis**: `comparePrediction()` — computes delta, accuracy between predicted and actual
- **Timeline**: `getOutcomeTimeline()` — builds chronological milestones
- **Integration**: auto-creates journal entries on every action (outcome + retrospective types)
- **Storage**: separate localStorage key (`decision-os:outcomes`)

### New: `src/components/OutcomeTracker.tsx` (305 lines)
- Option chooser UI (step 1)
- Implementation date input with save button
- Outcome rating slider (1-10) with notes textarea
- PredictionComparisonCard: dual progress bars, delta/accuracy display
- Follow-up check-in survey with satisfaction counter
- Milestone timeline with type-specific icons and color-coded dots

### Modified: `src/components/ResultsView.tsx`
- Integrated `OutcomeTracker` below What-If Analysis panel

### New: `src/__tests__/components/OutcomeTracker.test.tsx` (317 lines)
- 18 unit tests for outcome-tracking logic
- 8 component tests for OutcomeTracker rendering and interactions

## Acceptance Criteria
- [x] Record chosen option after decision finalized
- [x] Outcome rating and notes input
- [x] Timeline visualization (decision → implementation → outcome)
- [x] Predicted vs actual comparison
- [x] Auto-creates journal entries
- [x] >= 6 component tests (8 tests)
- [x] >= 4 unit tests for outcome logic (18 tests)

Closes #100
