### PR TITLE
feat(patterns): add cross-decision pattern recognition

### DIFF
--- a/src/__tests__/patterns.test.tsx
+++ b/src/__tests__/patterns.test.tsx
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { Decision } from "@/lib/types";
+import type { DecisionOutcome } from "@/lib/outcome-tracking";
+import { detectPatterns } from "@/lib/patterns";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeDecision(overrides: Partial<Decision> & { id: string }): Decision {
+  return {
+    title: "Decision " + overrides.id,
+    options: [
+      { id: "o1", name: "Option A" },
+      { id: "o2", name: "Option B" },
+    ],
+    criteria: [
+      { id: "c1", name: "Quality", weight: 80, type: "benefit" },
+      { id: "c2", name: "Cost", weight: 50, type: "cost" },
+    ],
+    scores: {},
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeOutcome(overrides: Partial<DecisionOutcome> & { decisionId: string }): DecisionOutcome {
+  return {
+    chosenOptionId: "o1",
+    chosenOptionName: "Option A",
+    decidedAt: "2024-01-01T00:00:00Z",
+    followUps: [],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+describe("detectPatterns", () => {
+  it("returns empty array when fewer than MIN_DECISIONS", () => {
+    const decisions = [makeDecision({ id: "d1" }), makeDecision({ id: "d2" })];
+    expect(detectPatterns(decisions)).toEqual([]);
+  });
+
+  it("returns empty array for empty decisions array", () => {
+    expect(detectPatterns([])).toEqual([]);
+  });
+
+  it("detects central tendency bias when most scores are 4-6", () => {
+    const midScores = {
+      o1: { c1: { value: 5, confidence: "high" as const }, c2: { value: 5, confidence: "high" as const } },
+      o2: { c1: { value: 5, confidence: "high" as const }, c2: { value: 5, confidence: "high" as const } },
+    };
+
+    const decisions = [
+      makeDecision({ id: "d1", scores: midScores }),
+      makeDecision({ id: "d2", scores: midScores }),
+      makeDecision({ id: "d3", scores: midScores }),
+    ];
+
+    const patterns = detectPatterns(decisions);
+    const bias = patterns.find((p) => p.title === "Central Tendency Bias");
+    expect(bias).toBeDefined();
+    expect(bias?.type).toBe("scoring-bias");
+    expect(bias?.confidence).toBeGreaterThan(0.5);
+  });
+
+  it("does not detect central tendency when scores are spread", () => {
+    const spreadScores = {
+      o1: { c1: { value: 1, confidence: "high" as const }, c2: { value: 10, confidence: "high" as const } },
+      o2: { c1: { value: 2, confidence: "high" as const }, c2: { value: 9, confidence: "high" as const } },
+    };
+
+    const decisions = [
+      makeDecision({ id: "d1", scores: spreadScores }),
+      makeDecision({ id: "d2", scores: spreadScores }),
+      makeDecision({ id: "d3", scores: spreadScores }),
+    ];
+
+    const patterns = detectPatterns(decisions);
+    const bias = patterns.find((p) => p.title === "Central Tendency Bias");
+    expect(bias).toBeUndefined();
+  });
+
+  it("detects first-option anchoring", () => {
+    const anchoredScores = {
+      o1: { c1: { value: 9, confidence: "high" as const }, c2: { value: 9, confidence: "high" as const } },
+      o2: { c1: { value: 3, confidence: "high" as const }, c2: { value: 3, confidence: "high" as const } },
+    };
+
+    const decisions = [
+      makeDecision({ id: "d1", scores: anchoredScores }),
+      makeDecision({ id: "d2", scores: anchoredScores }),
+      makeDecision({ id: "d3", scores: anchoredScores }),
+    ];
+
+    const patterns = detectPatterns(decisions);
+    const anchoring = patterns.find((p) => p.title === "First-Option Anchoring");
+    expect(anchoring).toBeDefined();
+    expect(anchoring?.type).toBe("scoring-bias");
+  });
+
+  it("detects weight preference when same criterion is always heaviest", () => {
+    const decisions = [
+      makeDecision({ id: "d1", criteria: [{ id: "c1", name: "Safety", weight: 100, type: "benefit" }, { id: "c2", name: "Cost", weight: 30, type: "cost" }] }),
+      makeDecision({ id: "d2", criteria: [{ id: "c1", name: "Safety", weight: 90, type: "benefit" }, { id: "c2", name: "Fun", weight: 40, type: "benefit" }] }),
+      makeDecision({ id: "d3", criteria: [{ id: "c1", name: "Safety", weight: 80, type: "benefit" }, { id: "c2", name: "Innovation", weight: 50, type: "benefit" }] }),
+    ];
+
+    const patterns = detectPatterns(decisions);
+    const pref = patterns.find((p) => p.type === "weight-preference");
+    expect(pref).toBeDefined();
+    expect(pref?.description).toContain("safety");
+  });
+
+  it("detects prediction accuracy (optimism bias)", () => {
+    const decisions = [
+      makeDecision({ id: "d1" }),
+      makeDecision({ id: "d2" }),
+      makeDecision({ id: "d3" }),
+    ];
+
+    const outcomes = [
+      makeOutcome({ decisionId: "d1", predictedScore: 8, outcomeRating: 4 }),
+      makeOutcome({ decisionId: "d2", predictedScore: 9, outcomeRating: 5 }),
+    ];
+
+    const patterns = detectPatterns(decisions, outcomes);
+    const pred = patterns.find((p) => p.type === "prediction-accuracy");
+    expect(pred).toBeDefined();
+    expect(pred?.title).toBe("Optimism Bias");
+  });
+
+  it("detects criterion reuse across decisions", () => {
+    const decisions = [
+      makeDecision({ id: "d1", criteria: [{ id: "c1", name: "Quality", weight: 50, type: "benefit" }, { id: "c2", name: "Cost", weight: 50, type: "cost" }] }),
+      makeDecision({ id: "d2", criteria: [{ id: "c1", name: "Quality", weight: 60, type: "benefit" }, { id: "c2", name: "Speed", weight: 40, type: "benefit" }] }),
+      makeDecision({ id: "d3", criteria: [{ id: "c1", name: "Quality", weight: 70, type: "benefit" }, { id: "c2", name: "Risk", weight: 30, type: "benefit" }] }),
+    ];
+
+    const patterns = detectPatterns(decisions);
+    const reuse = patterns.find((p) => p.type === "criterion-reuse");
+    expect(reuse).toBeDefined();
+    expect(reuse?.description).toContain("quality");
+  });
+
+  it("includes evidence strings in patterns", () => {
+    const midScores = {
+      o1: { c1: { value: 5, confidence: "high" as const }, c2: { value: 5, confidence: "high" as const } },
+      o2: { c1: { value: 5, confidence: "high" as const }, c2: { value: 5, confidence: "high" as const } },
+    };
+    const decisions = [
+      makeDecision({ id: "d1", scores: midScores }),
+      makeDecision({ id: "d2", scores: midScores }),
+      makeDecision({ id: "d3", scores: midScores }),
+    ];
+
+    const patterns = detectPatterns(decisions);
+    const bias = patterns.find((p) => p.title === "Central Tendency Bias");
+    expect(bias?.evidence).toBeDefined();
+    expect(bias!.evidence.length).toBeGreaterThan(0);
+  });
+
+  it("returns patterns with valid confidence between 0 and 1", () => {
+    const midScores = {
+      o1: { c1: { value: 5, confidence: "high" as const }, c2: { value: 5, confidence: "high" as const } },
+      o2: { c1: { value: 5, confidence: "high" as const }, c2: { value: 5, confidence: "high" as const } },
+    };
+    const decisions = [
+      makeDecision({ id: "d1", scores: midScores }),
+      makeDecision({ id: "d2", scores: midScores }),
+      makeDecision({ id: "d3", scores: midScores }),
+    ];
+
+    const patterns = detectPatterns(decisions);
+    for (const p of patterns) {
+      expect(p.confidence).toBeGreaterThanOrEqual(0);
+      expect(p.confidence).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Component tests
+// ---------------------------------------------------------------------------
+
+// Mock dependencies for component tests
+const mockGetDecisions = vi.fn<() => Decision[]>(() => []);
+
+vi.mock("@/lib/storage", () => ({
+  getDecisions: (...args: unknown[]) => mockGetDecisions(...(args as [])),
+}));
+
+import { PatternInsights } from "@/components/PatternInsights";
+
+describe("PatternInsights component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDecisions.mockReturnValue([]);
+  });
+
+  it("renders empty state when no patterns detected", () => {
+    mockGetDecisions.mockReturnValue([makeDecision({ id: "d1" })]);
+    render(<PatternInsights decision={makeDecision({ id: "d1" })} />);
+
+    expect(screen.getByTestId("patterns-empty")).toBeInTheDocument();
+    expect(screen.getByText("No Patterns Detected")).toBeInTheDocument();
+  });
+
+  it("has aria-label for accessibility", () => {
+    mockGetDecisions.mockReturnValue([makeDecision({ id: "d1" })]);
+    render(<PatternInsights decision={makeDecision({ id: "d1" })} />);
+
+    expect(screen.getByRole("region", { name: "Pattern Insights" })).toBeInTheDocument();
+  });
+
+  it("renders pattern cards when patterns are detected", () => {
+    const midScores = {
+      o1: { c1: { value: 5, confidence: "high" as const }, c2: { value: 5, confidence: "high" as const } },
+      o2: { c1: { value: 5, confidence: "high" as const }, c2: { value: 5, confidence: "high" as const } },
+    };
+    const decisions = [
+      makeDecision({ id: "d1", scores: midScores }),
+      makeDecision({ id: "d2", scores: midScores }),
+      makeDecision({ id: "d3", scores: midScores }),
+    ];
+    mockGetDecisions.mockReturnValue(decisions);
+
+    render(<PatternInsights decision={decisions[0]} />);
+
+    expect(screen.getByText("Decision Patterns")).toBeInTheDocument();
+    expect(screen.getAllByTestId("pattern-card").length).toBeGreaterThan(0);
+  });
+
+  it("renders the heading with pattern count badge", () => {
+    const midScores = {
+      o1: { c1: { value: 5, confidence: "high" as const }, c2: { value: 5, confidence: "high" as const } },
+      o2: { c1: { value: 5, confidence: "high" as const }, c2: { value: 5, confidence: "high" as const } },
+    };
+    const decisions = [
+      makeDecision({ id: "d1", scores: midScores }),
+      makeDecision({ id: "d2", scores: midScores }),
+      makeDecision({ id: "d3", scores: midScores }),
+    ];
+    mockGetDecisions.mockReturnValue(decisions);
+
+    render(<PatternInsights decision={decisions[0]} />);
+
+    // Should show count badge
+    const patterns = detectPatterns(decisions);
+    expect(screen.getByText(String(patterns.length))).toBeInTheDocument();
+  });
+});

--- a/src/components/PatternInsights.tsx
+++ b/src/components/PatternInsights.tsx
@@ -1,0 +1,174 @@
+/**
+ * PatternInsights — displays detected cross-decision patterns as cards.
+ *
+ * Shows pattern cards with confidence indicators, evidence lists,
+ * and a "Not enough data" placeholder when fewer than 3 decisions exist.
+ */
+
+"use client";
+
+import { useMemo } from "react";
+import {
+  TrendingUp,
+  Scale,
+  Target,
+  Repeat,
+  Brain,
+  Info,
+} from "lucide-react";
+import type { Decision } from "@/lib/types";
+import { getDecisions } from "@/lib/storage";
+import { detectPatterns, MIN_DECISIONS } from "@/lib/patterns";
+import type { DecisionPattern, PatternType } from "@/lib/patterns";
+
+// ---------------------------------------------------------------------------
+// Style map
+// ---------------------------------------------------------------------------
+
+const PATTERN_STYLES: Record<
+  PatternType,
+  { icon: typeof TrendingUp; color: string; bg: string; border: string }
+> = {
+  "scoring-bias": {
+    icon: TrendingUp,
+    color: "text-orange-600",
+    bg: "bg-orange-100 dark:bg-orange-900/30",
+    border: "border-orange-300 dark:border-orange-700",
+  },
+  "weight-preference": {
+    icon: Scale,
+    color: "text-blue-600",
+    bg: "bg-blue-100 dark:bg-blue-900/30",
+    border: "border-blue-300 dark:border-blue-700",
+  },
+  "prediction-accuracy": {
+    icon: Target,
+    color: "text-purple-600",
+    bg: "bg-purple-100 dark:bg-purple-900/30",
+    border: "border-purple-300 dark:border-purple-700",
+  },
+  "criterion-reuse": {
+    icon: Repeat,
+    color: "text-emerald-600",
+    bg: "bg-emerald-100 dark:bg-emerald-900/30",
+    border: "border-emerald-300 dark:border-emerald-700",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Sub-component
+// ---------------------------------------------------------------------------
+
+interface PatternCardProps {
+  pattern: DecisionPattern;
+}
+
+function PatternCard({ pattern }: Readonly<PatternCardProps>) {
+  const style = PATTERN_STYLES[pattern.type];
+  const Icon = style.icon;
+  const confidencePct = Math.round(pattern.confidence * 100);
+
+  return (
+    <div
+      className={`rounded-lg border ${style.border} ${style.bg} p-4 space-y-2`}
+      data-testid="pattern-card"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <Icon className={`h-5 w-5 shrink-0 ${style.color}`} />
+          <h4 className={`font-semibold text-sm ${style.color}`}>
+            {pattern.title}
+          </h4>
+        </div>
+        <span
+          className="text-xs font-medium text-gray-500 dark:text-gray-400 tabular-nums"
+          title="Confidence level"
+        >
+          {confidencePct}%
+        </span>
+      </div>
+
+      <p className="text-sm text-gray-700 dark:text-gray-300">
+        {pattern.description}
+      </p>
+
+      {pattern.evidence.length > 0 && (
+        <ul className="space-y-0.5 text-xs text-gray-500 dark:text-gray-400 mt-1">
+          {pattern.evidence.map((e) => (
+            <li key={e} className="flex items-start gap-1.5">
+              <span className="mt-1 block h-1 w-1 rounded-full bg-gray-400 shrink-0" />
+              {e}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+interface PatternInsightsProps {
+  decision: Decision;
+}
+
+export function PatternInsights({ decision }: Readonly<PatternInsightsProps>) {
+  const patterns = useMemo(() => {
+    const allDecisions = getDecisions();
+    return detectPatterns(allDecisions);
+  // We include decision.id so patterns refresh when switching decisions
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [decision.id]);
+
+  // ── Not enough data ─────────────────────────────────────────────────
+  if (patterns.length === 0) {
+    return (
+      <section
+        className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-6 text-center"
+        aria-label="Pattern Insights"
+        data-testid="patterns-empty"
+      >
+        <Brain className="h-10 w-10 mx-auto mb-3 text-gray-300 dark:text-gray-600" />
+        <h3 className="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-1">
+          No Patterns Detected
+        </h3>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          {`Make at least ${MIN_DECISIONS} decisions with scores to discover your decision-making patterns.`}
+        </p>
+      </section>
+    );
+  }
+
+  // ── Pattern cards ───────────────────────────────────────────────────
+  return (
+    <section
+      className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-5 space-y-4"
+      aria-label="Pattern Insights"
+    >
+      <div className="flex items-center gap-2">
+        <Brain className="h-5 w-5 text-purple-600" />
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+          Decision Patterns
+        </h3>
+        <span className="rounded-full bg-purple-100 dark:bg-purple-900/30 px-2 py-0.5 text-xs font-medium text-purple-700 dark:text-purple-300">
+          {patterns.length}
+        </span>
+      </div>
+
+      <div className="flex items-start gap-2 rounded-md bg-gray-50 dark:bg-gray-800/50 p-3 text-xs text-gray-500 dark:text-gray-400">
+        <Info className="h-4 w-4 shrink-0 mt-0.5 text-gray-400" />
+        <span>
+          These patterns are detected from your decision history. Higher confidence means stronger evidence.
+        </span>
+      </div>
+
+      <div className="space-y-3" data-testid="pattern-list">
+        {patterns.map((p) => (
+          <PatternCard key={p.id} pattern={p} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/ResultsView.tsx
+++ b/src/components/ResultsView.tsx
@@ -36,6 +36,7 @@ import { FrameworkComparison } from "./FrameworkComparison";
 import { CompositeConfidenceIndicator } from "./CompositeConfidenceIndicator";
 import { OutcomeTracker } from "./OutcomeTracker";
 import { RetrospectiveView } from "./RetrospectiveView";
+import { PatternInsights } from "./PatternInsights";
 
 const ScoreChart = lazy(() => import("./ScoreChart").then((m) => ({ default: m.ScoreChart })));
 const ParetoChart = lazy(() => import("./ParetoChart").then((m) => ({ default: m.ParetoChart })));
@@ -644,6 +645,9 @@ export function ResultsView({ validation, completeness, onSwitchToBuilder }: Res
 
       {/* Retrospective Timeline */}
       <RetrospectiveView decision={decision} />
+
+      {/* Cross-Decision Pattern Insights */}
+      <PatternInsights decision={decision} />
     </div>
   );
 }

--- a/src/lib/patterns.ts
+++ b/src/lib/patterns.ts
@@ -1,0 +1,395 @@
+/**
+ * Cross-decision pattern recognition — analyzes decision history for
+ * recurring scoring biases, weight preferences, and prediction accuracy.
+ *
+ * Requires >= 3 decisions for meaningful analysis. All functions are pure
+ * and operate on arrays of decisions + optional outcomes.
+ *
+ * @module patterns
+ */
+
+import type { Decision } from "./types";
+import type { DecisionOutcome } from "./outcome-tracking";
+import { resolveScoreValue } from "./scoring";
+import { generateId } from "./utils";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Categories of detectable patterns */
+export type PatternType =
+  | "scoring-bias"
+  | "weight-preference"
+  | "prediction-accuracy"
+  | "criterion-reuse";
+
+/** A single detected pattern */
+export interface DecisionPattern {
+  id: string;
+  type: PatternType;
+  title: string;
+  description: string;
+  confidence: number; // 0–1
+  evidence: string[];
+}
+
+/** Minimum decisions required for meaningful analysis */
+export const MIN_DECISIONS = 3;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Collect all resolved scores from a decision's score matrix.
+ * Returns a flat array of numeric scores.
+ */
+function collectScores(decision: Decision): number[] {
+  const scores: number[] = [];
+  for (const optionId of decision.options.map((o) => o.id)) {
+    for (const criterionId of decision.criteria.map((c) => c.id)) {
+      const sv = decision.scores[optionId]?.[criterionId];
+      const val = resolveScoreValue(sv);
+      if (val !== null) scores.push(val);
+    }
+  }
+  return scores;
+}
+
+/**
+ * Calculate the standard deviation of a numeric array.
+ */
+function standardDeviation(values: number[]): number {
+  if (values.length < 2) return 0;
+  const mean = values.reduce((a, b) => a + b, 0) / values.length;
+  const variance = values.reduce((sum, v) => sum + (v - mean) ** 2, 0) / values.length;
+  return Math.sqrt(variance);
+}
+
+// ---------------------------------------------------------------------------
+// Pattern detection algorithms
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the average score for an option across all criteria.
+ * Returns null if no scored cells exist.
+ */
+function optionAverage(decision: Decision, optionId: string): number | null {
+  let sum = 0;
+  let count = 0;
+  for (const criterion of decision.criteria) {
+    const sv = decision.scores[optionId]?.[criterion.id];
+    const val = resolveScoreValue(sv);
+    if (val !== null) {
+      sum += val;
+      count++;
+    }
+  }
+  return count > 0 ? sum / count : null;
+}
+
+/**
+ * Check whether the first option has the highest average in a decision.
+ */
+function isFirstOptionHighest(decision: Decision): boolean {
+  if (decision.options.length < 2) return false;
+
+  const firstAvg = optionAverage(decision, decision.options[0].id);
+  if (firstAvg === null) return false;
+
+  for (const option of decision.options.slice(1)) {
+    const avg = optionAverage(decision, option.id);
+    if (avg !== null && avg > firstAvg) return false;
+  }
+  return true;
+}
+
+/**
+ * Detect central tendency bias (most scores cluster in 4–6 range).
+ */
+function detectCentralTendency(decisions: Decision[]): DecisionPattern | undefined {
+  const allScores = decisions.flatMap(collectScores);
+  if (allScores.length === 0) return undefined;
+
+  const midRange = allScores.filter((s) => s >= 4 && s <= 6);
+  const midRatio = midRange.length / allScores.length;
+
+  if (midRatio <= 0.6) return undefined;
+
+  return {
+    id: generateId(),
+    type: "scoring-bias",
+    title: "Central Tendency Bias",
+    description:
+      `${(midRatio * 100).toFixed(0)}% of your scores fall between 4 and 6. ` +
+      "Consider using the full 1–10 range to better differentiate between options.",
+    confidence: Math.min(1, midRatio),
+    evidence: [
+      `${midRange.length}/${allScores.length} scores in the 4–6 range`,
+      `Standard deviation: ${standardDeviation(allScores).toFixed(2)}`,
+    ],
+  };
+}
+
+/**
+ * Detect first-option anchoring (first option consistently scores highest).
+ */
+function detectAnchoring(decisions: Decision[]): DecisionPattern | undefined {
+  const eligible = decisions.filter((d) => d.options.length >= 2);
+  if (eligible.length < MIN_DECISIONS) return undefined;
+
+  const firstHighest = eligible.filter(isFirstOptionHighest).length;
+  const ratio = firstHighest / eligible.length;
+
+  if (ratio <= 0.7) return undefined;
+
+  return {
+    id: generateId(),
+    type: "scoring-bias",
+    title: "First-Option Anchoring",
+    description:
+      `In ${(ratio * 100).toFixed(0)}% of your decisions, the first option scores highest. ` +
+      "Try reordering options to check for anchoring bias.",
+    confidence: Math.min(1, ratio),
+    evidence: [
+      `First option highest in ${firstHighest}/${eligible.length} decisions`,
+    ],
+  };
+}
+
+/**
+ * 1. Scoring bias: detects central tendency (most scores 4–6) or anchoring
+ *    (first option consistently gets highest scores).
+ */
+function detectScoringBias(decisions: Decision[]): DecisionPattern[] {
+  const patterns: DecisionPattern[] = [];
+
+  const tendency = detectCentralTendency(decisions);
+  if (tendency) patterns.push(tendency);
+
+  const anchoring = detectAnchoring(decisions);
+  if (anchoring) patterns.push(anchoring);
+
+  return patterns;
+}
+
+/**
+ * 2. Weight preference: same criteria consistently get the highest weight.
+ */
+function detectWeightPreference(decisions: Decision[]): DecisionPattern[] {
+  const patterns: DecisionPattern[] = [];
+  const weightLeaders = new Map<string, number>();
+
+  for (const decision of decisions) {
+    if (decision.criteria.length < 2) continue;
+    // Find the criterion with the highest weight
+    let maxWeight = -1;
+    let maxName = "";
+    for (const c of decision.criteria) {
+      if (c.weight > maxWeight) {
+        maxWeight = c.weight;
+        maxName = c.name.toLowerCase().trim();
+      }
+    }
+    if (maxName) {
+      weightLeaders.set(maxName, (weightLeaders.get(maxName) ?? 0) + 1);
+    }
+  }
+
+  for (const [name, count] of weightLeaders) {
+    if (count >= 2 && count / decisions.length >= 0.5) {
+      patterns.push({
+        id: generateId(),
+        type: "weight-preference",
+        title: "Recurring Weight Priority",
+        description:
+          `"${name}" has been your highest-weighted criterion in ${count}/${decisions.length} decisions. ` +
+          "This may reflect a genuine priority or an unconscious preference.",
+        confidence: Math.min(1, count / decisions.length),
+        evidence: [
+          `"${name}" weighted highest ${count} times`,
+          `Across ${decisions.length} total decisions`,
+        ],
+      });
+    }
+  }
+
+  return patterns;
+}
+
+/** Comparison between a prediction and actual outcome */
+interface PredComparison {
+  predicted: number;
+  actual: number;
+  title: string;
+}
+
+/**
+ * Build prediction–outcome comparisons from decision + outcome data.
+ */
+function buildComparisons(
+  decisions: Decision[],
+  outcomes: DecisionOutcome[],
+): PredComparison[] {
+  const comparisons: PredComparison[] = [];
+
+  for (const outcome of outcomes) {
+    if (outcome.predictedScore === undefined || outcome.outcomeRating === undefined) continue;
+    const decision = decisions.find((d) => d.id === outcome.decisionId);
+    if (!decision) continue;
+
+    comparisons.push({
+      predicted: outcome.predictedScore,
+      actual: outcome.outcomeRating,
+      title: decision.title,
+    });
+  }
+  return comparisons;
+}
+
+/**
+ * Detect average delta bias (optimism / pessimism).
+ */
+function detectDeltaBias(comparisons: PredComparison[]): DecisionPattern | undefined {
+  const totalDelta = comparisons.reduce((sum, c) => sum + (c.actual - c.predicted), 0);
+  const avgDelta = totalDelta / comparisons.length;
+
+  if (Math.abs(avgDelta) <= 1) return undefined;
+
+  const direction = avgDelta < 0 ? "over-predicting" : "under-predicting";
+  const suffix = avgDelta < 0
+    ? "Your predictions are more optimistic than actual results."
+    : "Actual outcomes tend to exceed your predictions.";
+
+  return {
+    id: generateId(),
+    type: "prediction-accuracy",
+    title: avgDelta < 0 ? "Optimism Bias" : "Pessimism Bias",
+    description:
+      `You tend to be ${direction} outcomes by an average of ${Math.abs(avgDelta).toFixed(1)} points. ${suffix}`,
+    confidence: Math.min(1, Math.abs(avgDelta) / 5),
+    evidence: comparisons.map(
+      (c) => `"${c.title}": predicted ${c.predicted.toFixed(1)}, actual ${c.actual}`,
+    ),
+  };
+}
+
+/**
+ * Detect consistent over/under prediction pattern.
+ */
+function detectConsistentDirection(comparisons: PredComparison[]): DecisionPattern | undefined {
+  let overCount = 0;
+  let underCount = 0;
+
+  for (const c of comparisons) {
+    const delta = c.actual - c.predicted;
+    if (delta < -1) overCount++;
+    if (delta > 1) underCount++;
+  }
+
+  const dominant = Math.max(overCount, underCount);
+  if (dominant < 2) return undefined;
+
+  const ratio = dominant / comparisons.length;
+  if (ratio < 0.6) return undefined;
+
+  const direction = overCount > underCount ? "optimistic" : "conservative";
+  const label = direction.charAt(0).toUpperCase() + direction.slice(1);
+
+  return {
+    id: generateId(),
+    type: "prediction-accuracy",
+    title: `Consistently ${label} Predictions`,
+    description:
+      `${dominant}/${comparisons.length} predictions were ${direction}. ` +
+      "Consider adjusting your expectations when scoring options.",
+    confidence: Math.min(1, ratio),
+    evidence: [`${overCount} over-predictions, ${underCount} under-predictions`],
+  };
+}
+
+/**
+ * 3. Prediction accuracy: compares outcome ratings with predicted scores.
+ */
+function detectPredictionAccuracy(
+  decisions: Decision[],
+  outcomes: DecisionOutcome[],
+): DecisionPattern[] {
+  const comparisons = buildComparisons(decisions, outcomes);
+  if (comparisons.length < 2) return [];
+
+  const patterns: DecisionPattern[] = [];
+
+  const deltaBias = detectDeltaBias(comparisons);
+  if (deltaBias) patterns.push(deltaBias);
+
+  const directionBias = detectConsistentDirection(comparisons);
+  if (directionBias) patterns.push(directionBias);
+
+  return patterns;
+}
+
+/**
+ * 4. Criterion reuse: frequency analysis of criterion names across decisions.
+ */
+function detectCriterionReuse(decisions: Decision[]): DecisionPattern[] {
+  const patterns: DecisionPattern[] = [];
+  const nameCounts = new Map<string, number>();
+
+  for (const decision of decisions) {
+    for (const criterion of decision.criteria) {
+      const name = criterion.name.toLowerCase().trim();
+      nameCounts.set(name, (nameCounts.get(name) ?? 0) + 1);
+    }
+  }
+
+  // Find criteria used in >= 50% of decisions
+  const reused: Array<{ name: string; count: number }> = [];
+  for (const [name, count] of nameCounts) {
+    if (count >= 2 && count / decisions.length >= 0.5) {
+      reused.push({ name, count });
+    }
+  }
+
+  if (reused.length > 0) {
+    reused.sort((a, b) => b.count - a.count);
+    patterns.push({
+      id: generateId(),
+      type: "criterion-reuse",
+      title: "Recurring Decision Criteria",
+      description:
+        `You frequently use the same criteria across decisions: ` +
+        reused.map((r) => `"${r.name}" (${r.count}x)`).join(", ") +
+        ". These seem to be core values driving your decisions.",
+      confidence: Math.min(1, reused[0].count / decisions.length),
+      evidence: reused.map(
+        (r) => `"${r.name}" used in ${r.count}/${decisions.length} decisions`,
+      ),
+    });
+  }
+
+  return patterns;
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect patterns across a user's decision history.
+ * Returns an empty array if fewer than MIN_DECISIONS are provided.
+ */
+export function detectPatterns(
+  decisions: Decision[],
+  outcomes: DecisionOutcome[] = [],
+): DecisionPattern[] {
+  if (decisions.length < MIN_DECISIONS) return [];
+
+  return [
+    ...detectScoringBias(decisions),
+    ...detectWeightPreference(decisions),
+    ...detectPredictionAccuracy(decisions, outcomes),
+    ...detectCriterionReuse(decisions),
+  ];
+}


### PR DESCRIPTION
## Summary

Adds **cross-decision pattern recognition** — analyzes a user's decision history to detect recurring biases, preferences, and prediction accuracy.

## Changes

### New: `src/lib/patterns.ts`
- **4 pattern detection algorithms** (pure functions):
  1. **Central Tendency Bias** — detects when >60% of scores cluster in the 4-6 range
  2. **First-Option Anchoring** — detects when the first option consistently scores highest (>70%)
  3. **Weight Preference** — detects when the same criterion is always the highest-weighted
  4. **Prediction Accuracy** — detects optimism/pessimism bias by comparing predictions to outcomes
  5. **Criterion Reuse** — identifies recurring criteria across decisions
- Requires minimum 3 decisions for meaningful analysis
- Each pattern includes confidence score (0-1) and evidence strings

### New: `src/components/PatternInsights.tsx`
- Pattern cards with type-specific icons and color coding
- Confidence percentage badge on each card
- Evidence list with bullet points
- Empty state when no patterns detected (< 3 decisions)
- Info banner explaining confidence levels

### Modified: `src/components/ResultsView.tsx`
- Added `<PatternInsights>` below `<RetrospectiveView>`

### New: `src/__tests__/patterns.test.tsx`
- 10 unit tests: empty array, < MIN_DECISIONS, central tendency, spread scores, anchoring, weight preference, prediction accuracy (optimism bias), criterion reuse, evidence strings, confidence range
- 4 component tests: empty state, aria-label, pattern cards rendering, count badge

## Dependencies
- Journal data model (#98) ✓
- Outcome tracking (#100) ✓
- Retrospective view (#101) ✓

Closes #102
