### PR TITLE
feat(data): TaxEfficiencyProvider with inverted normalization

### DIFF
--- a/src/__tests__/data/tax-efficiency.test.ts
+++ b/src/__tests__/data/tax-efficiency.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { TaxEfficiencyProvider } from "@/lib/data/providers/tax-efficiency";
+import type { DataQuery } from "@/lib/data/provider";
+import { TAX_DATA } from "@/lib/data/datasets/tax-efficiency";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function query(overrides: Partial<DataQuery> = {}): DataQuery {
+  return {
+    country: "US",
+    category: "tax",
+    metric: "income-tax-rate",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("TaxEfficiencyProvider", () => {
+  let provider: TaxEfficiencyProvider;
+
+  beforeEach(() => {
+    provider = new TaxEfficiencyProvider();
+  });
+
+  // ── Identity ────────────────────────────────────────────────────
+
+  it("has correct id, name, and categories", () => {
+    expect(provider.id).toBe("tax-efficiency");
+    expect(provider.name).toBe("Tax Efficiency");
+    expect(provider.categories).toContain("tax");
+  });
+
+  // ── supports() ──────────────────────────────────────────────────
+
+  it("supports valid tax queries", () => {
+    expect(provider.supports(query())).toBe(true);
+    expect(
+      provider.supports(query({ metric: "corporate-tax-rate" })),
+    ).toBe(true);
+    expect(
+      provider.supports(query({ metric: "tax-freedom-index" })),
+    ).toBe(true);
+  });
+
+  it("rejects unsupported category", () => {
+    expect(provider.supports(query({ category: "cost-of-living" }))).toBe(
+      false,
+    );
+  });
+
+  it("rejects unknown metric", () => {
+    expect(provider.supports(query({ metric: "nonsense" }))).toBe(false);
+  });
+
+  // ── Tier 2 — bundled data ───────────────────────────────────────
+
+  it("returns Tier 2 data for a known country", async () => {
+    const result = await provider.fetch(query({ country: "US" }));
+    expect(result).not.toBeNull();
+    expect(result?.tier).toBe(2);
+    expect(result?.source).toBe("Tax Efficiency");
+    expect(result?.confidence).toBe(0.85);
+    expect(result?.rawValue).toBe(24); // US income tax rate
+    expect(result?.unit).toBe("%");
+  });
+
+  it("inverts normalization for tax rate metrics (lower tax = higher score)", async () => {
+    // UAE: 0% income tax → should score near 100
+    const uae = await provider.fetch(query({ country: "AE" }));
+    // Belgium: 40% income tax → should score much lower
+    const be = await provider.fetch(query({ country: "BE" }));
+
+    expect(uae).not.toBeNull();
+    expect(be).not.toBeNull();
+    expect(uae!.value).toBeGreaterThan(be!.value);
+    expect(uae!.value).toBeGreaterThan(80);
+  });
+
+  it("does NOT invert tax-freedom-index (already higher = better)", async () => {
+    // UAE has high freedom index (~92), Belgium low (~28)
+    const uae = await provider.fetch(
+      query({ country: "AE", metric: "tax-freedom-index" }),
+    );
+    const be = await provider.fetch(
+      query({ country: "BE", metric: "tax-freedom-index" }),
+    );
+
+    expect(uae).not.toBeNull();
+    expect(be).not.toBeNull();
+    expect(uae!.value).toBeGreaterThan(be!.value);
+  });
+
+  it("returns data for all supported metrics", async () => {
+    const metrics = [
+      "income-tax-rate",
+      "corporate-tax-rate",
+      "sales-tax-rate",
+      "social-security-rate",
+      "tax-freedom-index",
+    ];
+
+    for (const metric of metrics) {
+      const result = await provider.fetch(query({ metric }));
+      expect(result).not.toBeNull();
+      expect(result?.tier).toBe(2);
+    }
+  });
+
+  it("matches country case-insensitively", async () => {
+    const result = await provider.fetch(query({ country: "us" }));
+    expect(result).not.toBeNull();
+    expect(result?.rawValue).toBe(24);
+  });
+
+  // ── Tier 3 — estimation ─────────────────────────────────────────
+
+  it("returns Tier 3 estimated data for unknown country with income group", async () => {
+    // Myanmar is in the income-group map (LMC) but not in the tax dataset
+    const result = await provider.fetch(query({ country: "MM" }));
+    expect(result).not.toBeNull();
+    expect(result?.tier).toBe(3);
+    expect(result?.confidence).toBe(0.35);
+    expect(result?.source).toContain("estimated");
+  });
+
+  it("returns null for completely unknown country", async () => {
+    const result = await provider.fetch(query({ country: "XX" }));
+    expect(result).toBeNull();
+  });
+
+  // ── Dataset sanity ──────────────────────────────────────────────
+
+  it("bundled dataset covers >= 60 countries", () => {
+    expect(TAX_DATA.length).toBeGreaterThanOrEqual(60);
+  });
+
+  it("all tax rates are non-negative", () => {
+    for (const entry of TAX_DATA) {
+      expect(entry.incomeTaxRate).toBeGreaterThanOrEqual(0);
+      expect(entry.corporateTaxRate).toBeGreaterThanOrEqual(0);
+      expect(entry.salesTaxRate).toBeGreaterThanOrEqual(0);
+      expect(entry.socialSecurityRate).toBeGreaterThanOrEqual(0);
+    }
+  });
+});

--- a/src/lib/data/datasets/tax-efficiency.ts
+++ b/src/lib/data/datasets/tax-efficiency.ts
@@ -1,0 +1,173 @@
+/**
+ * Bundled tax-efficiency data for OECD + major economies.
+ *
+ * All rates are expressed as percentages (0–60+).
+ * The `taxFreedomIndex` is a composite 0–100 score where
+ * **higher = lower tax burden** (inverted).
+ *
+ * @module data/datasets/tax-efficiency
+ */
+
+export interface CountryTaxData {
+  country: string; // ISO 3166-1 alpha-2
+  /** Effective income tax rate for median income (%) */
+  incomeTaxRate: number;
+  /** Headline corporate tax rate (%) */
+  corporateTaxRate: number;
+  /** Standard VAT / sales-tax rate (%) */
+  salesTaxRate: number;
+  /** Employee social-security contribution rate (%) */
+  socialSecurityRate: number;
+  /** Composite tax-freedom index (0–100, 100 = lowest burden) */
+  taxFreedomIndex: number;
+}
+
+/**
+ * Income-group based fallback rates for Tier 3 estimation.
+ */
+export const TAX_GROUP_DEFAULTS: Readonly<
+  Record<string, Omit<CountryTaxData, "country">>
+> = {
+  HIC: {
+    incomeTaxRate: 30,
+    corporateTaxRate: 23,
+    salesTaxRate: 18,
+    socialSecurityRate: 12,
+    taxFreedomIndex: 45,
+  },
+  UMC: {
+    incomeTaxRate: 22,
+    corporateTaxRate: 25,
+    salesTaxRate: 15,
+    socialSecurityRate: 8,
+    taxFreedomIndex: 55,
+  },
+  LMC: {
+    incomeTaxRate: 15,
+    corporateTaxRate: 28,
+    salesTaxRate: 12,
+    socialSecurityRate: 5,
+    taxFreedomIndex: 60,
+  },
+  LIC: {
+    incomeTaxRate: 10,
+    corporateTaxRate: 30,
+    salesTaxRate: 10,
+    socialSecurityRate: 3,
+    taxFreedomIndex: 65,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Dataset — OECD + major economies
+// ---------------------------------------------------------------------------
+
+export const TAX_DATA: readonly CountryTaxData[] = [
+  // North America
+  { country: "US", incomeTaxRate: 24, corporateTaxRate: 21, salesTaxRate: 7, socialSecurityRate: 7.65, taxFreedomIndex: 58 },
+  { country: "CA", incomeTaxRate: 26, corporateTaxRate: 26.5, salesTaxRate: 5, socialSecurityRate: 5.95, taxFreedomIndex: 52 },
+  { country: "MX", incomeTaxRate: 30, corporateTaxRate: 30, salesTaxRate: 16, socialSecurityRate: 3, taxFreedomIndex: 42 },
+
+  // Europe — Western
+  { country: "GB", incomeTaxRate: 20, corporateTaxRate: 25, salesTaxRate: 20, socialSecurityRate: 12, taxFreedomIndex: 48 },
+  { country: "DE", incomeTaxRate: 30, corporateTaxRate: 30, salesTaxRate: 19, socialSecurityRate: 20, taxFreedomIndex: 36 },
+  { country: "FR", incomeTaxRate: 30, corporateTaxRate: 25, salesTaxRate: 20, socialSecurityRate: 22, taxFreedomIndex: 32 },
+  { country: "NL", incomeTaxRate: 37, corporateTaxRate: 25.8, salesTaxRate: 21, socialSecurityRate: 28, taxFreedomIndex: 30 },
+  { country: "BE", incomeTaxRate: 40, corporateTaxRate: 25, salesTaxRate: 21, socialSecurityRate: 13, taxFreedomIndex: 28 },
+  { country: "CH", incomeTaxRate: 12, corporateTaxRate: 14.9, salesTaxRate: 8.1, socialSecurityRate: 6.4, taxFreedomIndex: 76 },
+  { country: "AT", incomeTaxRate: 32, corporateTaxRate: 23, salesTaxRate: 20, socialSecurityRate: 18, taxFreedomIndex: 34 },
+  { country: "LU", incomeTaxRate: 28, corporateTaxRate: 24.9, salesTaxRate: 17, socialSecurityRate: 12.5, taxFreedomIndex: 40 },
+  { country: "IE", incomeTaxRate: 20, corporateTaxRate: 12.5, salesTaxRate: 23, socialSecurityRate: 4, taxFreedomIndex: 58 },
+  { country: "IT", incomeTaxRate: 35, corporateTaxRate: 24, salesTaxRate: 22, socialSecurityRate: 10, taxFreedomIndex: 35 },
+  { country: "ES", incomeTaxRate: 24, corporateTaxRate: 25, salesTaxRate: 21, socialSecurityRate: 6.4, taxFreedomIndex: 44 },
+  { country: "PT", incomeTaxRate: 23, corporateTaxRate: 21, salesTaxRate: 23, socialSecurityRate: 11, taxFreedomIndex: 42 },
+
+  // Europe — Nordics
+  { country: "SE", incomeTaxRate: 32, corporateTaxRate: 20.6, salesTaxRate: 25, socialSecurityRate: 7, taxFreedomIndex: 38 },
+  { country: "NO", incomeTaxRate: 22, corporateTaxRate: 22, salesTaxRate: 25, socialSecurityRate: 8, taxFreedomIndex: 44 },
+  { country: "DK", incomeTaxRate: 37, corporateTaxRate: 22, salesTaxRate: 25, socialSecurityRate: 0, taxFreedomIndex: 36 },
+  { country: "FI", incomeTaxRate: 30, corporateTaxRate: 20, salesTaxRate: 25.5, socialSecurityRate: 8, taxFreedomIndex: 38 },
+  { country: "IS", incomeTaxRate: 23, corporateTaxRate: 20, salesTaxRate: 24, socialSecurityRate: 4, taxFreedomIndex: 46 },
+
+  // Europe — Central / Eastern
+  { country: "PL", incomeTaxRate: 12, corporateTaxRate: 19, salesTaxRate: 23, socialSecurityRate: 14, taxFreedomIndex: 52 },
+  { country: "CZ", incomeTaxRate: 15, corporateTaxRate: 19, salesTaxRate: 21, socialSecurityRate: 11, taxFreedomIndex: 54 },
+  { country: "HU", incomeTaxRate: 15, corporateTaxRate: 9, salesTaxRate: 27, socialSecurityRate: 18.5, taxFreedomIndex: 50 },
+  { country: "SK", incomeTaxRate: 19, corporateTaxRate: 21, salesTaxRate: 20, socialSecurityRate: 14, taxFreedomIndex: 48 },
+  { country: "RO", incomeTaxRate: 10, corporateTaxRate: 16, salesTaxRate: 19, socialSecurityRate: 25, taxFreedomIndex: 52 },
+  { country: "BG", incomeTaxRate: 10, corporateTaxRate: 10, salesTaxRate: 20, socialSecurityRate: 13, taxFreedomIndex: 62 },
+  { country: "HR", incomeTaxRate: 20, corporateTaxRate: 18, salesTaxRate: 25, socialSecurityRate: 20, taxFreedomIndex: 40 },
+  { country: "SI", incomeTaxRate: 27, corporateTaxRate: 19, salesTaxRate: 22, socialSecurityRate: 22, taxFreedomIndex: 36 },
+  { country: "EE", incomeTaxRate: 20, corporateTaxRate: 20, salesTaxRate: 22, socialSecurityRate: 2, taxFreedomIndex: 56 },
+  { country: "LT", incomeTaxRate: 20, corporateTaxRate: 15, salesTaxRate: 21, socialSecurityRate: 20, taxFreedomIndex: 46 },
+  { country: "LV", incomeTaxRate: 20, corporateTaxRate: 20, salesTaxRate: 21, socialSecurityRate: 11, taxFreedomIndex: 48 },
+  { country: "GR", incomeTaxRate: 22, corporateTaxRate: 22, salesTaxRate: 24, socialSecurityRate: 14, taxFreedomIndex: 40 },
+  { country: "RS", incomeTaxRate: 10, corporateTaxRate: 15, salesTaxRate: 20, socialSecurityRate: 20, taxFreedomIndex: 52 },
+  { country: "TR", incomeTaxRate: 15, corporateTaxRate: 25, salesTaxRate: 20, socialSecurityRate: 15, taxFreedomIndex: 46 },
+  { country: "UA", incomeTaxRate: 18, corporateTaxRate: 18, salesTaxRate: 20, socialSecurityRate: 22, taxFreedomIndex: 44 },
+
+  // Asia-Pacific
+  { country: "JP", incomeTaxRate: 23, corporateTaxRate: 23.2, salesTaxRate: 10, socialSecurityRate: 15, taxFreedomIndex: 46 },
+  { country: "KR", incomeTaxRate: 15, corporateTaxRate: 25, salesTaxRate: 10, socialSecurityRate: 9.4, taxFreedomIndex: 54 },
+  { country: "SG", incomeTaxRate: 7, corporateTaxRate: 17, salesTaxRate: 9, socialSecurityRate: 20, taxFreedomIndex: 72 },
+  { country: "HK", incomeTaxRate: 15, corporateTaxRate: 16.5, salesTaxRate: 0, socialSecurityRate: 5, taxFreedomIndex: 78 },
+  { country: "TW", incomeTaxRate: 12, corporateTaxRate: 20, salesTaxRate: 5, socialSecurityRate: 11, taxFreedomIndex: 62 },
+  { country: "AU", incomeTaxRate: 24.5, corporateTaxRate: 30, salesTaxRate: 10, socialSecurityRate: 0, taxFreedomIndex: 52 },
+  { country: "NZ", incomeTaxRate: 17.5, corporateTaxRate: 28, salesTaxRate: 15, socialSecurityRate: 0, taxFreedomIndex: 56 },
+  { country: "CN", incomeTaxRate: 20, corporateTaxRate: 25, salesTaxRate: 13, socialSecurityRate: 11, taxFreedomIndex: 46 },
+  { country: "IN", incomeTaxRate: 10, corporateTaxRate: 25, salesTaxRate: 18, socialSecurityRate: 12, taxFreedomIndex: 52 },
+  { country: "TH", incomeTaxRate: 10, corporateTaxRate: 20, salesTaxRate: 7, socialSecurityRate: 5, taxFreedomIndex: 64 },
+  { country: "MY", incomeTaxRate: 8, corporateTaxRate: 24, salesTaxRate: 6, socialSecurityRate: 11, taxFreedomIndex: 62 },
+  { country: "VN", incomeTaxRate: 10, corporateTaxRate: 20, salesTaxRate: 10, socialSecurityRate: 11, taxFreedomIndex: 58 },
+  { country: "PH", incomeTaxRate: 20, corporateTaxRate: 25, salesTaxRate: 12, socialSecurityRate: 5, taxFreedomIndex: 52 },
+  { country: "ID", incomeTaxRate: 15, corporateTaxRate: 22, salesTaxRate: 11, socialSecurityRate: 4, taxFreedomIndex: 58 },
+
+  // Middle East
+  { country: "AE", incomeTaxRate: 0, corporateTaxRate: 9, salesTaxRate: 5, socialSecurityRate: 5, taxFreedomIndex: 92 },
+  { country: "SA", incomeTaxRate: 0, corporateTaxRate: 20, salesTaxRate: 15, socialSecurityRate: 10, taxFreedomIndex: 80 },
+  { country: "QA", incomeTaxRate: 0, corporateTaxRate: 10, salesTaxRate: 0, socialSecurityRate: 5, taxFreedomIndex: 90 },
+  { country: "BH", incomeTaxRate: 0, corporateTaxRate: 0, salesTaxRate: 10, socialSecurityRate: 7, taxFreedomIndex: 92 },
+  { country: "KW", incomeTaxRate: 0, corporateTaxRate: 15, salesTaxRate: 0, socialSecurityRate: 8, taxFreedomIndex: 88 },
+  { country: "IL", incomeTaxRate: 25, corporateTaxRate: 23, salesTaxRate: 17, socialSecurityRate: 12, taxFreedomIndex: 42 },
+
+  // Africa
+  { country: "ZA", incomeTaxRate: 18, corporateTaxRate: 27, salesTaxRate: 15, socialSecurityRate: 1, taxFreedomIndex: 52 },
+  { country: "NG", incomeTaxRate: 7, corporateTaxRate: 30, salesTaxRate: 7.5, socialSecurityRate: 8, taxFreedomIndex: 58 },
+  { country: "KE", incomeTaxRate: 10, corporateTaxRate: 30, salesTaxRate: 16, socialSecurityRate: 6, taxFreedomIndex: 52 },
+  { country: "EG", incomeTaxRate: 15, corporateTaxRate: 22.5, salesTaxRate: 14, socialSecurityRate: 11, taxFreedomIndex: 52 },
+  { country: "MA", incomeTaxRate: 20, corporateTaxRate: 31, salesTaxRate: 20, socialSecurityRate: 6.7, taxFreedomIndex: 42 },
+  { country: "GH", incomeTaxRate: 15, corporateTaxRate: 25, salesTaxRate: 15, socialSecurityRate: 5.5, taxFreedomIndex: 52 },
+
+  // South America
+  { country: "BR", incomeTaxRate: 15, corporateTaxRate: 34, salesTaxRate: 17, socialSecurityRate: 11, taxFreedomIndex: 38 },
+  { country: "AR", incomeTaxRate: 27, corporateTaxRate: 35, salesTaxRate: 21, socialSecurityRate: 17, taxFreedomIndex: 28 },
+  { country: "CL", incomeTaxRate: 8, corporateTaxRate: 27, salesTaxRate: 19, socialSecurityRate: 7, taxFreedomIndex: 56 },
+  { country: "CO", incomeTaxRate: 10, corporateTaxRate: 35, salesTaxRate: 19, socialSecurityRate: 8, taxFreedomIndex: 46 },
+  { country: "PE", incomeTaxRate: 8, corporateTaxRate: 29.5, salesTaxRate: 18, socialSecurityRate: 13, taxFreedomIndex: 50 },
+  { country: "UY", incomeTaxRate: 15, corporateTaxRate: 25, salesTaxRate: 22, socialSecurityRate: 15, taxFreedomIndex: 44 },
+  { country: "CR", incomeTaxRate: 15, corporateTaxRate: 30, salesTaxRate: 13, socialSecurityRate: 10.5, taxFreedomIndex: 46 },
+  { country: "PA", incomeTaxRate: 15, corporateTaxRate: 25, salesTaxRate: 7, socialSecurityRate: 10, taxFreedomIndex: 58 },
+];
+
+// ---------------------------------------------------------------------------
+// Dataset range helpers (pre-computed for normalization)
+// ---------------------------------------------------------------------------
+
+function computeRange(accessor: (c: CountryTaxData) => number): { min: number; max: number } {
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  for (const c of TAX_DATA) {
+    const v = accessor(c);
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+  return { min, max };
+}
+
+export const TAX_RANGES = {
+  incomeTaxRate: computeRange((c) => c.incomeTaxRate),
+  corporateTaxRate: computeRange((c) => c.corporateTaxRate),
+  salesTaxRate: computeRange((c) => c.salesTaxRate),
+  socialSecurityRate: computeRange((c) => c.socialSecurityRate),
+  taxFreedomIndex: computeRange((c) => c.taxFreedomIndex),
+} as const;

--- a/src/lib/data/providers/tax-efficiency.ts
+++ b/src/lib/data/providers/tax-efficiency.ts
@@ -1,0 +1,148 @@
+/**
+ * Tax-efficiency data provider.
+ *
+ * Tier 2 — Bundled dataset (OECD + major economies)
+ * Tier 3 — Regional estimation via World Bank income-group defaults
+ *
+ * Tax rates are "cost" criteria — lower tax is better for the user.
+ * For rate metrics, normalization is **inverted**: 100 = 0% tax, 0 = max tax.
+ * For `tax-freedom-index`, no inversion is needed (already higher = better).
+ *
+ * @module data/providers/tax-efficiency
+ */
+
+import { DataProvider } from "../provider";
+import type { DataPoint, DataQuery } from "../provider";
+import {
+  TAX_DATA,
+  TAX_GROUP_DEFAULTS,
+  TAX_RANGES,
+} from "../datasets/tax-efficiency";
+import type { CountryTaxData } from "../datasets/tax-efficiency";
+import { COUNTRY_INCOME_GROUP } from "../datasets/cost-of-living";
+
+// ---------------------------------------------------------------------------
+// Metric mapping
+// ---------------------------------------------------------------------------
+
+type MetricKey = keyof typeof TAX_RANGES;
+
+const METRIC_TO_FIELD: Readonly<Record<string, MetricKey>> = {
+  "income-tax-rate": "incomeTaxRate",
+  "corporate-tax-rate": "corporateTaxRate",
+  "sales-tax-rate": "salesTaxRate",
+  "social-security-rate": "socialSecurityRate",
+  "tax-freedom-index": "taxFreedomIndex",
+};
+
+const METRIC_UNITS: Readonly<Record<string, string>> = {
+  "income-tax-rate": "%",
+  "corporate-tax-rate": "%",
+  "sales-tax-rate": "%",
+  "social-security-rate": "%",
+  "tax-freedom-index": "index",
+};
+
+/** Metrics where lower raw value = higher score (inverted normalization) */
+const INVERTED_METRICS = new Set<string>([
+  "income-tax-rate",
+  "corporate-tax-rate",
+  "sales-tax-rate",
+  "social-security-rate",
+]);
+
+const SUPPORTED_METRICS = Object.keys(METRIC_TO_FIELD);
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export class TaxEfficiencyProvider extends DataProvider {
+  readonly id = "tax-efficiency";
+  readonly name = "Tax Efficiency";
+  readonly categories = ["tax"] as const;
+
+  supports(query: DataQuery): boolean {
+    return (
+      query.category === "tax" && SUPPORTED_METRICS.includes(query.metric)
+    );
+  }
+
+  protected async fetchData(query: DataQuery): Promise<DataPoint | null> {
+    // Tier 2 — bundled data
+    const bundled = this.lookupBundled(query);
+    if (bundled) return bundled;
+
+    // Tier 3 — estimation
+    return this.estimate(query);
+  }
+
+  // ── Tier 2 ──────────────────────────────────────────────────────
+
+  private lookupBundled(query: DataQuery): DataPoint | null {
+    const entry = this.findCountry(query);
+    if (!entry) return null;
+
+    return this.buildPoint(entry, query.metric, 2, 0.85, this.name);
+  }
+
+  private findCountry(query: DataQuery): CountryTaxData | undefined {
+    const code = query.country.toUpperCase();
+    return TAX_DATA.find((c) => c.country === code);
+  }
+
+  // ── Tier 3 ──────────────────────────────────────────────────────
+
+  private estimate(query: DataQuery): DataPoint | null {
+    const group = COUNTRY_INCOME_GROUP[query.country.toUpperCase()];
+    if (!group) return null;
+
+    const defaults = TAX_GROUP_DEFAULTS[group];
+    if (!defaults) return null;
+
+    const entry: CountryTaxData = {
+      country: query.country.toUpperCase(),
+      ...defaults,
+    };
+
+    return this.buildPoint(
+      entry,
+      query.metric,
+      3,
+      0.35,
+      `${this.name} (estimated)`,
+    );
+  }
+
+  // ── Shared builder ──────────────────────────────────────────────
+
+  private buildPoint(
+    entry: CountryTaxData,
+    metric: string,
+    tier: 1 | 2 | 3,
+    confidence: number,
+    source: string,
+  ): DataPoint | null {
+    const field = METRIC_TO_FIELD[metric];
+    if (field === undefined) return null;
+
+    const rawValue = entry[field];
+    const range = TAX_RANGES[field];
+    const inverted = INVERTED_METRICS.has(metric);
+
+    // For inverted metrics: 100 means lowest tax (best), 0 means highest
+    const normalized = inverted
+      ? 100 - this.normalize(rawValue, range.min, range.max)
+      : this.normalize(rawValue, range.min, range.max);
+
+    return {
+      value: normalized,
+      rawValue,
+      unit: METRIC_UNITS[metric] ?? "%",
+      source,
+      confidence,
+      tier,
+      updatedAt: "2025-01-01T00:00:00Z",
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Implements the `TaxEfficiencyProvider` with 5 tax metrics, inverted normalization for rate metrics, and bundled data for 68 countries.

## Changes

### `src/lib/data/providers/tax-efficiency.ts`
- **`TaxEfficiencyProvider`** extends `DataProvider`
- 5 metrics: `income-tax-rate`, `corporate-tax-rate`, `sales-tax-rate`, `social-security-rate`, `tax-freedom-index`
- **Inverted normalization**: For rate metrics, lower tax → higher score (100 = 0% tax, 0 = 60%+ tax)
- `tax-freedom-index` uses direct normalization (higher = better)
- **Tier 2**: Bundled country lookup
- **Tier 3**: Income-group estimation via `TAX_GROUP_DEFAULTS`

### `src/lib/data/datasets/tax-efficiency.ts`
- `CountryTaxData` interface
- `TAX_DATA` — 68 countries across all regions
- `TAX_GROUP_DEFAULTS` — per-income-group fallback rates
- `TAX_RANGES` — pre-computed min/max for normalization

### `src/__tests__/data/tax-efficiency.test.ts`
- 13 tests: identity, supports, Tier 2 lookup, inverted normalization (UAE vs Belgium), direct normalization (tax-freedom-index), all metrics, case-insensitive, Tier 3 estimation, unknown country, dataset sanity (≥60 countries, non-negative rates)

## Checklist
- [x] TypeScript strict
- [x] 13 tests passing
- [x] Zero lint errors
- [x] ≥ 4 metrics (5 total)
- [x] Inverted normalization
- [x] Tier 2 bundled data for 68 countries
- [x] Tier 3 estimation

Closes #106
