### PR TITLE
feat(data): DataProvider base class and enrichment types

### DIFF
--- a/docs/DECISIONS/ADR-005-data-enrichment.md
+++ b/docs/DECISIONS/ADR-005-data-enrichment.md
@@ -1,0 +1,65 @@
+# ADR-005: Data Enrichment Provider Architecture
+
+## Status
+
+Accepted
+
+## Context
+
+DecisionOS currently relies entirely on manual user input for scoring
+criteria. For location-based decisions (the primary use-case) much of
+this data — cost-of-living indices, tax rates, university rankings,
+safety scores — is publicly available.
+
+We need a pluggable system that can:
+
+1. Pull data from **bundled datasets** (Tier 2) and **live APIs** (Tier 1)
+2. Fall back to **estimation** when exact data is unavailable (Tier 3)
+3. Normalise heterogeneous raw values onto a common 0–100 scale
+4. Cache results to avoid redundant lookups
+5. Expose source attribution and confidence for transparency
+
+Options considered:
+
+1. Hard-code each data source directly into UI components
+2. Create a provider registry with a common `DataProvider` base class
+3. Use a single monolithic "data service" without abstraction
+
+## Decision
+
+**Option 2 — abstract `DataProvider` base class with a provider registry.**
+
+Key components:
+
+- `DataProvider` abstract class (`src/lib/data/provider.ts`) defines
+  `fetch()`, `supports()`, cache logic, and `normalize()`.
+- `DataPoint` interface: `value` (0–100), `rawValue`, `unit`, `source`,
+  `confidence` (0–1), `tier` (1 | 2 | 3), `updatedAt`, `citation?`.
+- `DataQuery` interface: `country`, `city?`, `category`, `metric`.
+- Each concrete provider (cost-of-living, tax, etc.) extends
+  `DataProvider` and implements `fetchData()` + `supports()`.
+- A provider registry (issue #104) aggregates providers and routes
+  queries.
+
+## Rationale
+
+- **Extensibility** — new data sources are added by subclassing, no
+  changes to existing code.
+- **Testability** — each provider is independently unit-testable;
+  base class cache logic is tested once.
+- **Tier system** — lets the UI clearly communicate data freshness
+  (live → bundled → estimated).
+- **Cache-first** — 24-hour in-memory TTL avoids repeated lookups
+  during a single session.
+- **Normalisation** — linear min-max mapping keeps all scores on the
+  same 0–100 scale used by the scoring engine.
+
+## Consequences
+
+- Every new data source requires a new subclass and registration.
+- In-memory cache is lost on page reload; this is acceptable for a
+  local-first app where sessions are short.
+- The `normalize()` function assumes linear scaling; some metrics may
+  need logarithmic or percentile-based normalization in the future.
+- Confidence values are provider-reported; there is no cross-provider
+  calibration mechanism yet.

--- a/src/__tests__/data/provider.test.ts
+++ b/src/__tests__/data/provider.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { DataProvider, DataPoint, DataQuery } from "@/lib/data/provider";
+
+// ---------------------------------------------------------------------------
+// Concrete stub used across tests
+// ---------------------------------------------------------------------------
+
+class StubProvider extends DataProvider {
+  readonly id = "stub";
+  readonly name = "Stub Provider";
+  readonly categories = ["test-category"] as const;
+
+  /** Controls what `fetchData` resolves to */
+  result: DataPoint | null = null;
+
+  /** Track how many times fetchData is actually invoked */
+  fetchCount = 0;
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected async fetchData(query: DataQuery): Promise<DataPoint | null> {
+    this.fetchCount += 1;
+    return this.result;
+  }
+
+  supports(query: DataQuery): boolean {
+    return this.categories.includes(query.category as "test-category");
+  }
+
+  // Expose protected helpers for testing
+  publicNormalize(value: number, min: number, max: number): number {
+    return this.normalize(value, min, max);
+  }
+
+  publicGetCacheKey(query: DataQuery): string {
+    return this.getCacheKey(query);
+  }
+
+  setTtl(ms: number): void {
+    this.ttlMs = ms;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const baseQuery: DataQuery = {
+  country: "US",
+  city: "New York",
+  category: "test-category",
+  metric: "rent",
+};
+
+const samplePoint: DataPoint = {
+  value: 72,
+  rawValue: 2800,
+  unit: "USD",
+  source: "Stub Provider",
+  confidence: 0.85,
+  tier: 2,
+  updatedAt: "2025-01-01T00:00:00Z",
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DataProvider", () => {
+  let provider: StubProvider;
+
+  beforeEach(() => {
+    provider = new StubProvider();
+    provider.result = { ...samplePoint };
+  });
+
+  // ── Abstract contract ─────────────────────────────────────────────
+
+  it("exposes id, name, and categories", () => {
+    expect(provider.id).toBe("stub");
+    expect(provider.name).toBe("Stub Provider");
+    expect(provider.categories).toContain("test-category");
+  });
+
+  it("supports() returns true for matching category", () => {
+    expect(provider.supports(baseQuery)).toBe(true);
+  });
+
+  it("supports() returns false for unknown category", () => {
+    expect(provider.supports({ ...baseQuery, category: "unknown" })).toBe(
+      false,
+    );
+  });
+
+  // ── fetch() + caching ─────────────────────────────────────────────
+
+  it("fetch() returns the data point from fetchData()", async () => {
+    const result = await provider.fetch(baseQuery);
+    expect(result).toEqual(samplePoint);
+    expect(provider.fetchCount).toBe(1);
+  });
+
+  it("fetch() returns null when fetchData() returns null", async () => {
+    provider.result = null;
+    const result = await provider.fetch(baseQuery);
+    expect(result).toBeNull();
+    expect(provider.fetchCount).toBe(1);
+  });
+
+  it("fetch() caches results and skips fetchData on re-fetch", async () => {
+    await provider.fetch(baseQuery);
+    await provider.fetch(baseQuery);
+    expect(provider.fetchCount).toBe(1);
+    expect(provider.cacheSize).toBe(1);
+  });
+
+  it("fetch() calls fetchData again after cache expires", async () => {
+    provider.setTtl(0); // instant expiry
+    await provider.fetch(baseQuery);
+
+    // Advance time by 1 ms so the entry is expired
+    vi.spyOn(Date, "now").mockReturnValue(Date.now() + 1);
+
+    await provider.fetch(baseQuery);
+    expect(provider.fetchCount).toBe(2);
+
+    vi.restoreAllMocks();
+  });
+
+  it("different queries produce different cache entries", async () => {
+    const query2: DataQuery = { ...baseQuery, city: "Chicago" };
+    await provider.fetch(baseQuery);
+    await provider.fetch(query2);
+    expect(provider.cacheSize).toBe(2);
+    expect(provider.fetchCount).toBe(2);
+  });
+
+  it("clearCache() empties the cache", async () => {
+    await provider.fetch(baseQuery);
+    expect(provider.cacheSize).toBe(1);
+    provider.clearCache();
+    expect(provider.cacheSize).toBe(0);
+  });
+
+  // ── getCacheKey ───────────────────────────────────────────────────
+
+  it("getCacheKey() is deterministic", () => {
+    const key1 = provider.publicGetCacheKey(baseQuery);
+    const key2 = provider.publicGetCacheKey(baseQuery);
+    expect(key1).toBe(key2);
+  });
+
+  it("getCacheKey() is case-insensitive for country and city", () => {
+    const upper = provider.publicGetCacheKey({
+      ...baseQuery,
+      country: "US",
+      city: "New York",
+    });
+    const lower = provider.publicGetCacheKey({
+      ...baseQuery,
+      country: "us",
+      city: "new york",
+    });
+    expect(upper).toBe(lower);
+  });
+
+  it("getCacheKey() handles missing city with placeholder", () => {
+    const key = provider.publicGetCacheKey({
+      country: "FR",
+      category: "test-category",
+      metric: "rent",
+    });
+    expect(key).toContain("_");
+    expect(key).not.toContain("undefined");
+  });
+
+  // ── normalize ─────────────────────────────────────────────────────
+
+  it("normalize() maps value to 0–100 linearly", () => {
+    expect(provider.publicNormalize(50, 0, 100)).toBe(50);
+    expect(provider.publicNormalize(0, 0, 100)).toBe(0);
+    expect(provider.publicNormalize(100, 0, 100)).toBe(100);
+  });
+
+  it("normalize() clamps below 0", () => {
+    expect(provider.publicNormalize(-10, 0, 100)).toBe(0);
+  });
+
+  it("normalize() clamps above 100", () => {
+    expect(provider.publicNormalize(200, 0, 100)).toBe(100);
+  });
+
+  it("normalize() returns 50 when min === max (avoid division by zero)", () => {
+    expect(provider.publicNormalize(42, 42, 42)).toBe(50);
+  });
+
+  it("normalize() handles inverted ranges correctly", () => {
+    // min > max effectively inverts the scale
+    const result = provider.publicNormalize(75, 100, 0);
+    // (75 - 100) / (0 - 100) = -25 / -100 = 0.25 → 25
+    expect(result).toBe(25);
+  });
+
+  // ── DataPoint structure ───────────────────────────────────────────
+
+  it("DataPoint has required fields", () => {
+    expect(samplePoint.value).toBeGreaterThanOrEqual(0);
+    expect(samplePoint.value).toBeLessThanOrEqual(100);
+    expect(samplePoint.confidence).toBeGreaterThanOrEqual(0);
+    expect(samplePoint.confidence).toBeLessThanOrEqual(1);
+    expect([1, 2, 3]).toContain(samplePoint.tier);
+    expect(samplePoint.unit).toBeTruthy();
+    expect(samplePoint.source).toBeTruthy();
+    expect(samplePoint.updatedAt).toBeTruthy();
+  });
+});

--- a/src/lib/data/provider.ts
+++ b/src/lib/data/provider.ts
@@ -1,0 +1,171 @@
+/**
+ * Data provider base class and shared types for the enrichment system.
+ *
+ * Every data source (cost-of-living, tax, university rankings, etc.)
+ * extends `DataProvider`. The base class supplies:
+ * - In-memory cache with configurable TTL
+ * - Linear min-max normalization
+ * - Deterministic cache keys
+ * - Standard fetch + supports interface
+ *
+ * @module data/provider
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A single enriched data point */
+export interface DataPoint {
+  /** Normalised value on a 0–100 scale */
+  value: number;
+  /** Original value in the metric's native unit */
+  rawValue: number;
+  /** Unit of the raw value (e.g. "USD", "index", "rank") */
+  unit: string;
+  /** Human-readable provider name */
+  source: string;
+  /** How reliable this data point is (0.0–1.0) */
+  confidence: number;
+  /** Data freshness tier: 1 = live API, 2 = bundled, 3 = estimated */
+  tier: 1 | 2 | 3;
+  /** When the data was last refreshed (ISO 8601) */
+  updatedAt: string;
+  /** Optional source URL for citation */
+  citation?: string;
+}
+
+/** Structured query for fetching a data point */
+export interface DataQuery {
+  /** City name (optional — some metrics are country-level) */
+  city?: string;
+  /** ISO 3166-1 alpha-2 country code */
+  country: string;
+  /** Top-level metric category (e.g. "cost-of-living", "tax") */
+  category: string;
+  /** Specific metric within the category (e.g. "rent-1br-center") */
+  metric: string;
+}
+
+/** Cached entry wrapping a DataPoint with expiry */
+interface CacheEntry {
+  data: DataPoint;
+  expiresAt: number; // Unix ms
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Default cache TTL: 24 hours */
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// DataProvider abstract class
+// ---------------------------------------------------------------------------
+
+/**
+ * Base class for all data providers.
+ *
+ * Subclasses must implement:
+ * - `id` — unique provider identifier
+ * - `name` — human-readable provider name
+ * - `categories` — list of supported categories
+ * - `fetchData(query)` — the actual data retrieval logic
+ * - `supports(query)` — whether this provider can handle the query
+ */
+export abstract class DataProvider {
+  /** Unique provider identifier */
+  abstract readonly id: string;
+
+  /** Human-readable name */
+  abstract readonly name: string;
+
+  /** Categories this provider covers */
+  abstract readonly categories: readonly string[];
+
+  /** Cache TTL in milliseconds */
+  protected ttlMs: number = DEFAULT_TTL_MS;
+
+  /** Internal cache */
+  private readonly cache = new Map<string, CacheEntry>();
+
+  // ── Abstract methods required by subclasses ──────────────────────────
+
+  /**
+   * Fetch a data point for the given query.
+   * Implementations should NOT cache — the base class handles that.
+   * Return `null` if the query cannot be satisfied.
+   */
+  protected abstract fetchData(query: DataQuery): Promise<DataPoint | null>;
+
+  /**
+   * Whether this provider can handle the given query.
+   */
+  abstract supports(query: DataQuery): boolean;
+
+  // ── Public API ──────────────────────────────────────────────────────
+
+  /**
+   * Fetch a data point, returning a cached result if available.
+   * Returns `null` when the query cannot be fulfilled.
+   */
+  async fetch(query: DataQuery): Promise<DataPoint | null> {
+    const key = this.getCacheKey(query);
+    const cached = this.cache.get(key);
+
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.data;
+    }
+
+    const data = await this.fetchData(query);
+    if (data) {
+      this.cache.set(key, { data, expiresAt: Date.now() + this.ttlMs });
+    }
+    return data;
+  }
+
+  /**
+   * Clear the entire cache.
+   */
+  clearCache(): void {
+    this.cache.clear();
+  }
+
+  /**
+   * Number of entries currently in the cache (including expired).
+   */
+  get cacheSize(): number {
+    return this.cache.size;
+  }
+
+  // ── Protected helpers ───────────────────────────────────────────────
+
+  /**
+   * Build a deterministic cache key from a query.
+   */
+  protected getCacheKey(query: DataQuery): string {
+    const parts = [
+      this.id,
+      query.country.toLowerCase(),
+      query.city?.toLowerCase() ?? "_",
+      query.category,
+      query.metric,
+    ];
+    return parts.join("|");
+  }
+
+  /**
+   * Linear min-max normalization to a 0–100 scale.
+   *
+   * @param value — raw value to normalize
+   * @param min — the minimum of the domain (maps to 0)
+   * @param max — the maximum of the domain (maps to 100)
+   * @returns normalized value clamped to [0, 100]
+   */
+  protected normalize(value: number, min: number, max: number): number {
+    if (max === min) return 50; // avoid division by zero
+    const ratio = (value - min) / (max - min);
+    return Math.max(0, Math.min(100, ratio * 100));
+  }
+}


### PR DESCRIPTION
## Summary

Adds the `DataProvider` abstract base class and shared types that form the foundation of the data enrichment system. All future data providers (cost-of-living, tax, university rankings, etc.) will extend this class.

## Changes

### `src/lib/data/provider.ts`
- **`DataPoint`** interface — normalized value (0–100), rawValue, unit, source, confidence (0–1), tier (1/2/3), updatedAt, optional citation
- **`DataQuery`** interface — country, city?, category, metric
- **`DataProvider`** abstract class:
  - `fetch(query)` — cache-first data retrieval
  - `supports(query)` — query capability check
  - In-memory cache with configurable TTL (default 24h)
  - `normalize(value, min, max)` — linear min-max to 0–100, clamped
  - `getCacheKey(query)` — deterministic, case-insensitive
  - `clearCache()`, `cacheSize`

### `docs/DECISIONS/ADR-005-data-enrichment.md`
- Documents the provider architecture decision

### `src/__tests__/data/provider.test.ts`
- 18 unit tests covering: abstract contract, fetch + caching, cache expiry, cache key determinism, normalization (linear, clamp, edge cases), DataPoint validation

## Checklist
- [x] TypeScript strict
- [x] 18 tests passing
- [x] Zero lint errors
- [x] ADR-005 written

Closes #103
