### PR TITLE
feat(data): provider registry and enrichment engine

### DIFF
--- a/src/__tests__/data/engine.test.ts
+++ b/src/__tests__/data/engine.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { DataProvider, DataPoint, DataQuery } from "@/lib/data/provider";
+import { ProviderRegistry } from "@/lib/data/registry";
+import { EnrichmentEngine } from "@/lib/data/engine";
+import type { Decision } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Stub provider
+// ---------------------------------------------------------------------------
+
+function makePoint(overrides: Partial<DataPoint> = {}): DataPoint {
+  return {
+    value: 60,
+    rawValue: 1500,
+    unit: "USD",
+    source: "stub",
+    confidence: 0.8,
+    tier: 2,
+    updatedAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+class StubProvider extends DataProvider {
+  readonly id: string;
+  readonly name: string;
+  readonly categories: readonly string[];
+  result: DataPoint | null;
+
+  constructor(
+    id: string,
+    categories: string[],
+    result: DataPoint | null = makePoint(),
+  ) {
+    super();
+    this.id = id;
+    this.name = `Provider ${id}`;
+    this.categories = categories;
+    this.result = result;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected async fetchData(query: DataQuery): Promise<DataPoint | null> {
+    return this.result;
+  }
+
+  supports(query: DataQuery): boolean {
+    return this.categories.includes(query.category);
+  }
+}
+
+/** A provider that never resolves (simulates timeout) */
+class HangingProvider extends DataProvider {
+  readonly id = "hanging";
+  readonly name = "Hanging Provider";
+  readonly categories = ["test"] as const;
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected fetchData(_q: DataQuery): Promise<DataPoint | null> {
+    return new Promise(() => {
+      /* never resolves */
+    });
+  }
+
+  supports(): boolean {
+    return true;
+  }
+}
+
+/** A provider that rejects */
+class FailingProvider extends DataProvider {
+  readonly id = "failing";
+  readonly name = "Failing Provider";
+  readonly categories = ["test"] as const;
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected async fetchData(_q: DataQuery): Promise<DataPoint | null> {
+    throw new Error("network error");
+  }
+
+  supports(): boolean {
+    return true;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const baseQuery: DataQuery = {
+  country: "US",
+  city: "Boston",
+  category: "test",
+  metric: "alpha",
+};
+
+function makeDecision(overrides: Partial<Decision> = {}): Decision {
+  return {
+    id: "d1",
+    title: "Where to live?",
+    options: [
+      { id: "o1", name: "Berlin, DE" },
+      { id: "o2", name: "Tokyo, JP" },
+    ],
+    criteria: [
+      { id: "c1", name: "Cost of Living", weight: 50, type: "cost" },
+      { id: "c2", name: "Safety", weight: 30, type: "benefit" },
+    ],
+    scores: {},
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// ProviderRegistry tests
+// ---------------------------------------------------------------------------
+
+describe("ProviderRegistry", () => {
+  let reg: ProviderRegistry;
+
+  beforeEach(() => {
+    reg = new ProviderRegistry();
+  });
+
+  it("registers and retrieves a provider by id", () => {
+    const p = new StubProvider("a", ["cat"]);
+    reg.register(p);
+    expect(reg.getProvider("a")).toBe(p);
+    expect(reg.size).toBe(1);
+  });
+
+  it("returns undefined for unknown id", () => {
+    expect(reg.getProvider("nope")).toBeUndefined();
+  });
+
+  it("overwrites provider on duplicate id", () => {
+    const p1 = new StubProvider("a", ["cat1"]);
+    const p2 = new StubProvider("a", ["cat2"]);
+    reg.register(p1);
+    reg.register(p2);
+    expect(reg.size).toBe(1);
+    expect(reg.getProvider("a")).toBe(p2);
+  });
+
+  it("getProvidersForCategory returns matching providers", () => {
+    reg.register(new StubProvider("a", ["cost", "tax"]));
+    reg.register(new StubProvider("b", ["tax"]));
+    reg.register(new StubProvider("c", ["safety"]));
+    expect(reg.getProvidersForCategory("tax")).toHaveLength(2);
+    expect(reg.getProvidersForCategory("cost")).toHaveLength(1);
+    expect(reg.getProvidersForCategory("unknown")).toHaveLength(0);
+  });
+
+  it("listCategories returns sorted de-duplicated list", () => {
+    reg.register(new StubProvider("a", ["tax", "cost"]));
+    reg.register(new StubProvider("b", ["tax", "safety"]));
+    expect(reg.listCategories()).toEqual(["cost", "safety", "tax"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EnrichmentEngine tests
+// ---------------------------------------------------------------------------
+
+describe("EnrichmentEngine", () => {
+  let reg: ProviderRegistry;
+  let engine: EnrichmentEngine;
+
+  beforeEach(() => {
+    reg = new ProviderRegistry();
+    engine = new EnrichmentEngine(reg);
+  });
+
+  it("enrich() returns null when no providers match", async () => {
+    const result = await engine.enrich(baseQuery);
+    expect(result).toBeNull();
+  });
+
+  it("enrich() returns data from a matching provider", async () => {
+    const point = makePoint({ value: 77 });
+    reg.register(new StubProvider("a", ["test"], point));
+    const result = await engine.enrich(baseQuery);
+    expect(result).toEqual(point);
+  });
+
+  it("enrich() prefers lower-tier results", async () => {
+    const tier2 = makePoint({ tier: 2, confidence: 0.9 });
+    const tier1 = makePoint({ tier: 1, confidence: 0.7 });
+    reg.register(new StubProvider("bundled", ["test"], tier2));
+    reg.register(new StubProvider("live", ["test"], tier1));
+    const result = await engine.enrich(baseQuery);
+    expect(result?.tier).toBe(1);
+  });
+
+  it("enrich() prefers higher confidence on same tier", async () => {
+    const low = makePoint({ tier: 2, confidence: 0.5 });
+    const high = makePoint({ tier: 2, confidence: 0.95 });
+    reg.register(new StubProvider("lo", ["test"], low));
+    reg.register(new StubProvider("hi", ["test"], high));
+    const result = await engine.enrich(baseQuery);
+    expect(result?.confidence).toBe(0.95);
+  });
+
+  it("enrich() gracefully handles provider errors", async () => {
+    reg.register(new FailingProvider());
+    const result = await engine.enrich(baseQuery);
+    expect(result).toBeNull();
+  });
+
+  it("enrich() times out slow providers", async () => {
+    reg.register(new HangingProvider());
+    engine.setTimeout(50); // 50ms timeout
+    const result = await engine.enrich(baseQuery);
+    expect(result).toBeNull();
+  }, 2000);
+
+  it("enrichBatch() processes multiple queries in parallel", async () => {
+    reg.register(new StubProvider("a", ["test"], makePoint({ value: 10 })));
+    reg.register(new StubProvider("b", ["other"], makePoint({ value: 90 })));
+
+    const queries: DataQuery[] = [
+      { country: "US", category: "test", metric: "x" },
+      { country: "US", category: "other", metric: "y" },
+      { country: "US", category: "none", metric: "z" },
+    ];
+
+    const results = await engine.enrichBatch(queries);
+    expect(results.size).toBe(3);
+
+    // "none" category → null
+    const keys = [...results.keys()];
+    const values = [...results.values()];
+    const nullCount = values.filter((v) => v === null).length;
+    expect(nullCount).toBe(1);
+    expect(keys.length).toBe(3);
+  });
+
+  // ── suggestEnrichments ──────────────────────────────────────────
+
+  it("suggestEnrichments() returns queries from matching criteria", () => {
+    reg.register(new StubProvider("col", ["cost-of-living"]));
+    reg.register(new StubProvider("safe", ["safety"]));
+
+    const decision = makeDecision();
+    const suggestions = engine.suggestEnrichments(decision);
+
+    // 2 criteria × 2 options = up to 4 suggestions
+    expect(suggestions.length).toBeGreaterThanOrEqual(2);
+
+    const categories = suggestions.map((s) => s.category);
+    expect(categories).toContain("cost-of-living");
+    expect(categories).toContain("safety");
+  });
+
+  it("suggestEnrichments() de-duplicates queries", () => {
+    reg.register(new StubProvider("col", ["cost-of-living"]));
+
+    const decision = makeDecision({
+      criteria: [
+        { id: "c1", name: "Cost of Living", weight: 50, type: "cost" },
+        { id: "c2", name: "Living Cost", weight: 30, type: "cost" },
+      ],
+    });
+
+    const suggestions = engine.suggestEnrichments(decision);
+    const keys = suggestions.map(
+      (s) => `${s.country}|${s.city ?? "_"}|${s.category}|${s.metric}`,
+    );
+    const unique = new Set(keys);
+    expect(unique.size).toBe(keys.length);
+  });
+
+  it("suggestEnrichments() returns empty for unrecognised criteria", () => {
+    reg.register(new StubProvider("col", ["cost-of-living"]));
+    const decision = makeDecision({
+      criteria: [{ id: "c1", name: "Vibes", weight: 100, type: "benefit" }],
+    });
+    expect(engine.suggestEnrichments(decision)).toEqual([]);
+  });
+
+  it("suggestEnrichments() skips categories with no registered providers", () => {
+    // Nothing registered → no suggestions even for matching criteria
+    const decision = makeDecision();
+    expect(engine.suggestEnrichments(decision)).toEqual([]);
+  });
+});

--- a/src/lib/data/engine.ts
+++ b/src/lib/data/engine.ts
@@ -1,0 +1,261 @@
+/**
+ * Enrichment engine — the bridge between data providers and Decision OS.
+ *
+ * Responsibilities:
+ * - Three-tier fallback: Tier 1 (live) → Tier 2 (bundled) → Tier 3 (estimated)
+ * - Per-provider timeout (default 5 s)
+ * - Batch enrichment (parallel queries)
+ * - `suggestEnrichments()` — analyse a Decision's criteria names and propose
+ *   matching DataQuery objects
+ *
+ * @module data/engine
+ */
+
+import type { Decision } from "../types";
+import type { DataPoint, DataQuery } from "./provider";
+import type { ProviderRegistry } from "./registry";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Default per-provider timeout in milliseconds */
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Race a promise against a timeout. Resolves to `null` if the timeout
+ * fires first.
+ */
+function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+): Promise<T | null> {
+  return new Promise<T | null>((resolve) => {
+    const timer = setTimeout(() => resolve(null), ms);
+    promise
+      .then((v) => {
+        clearTimeout(timer);
+        resolve(v);
+      })
+      .catch(() => {
+        clearTimeout(timer);
+        resolve(null);
+      });
+  });
+}
+
+/**
+ * Keyword → category mapping used by `suggestEnrichments` to infer what
+ * data queries might be useful for a given criterion name.
+ */
+const KEYWORD_MAP: ReadonlyArray<{
+  pattern: RegExp;
+  category: string;
+  metric: string;
+}> = [
+  { pattern: /cost.?of.?living|col\b|living.?cost/i, category: "cost-of-living", metric: "overall" },
+  { pattern: /rent|housing/i, category: "cost-of-living", metric: "rent-1br-center" },
+  { pattern: /groceries|food/i, category: "cost-of-living", metric: "groceries" },
+  { pattern: /tax|income.?tax/i, category: "tax", metric: "income-tax-rate" },
+  { pattern: /corporate.?tax|business.?tax/i, category: "tax", metric: "corporate-tax-rate" },
+  { pattern: /universit|higher.?ed|college/i, category: "university", metric: "ranking" },
+  { pattern: /safe|crime|security/i, category: "safety", metric: "safety-index" },
+  { pattern: /climate|weather|temperature/i, category: "climate", metric: "avg-temperature" },
+  { pattern: /health|healthcare/i, category: "healthcare", metric: "quality-index" },
+  { pattern: /internet|connectivity|broadband/i, category: "infrastructure", metric: "internet-speed" },
+  { pattern: /pollution|air.?quality|environment/i, category: "environment", metric: "pollution-index" },
+  { pattern: /transport|commut/i, category: "infrastructure", metric: "transport-index" },
+];
+
+// ---------------------------------------------------------------------------
+// EnrichmentEngine
+// ---------------------------------------------------------------------------
+
+export class EnrichmentEngine {
+  private readonly registry: ProviderRegistry;
+  private timeoutMs: number;
+
+  constructor(registry: ProviderRegistry, timeoutMs = DEFAULT_TIMEOUT_MS) {
+    this.registry = registry;
+    this.timeoutMs = timeoutMs;
+  }
+
+  /**
+   * Set the per-provider timeout (ms).
+   */
+  setTimeout(ms: number): void {
+    this.timeoutMs = ms;
+  }
+
+  // ── Single-query enrichment with three-tier fallback ──────────────
+
+  /**
+   * Enrich a single query using the three-tier fallback strategy:
+   *
+   * 1. Try every provider that supports the query, preferring lower tiers
+   *    (Tier 1 > Tier 2 > Tier 3).
+   * 2. Each provider call is capped by `timeoutMs`.
+   * 3. Returns the best `DataPoint` found, or `null` if no provider can
+   *    satisfy the query.
+   */
+  async enrich(query: DataQuery): Promise<DataPoint | null> {
+    const providers = this.registry.getProvidersForCategory(query.category);
+    const candidates = providers.filter((p) => p.supports(query));
+
+    if (candidates.length === 0) return null;
+
+    let best: DataPoint | null = null;
+
+    for (const provider of candidates) {
+      const result = await withTimeout(provider.fetch(query), this.timeoutMs);
+      if (result) {
+        best = pickBetter(best, result);
+        // Short-circuit: Tier 1 with high confidence is optimal
+        if (best.tier === 1 && best.confidence >= 0.9) break;
+      }
+    }
+
+    return best;
+  }
+
+  // ── Batch enrichment ──────────────────────────────────────────────
+
+  /**
+   * Enrich multiple queries in parallel. Returns a `Map` keyed by a
+   * deterministic string representation of each query.
+   *
+   * Queries that cannot be satisfied map to `null`.
+   */
+  async enrichBatch(
+    queries: readonly DataQuery[],
+  ): Promise<Map<string, DataPoint | null>> {
+    const results = new Map<string, DataPoint | null>();
+    const settled = await Promise.allSettled(
+      queries.map((q) => this.enrich(q)),
+    );
+
+    for (let i = 0; i < queries.length; i++) {
+      const key = queryKey(queries[i]);
+      const outcome = settled[i];
+      results.set(key, outcome.status === "fulfilled" ? outcome.value : null);
+    }
+
+    return results;
+  }
+
+  // ── Suggestion engine ─────────────────────────────────────────────
+
+  /**
+   * Analyse a `Decision`'s criteria names, option names, and description
+   * to propose enrichment queries.
+   *
+   * Returns a list of `DataQuery` objects that the UI can offer to the
+   * user for one-click enrichment.
+   */
+  suggestEnrichments(decision: Decision): DataQuery[] {
+    const locations = extractLocations(decision);
+    const suggestions: DataQuery[] = [];
+    const seen = new Set<string>();
+
+    for (const criterion of decision.criteria) {
+      this.collectCriterionSuggestions(criterion.name, locations, seen, suggestions);
+    }
+
+    return suggestions;
+  }
+
+  /** Push matching queries for a single criterion name. */
+  private collectCriterionSuggestions(
+    criterionName: string,
+    locations: readonly Location[],
+    seen: Set<string>,
+    out: DataQuery[],
+  ): void {
+    for (const entry of KEYWORD_MAP) {
+      if (!entry.pattern.test(criterionName)) continue;
+      if (this.registry.getProvidersForCategory(entry.category).length === 0) continue;
+
+      for (const loc of locations) {
+        const query: DataQuery = {
+          country: loc.country,
+          city: loc.city,
+          category: entry.category,
+          metric: entry.metric,
+        };
+        const key = queryKey(query);
+        if (!seen.has(key)) {
+          seen.add(key);
+          out.push(query);
+        }
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Given two candidate DataPoints, return the one with the better tier
+ * (lower = better). On equal tier, pick the higher confidence.
+ */
+function pickBetter(current: DataPoint | null, next: DataPoint): DataPoint {
+  if (!current) return next;
+  if (next.tier < current.tier) return next;
+  if (next.tier === current.tier && next.confidence > current.confidence) {
+    return next;
+  }
+  return current;
+}
+
+/** Deterministic string key for a DataQuery */
+function queryKey(q: DataQuery): string {
+  return [
+    q.country.toLowerCase(),
+    q.city?.toLowerCase() ?? "_",
+    q.category,
+    q.metric,
+  ].join("|");
+}
+
+/** Simple location struct */
+interface Location {
+  country: string;
+  city?: string;
+}
+
+/**
+ * Best-effort extraction of locations from option names.
+ *
+ * For now this is a naive implementation that treats each option name
+ * as a potential "City, Country" or just "Country" pair. A more
+ * sophisticated NLP-based approach can replace this later.
+ */
+function extractLocations(decision: Decision): Location[] {
+  const locations: Location[] = [];
+  const seen = new Set<string>();
+
+  for (const option of decision.options) {
+    const parts = option.name.split(",").map((s) => s.trim());
+    const loc: Location =
+      parts.length >= 2
+        ? { city: parts[0], country: parts[1] }
+        : { country: parts[0] };
+
+    const key =
+      (loc.country?.toLowerCase() ?? "") +
+      "|" +
+      (loc.city?.toLowerCase() ?? "");
+    if (!seen.has(key)) {
+      seen.add(key);
+      locations.push(loc);
+    }
+  }
+
+  return locations;
+}

--- a/src/lib/data/registry.ts
+++ b/src/lib/data/registry.ts
@@ -1,0 +1,67 @@
+/**
+ * Provider registry for the data-enrichment system.
+ *
+ * The registry holds all registered `DataProvider` instances and exposes
+ * lookup helpers used by the `EnrichmentEngine`.
+ *
+ * @module data/registry
+ */
+
+import type { DataProvider } from "./provider";
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+export class ProviderRegistry {
+  private readonly providers = new Map<string, DataProvider>();
+
+  /**
+   * Register a data provider. Overwrites any existing provider with the
+   * same `id`.
+   */
+  register(provider: DataProvider): void {
+    this.providers.set(provider.id, provider);
+  }
+
+  /**
+   * Retrieve a provider by its unique `id`.
+   */
+  getProvider(id: string): DataProvider | undefined {
+    return this.providers.get(id);
+  }
+
+  /**
+   * Return every provider that lists `category` in its `categories`.
+   */
+  getProvidersForCategory(category: string): DataProvider[] {
+    const result: DataProvider[] = [];
+    for (const p of this.providers.values()) {
+      if (p.categories.includes(category)) {
+        result.push(p);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Return a de-duplicated list of all categories covered by every
+   * registered provider.
+   */
+  listCategories(): string[] {
+    const cats = new Set<string>();
+    for (const p of this.providers.values()) {
+      for (const c of p.categories) {
+        cats.add(c);
+      }
+    }
+    return [...cats].sort((a, b) => a.localeCompare(b));
+  }
+
+  /**
+   * Total number of registered providers.
+   */
+  get size(): number {
+    return this.providers.size;
+  }
+}


### PR DESCRIPTION
## Summary

Adds the provider registry and enrichment engine that orchestrate data providers for Decision OS.

## Changes

### `src/lib/data/registry.ts`
- **`ProviderRegistry`** class:
  - `register(provider)` — register a DataProvider by id
  - `getProvider(id)` — retrieve by unique id
  - `getProvidersForCategory(category)` — find all providers covering a category
  - `listCategories()` — sorted, de-duplicated list of all categories
  - `size` — total registered providers

### `src/lib/data/engine.ts`
- **`EnrichmentEngine`** class:
  - `enrich(query)` — three-tier fallback: tries all matching providers, picks best tier then highest confidence
  - `enrichBatch(queries)` — parallel enrichment of multiple queries
  - `suggestEnrichments(decision)` — analyses criteria names + option names to propose data queries
  - `setTimeout(ms)` — configurable per-provider timeout (default 5s)
  - Graceful degradation: errors and timeouts resolve to `null`, never throws
- **KEYWORD_MAP** — 12 regex patterns mapping criterion names to enrichment categories
- **`extractLocations()`** — parses "City, Country" from option names
- **`withTimeout()`** / **`pickBetter()`** — internal helpers

### `src/__tests__/data/engine.test.ts`
- 16 unit tests:
  - Registry: register, get, overwrite, category filtering, listCategories
  - Engine: no-match, single match, tier preference, confidence preference, error handling, timeout, batch, suggestEnrichments (matching, dedup, unrecognised, no providers)

## Checklist
- [x] TypeScript strict
- [x] 16 tests passing
- [x] Zero lint errors
- [x] Graceful degradation (never throws)

Closes #104
