### PR TITLE
feat: score provenance tracking and user override UI (#109)

### DIFF
--- a/src/__tests__/components/ScoreProvenanceIndicator.test.tsx
+++ b/src/__tests__/components/ScoreProvenanceIndicator.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Component tests for ScoreProvenanceIndicator (Issue #109).
+ *
+ * Validates:
+ * - Manual cells render no indicator
+ * - Enriched cells show data icon with source tooltip
+ * - Overridden cells show user icon with override details
+ * - Restore button appears and fires callback
+ * - Accessibility: ARIA labels present
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ScoreProvenanceIndicator } from "@/components/ScoreProvenanceIndicator";
+import {
+  createManualMetadata,
+  createEnrichedMetadata,
+  createOverrideMetadata,
+} from "@/lib/provenance";
+
+describe("ScoreProvenanceIndicator", () => {
+  it("renders nothing for undefined metadata", () => {
+    const { container } = render(
+      <ScoreProvenanceIndicator metadata={undefined} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing for manual provenance", () => {
+    const { container } = render(
+      <ScoreProvenanceIndicator metadata={createManualMetadata()} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("shows enriched indicator with source tooltip", () => {
+    const meta = createEnrichedMetadata(7, "CostOfLivingProvider", 2);
+    render(<ScoreProvenanceIndicator metadata={meta} />);
+
+    const indicator = screen.getByLabelText(/Enriched/);
+    expect(indicator).toBeInTheDocument();
+    expect(indicator.getAttribute("title")).toContain("CostOfLivingProvider");
+    expect(indicator.getAttribute("title")).toContain("Tier 2");
+  });
+
+  it("shows overridden indicator with override details", () => {
+    const enriched = createEnrichedMetadata(6, "Numbeo", 2);
+    const overridden = createOverrideMetadata(enriched, "Local data");
+    render(<ScoreProvenanceIndicator metadata={overridden} />);
+
+    const indicator = screen.getByLabelText(/Overridden/);
+    expect(indicator).toBeInTheDocument();
+    expect(indicator.getAttribute("title")).toContain("Overridden");
+    expect(indicator.getAttribute("title")).toContain("6");
+  });
+
+  it("shows restore button for overridden cells when canRestore is true", () => {
+    const enriched = createEnrichedMetadata(8, "src", 2);
+    const overridden = createOverrideMetadata(enriched);
+    render(
+      <ScoreProvenanceIndicator
+        metadata={overridden}
+        canRestore={true}
+        onRestore={() => undefined}
+      />,
+    );
+
+    const restoreBtn = screen.getByLabelText(/Restore enriched value/);
+    expect(restoreBtn).toBeInTheDocument();
+  });
+
+  it("hides restore button when canRestore is false", () => {
+    const enriched = createEnrichedMetadata(8, "src", 2);
+    const overridden = createOverrideMetadata(enriched);
+    render(
+      <ScoreProvenanceIndicator
+        metadata={overridden}
+        canRestore={false}
+        onRestore={() => undefined}
+      />,
+    );
+
+    expect(screen.queryByLabelText(/Restore enriched value/)).not.toBeInTheDocument();
+  });
+
+  it("calls onRestore when restore button is clicked", async () => {
+    const user = userEvent.setup();
+    const onRestore = vi.fn();
+    const enriched = createEnrichedMetadata(5, "src", 3);
+    const overridden = createOverrideMetadata(enriched);
+
+    render(
+      <ScoreProvenanceIndicator
+        metadata={overridden}
+        canRestore={true}
+        onRestore={onRestore}
+      />,
+    );
+
+    await user.click(screen.getByLabelText(/Restore enriched value/));
+    expect(onRestore).toHaveBeenCalledOnce();
+  });
+
+  it("enriched indicator has correct ARIA label", () => {
+    const meta = createEnrichedMetadata(9, "QualityOfLifeProvider", 1);
+    render(<ScoreProvenanceIndicator metadata={meta} />);
+
+    const indicator = screen.getByLabelText(/Enriched from QualityOfLifeProvider/);
+    expect(indicator).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/provenance.test.ts
+++ b/src/__tests__/provenance.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Unit tests for score provenance tracking logic (Issue #109).
+ *
+ * Validates:
+ * - Metadata factory helpers (manual, enriched, overridden)
+ * - Query helpers (getProvenance, getMetadata, canRestoreEnriched)
+ * - Matrix mutation helpers (set, removeOption, removeCriterion)
+ * - Display label generation
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  createManualMetadata,
+  createEnrichedMetadata,
+  createOverrideMetadata,
+  getProvenance,
+  getMetadata,
+  canRestoreEnriched,
+  setMetadataCell,
+  removeOptionMetadata,
+  removeCriterionMetadata,
+  provenanceLabel,
+} from "@/lib/provenance";
+import type { Decision, ScoreMetadata } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDecision(
+  scoreMetadata?: Decision["scoreMetadata"],
+): Decision {
+  return {
+    id: "test",
+    title: "Test",
+    description: "",
+    options: [{ id: "o1", name: "A" }],
+    criteria: [{ id: "c1", name: "X", weight: 50, type: "benefit" }],
+    scores: {},
+    scoreMetadata,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Provenance — factory helpers", () => {
+  it("createManualMetadata returns manual provenance", () => {
+    const meta = createManualMetadata();
+    expect(meta.provenance).toBe("manual");
+    expect(meta.enrichedValue).toBeUndefined();
+  });
+
+  it("createEnrichedMetadata stores value, source, and tier", () => {
+    const meta = createEnrichedMetadata(7.5, "CostOfLivingProvider", 2);
+    expect(meta.provenance).toBe("enriched");
+    expect(meta.enrichedValue).toBe(7.5);
+    expect(meta.enrichedSource).toBe("CostOfLivingProvider");
+    expect(meta.enrichedTier).toBe(2);
+  });
+
+  it("createOverrideMetadata preserves enrichment info", () => {
+    const enriched = createEnrichedMetadata(6, "Numbeo", 2);
+    const override = createOverrideMetadata(enriched, "Local knowledge");
+    expect(override.provenance).toBe("overridden");
+    expect(override.enrichedValue).toBe(6);
+    expect(override.enrichedSource).toBe("Numbeo");
+    expect(override.enrichedTier).toBe(2);
+    expect(override.overrideReason).toBe("Local knowledge");
+    expect(override.overriddenAt).toBeTruthy();
+  });
+
+  it("createOverrideMetadata sets ISO timestamp", () => {
+    const enriched = createEnrichedMetadata(5, "src", 1);
+    const before = Date.now();
+    const override = createOverrideMetadata(enriched);
+    const after = Date.now();
+    const ts = new Date(override.overriddenAt!).getTime();
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+  });
+});
+
+describe("Provenance — query helpers", () => {
+  it("getProvenance returns manual for cells without metadata", () => {
+    const decision = makeDecision();
+    expect(getProvenance(decision, "o1", "c1")).toBe("manual");
+  });
+
+  it("getProvenance returns enriched when metadata is set", () => {
+    const decision = makeDecision({
+      o1: { c1: createEnrichedMetadata(8, "src", 2) },
+    });
+    expect(getProvenance(decision, "o1", "c1")).toBe("enriched");
+  });
+
+  it("getMetadata returns undefined for missing cells", () => {
+    const decision = makeDecision();
+    expect(getMetadata(decision, "o1", "c1")).toBeUndefined();
+  });
+
+  it("getMetadata returns the metadata object when present", () => {
+    const meta = createEnrichedMetadata(5, "src", 3);
+    const decision = makeDecision({ o1: { c1: meta } });
+    expect(getMetadata(decision, "o1", "c1")).toEqual(meta);
+  });
+
+  it("canRestoreEnriched returns false for manual cells", () => {
+    const decision = makeDecision();
+    expect(canRestoreEnriched(decision, "o1", "c1")).toBe(false);
+  });
+
+  it("canRestoreEnriched returns false for enriched (not overridden) cells", () => {
+    const decision = makeDecision({
+      o1: { c1: createEnrichedMetadata(7, "src", 2) },
+    });
+    expect(canRestoreEnriched(decision, "o1", "c1")).toBe(false);
+  });
+
+  it("canRestoreEnriched returns true for overridden cells with enrichedValue", () => {
+    const enriched = createEnrichedMetadata(7, "src", 2);
+    const overridden = createOverrideMetadata(enriched);
+    const decision = makeDecision({ o1: { c1: overridden } });
+    expect(canRestoreEnriched(decision, "o1", "c1")).toBe(true);
+  });
+});
+
+describe("Provenance — matrix helpers", () => {
+  it("setMetadataCell creates matrix from undefined", () => {
+    const meta = createManualMetadata();
+    const result = setMetadataCell(undefined, "o1", "c1", meta);
+    expect(result.o1.c1).toEqual(meta);
+  });
+
+  it("setMetadataCell adds to existing matrix", () => {
+    const existing: Record<string, Record<string, ScoreMetadata>> = {
+      o1: { c1: createManualMetadata() },
+    };
+    const enriched = createEnrichedMetadata(5, "src", 2);
+    const result = setMetadataCell(existing, "o1", "c2", enriched);
+    expect(result.o1.c1.provenance).toBe("manual");
+    expect(result.o1.c2.provenance).toBe("enriched");
+  });
+
+  it("removeOptionMetadata removes the option row", () => {
+    const matrix = {
+      o1: { c1: createManualMetadata() },
+      o2: { c1: createManualMetadata() },
+    };
+    const result = removeOptionMetadata(matrix, "o1");
+    expect(result).toBeDefined();
+    expect(result!.o1).toBeUndefined();
+    expect(result!.o2).toBeDefined();
+  });
+
+  it("removeOptionMetadata returns undefined when last option removed", () => {
+    const matrix = { o1: { c1: createManualMetadata() } };
+    const result = removeOptionMetadata(matrix, "o1");
+    expect(result).toBeUndefined();
+  });
+
+  it("removeCriterionMetadata removes criterion from all options", () => {
+    const matrix = {
+      o1: { c1: createManualMetadata(), c2: createManualMetadata() },
+      o2: { c1: createManualMetadata() },
+    };
+    const result = removeCriterionMetadata(matrix, "c1");
+    expect(result).toBeDefined();
+    expect(result!.o1.c1).toBeUndefined();
+    expect(result!.o1.c2).toBeDefined();
+    expect(result!.o2).toBeUndefined(); // o2 had only c1
+  });
+
+  it("removeCriterionMetadata returns undefined when empty", () => {
+    const matrix = { o1: { c1: createManualMetadata() } };
+    const result = removeCriterionMetadata(matrix, "c1");
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("Provenance — provenanceLabel", () => {
+  it("returns 'Manually entered' for undefined", () => {
+    expect(provenanceLabel(undefined)).toBe("Manually entered");
+  });
+
+  it("returns 'Manually entered' for manual provenance", () => {
+    expect(provenanceLabel(createManualMetadata())).toBe("Manually entered");
+  });
+
+  it("returns enrichment details for enriched provenance", () => {
+    const label = provenanceLabel(createEnrichedMetadata(7, "Numbeo", 2));
+    expect(label).toContain("Enriched");
+    expect(label).toContain("Numbeo");
+    expect(label).toContain("Tier 2");
+  });
+
+  it("returns override details for overridden provenance", () => {
+    const enriched = createEnrichedMetadata(6, "Provider", 3);
+    const overridden = createOverrideMetadata(enriched);
+    const label = provenanceLabel(overridden);
+    expect(label).toContain("Overridden");
+    expect(label).toContain("6");
+    expect(label).toContain("Provider");
+  });
+});

--- a/src/components/DecisionBuilder.tsx
+++ b/src/components/DecisionBuilder.tsx
@@ -34,6 +34,8 @@ import type { CalibrationData } from "./ScoringPrompt";
 import { BiasWarnings } from "./BiasWarnings";
 import { useBiasDetection } from "@/hooks/useBiasDetection";
 import { MobileScoreCards } from "./MobileScoreCards";
+import { ScoreProvenanceIndicator } from "./ScoreProvenanceIndicator";
+import { getMetadata, canRestoreEnriched } from "@/lib/provenance";
 
 interface DecisionBuilderProps {
   validation: ValidationResult;
@@ -53,6 +55,7 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
     updateScore,
     updateConfidence,
     updateReasoning,
+    restoreEnrichedValue,
     undo,
     redo,
     canUndo,
@@ -699,6 +702,11 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
                             onChange={(text) => updateReasoning(opt.id, crit.id, text)}
                             optionName={opt.name}
                             criterionName={crit.name}
+                          />
+                          <ScoreProvenanceIndicator
+                            metadata={getMetadata(decision, opt.id, crit.id)}
+                            canRestore={canRestoreEnriched(decision, opt.id, crit.id)}
+                            onRestore={() => restoreEnrichedValue(opt.id, crit.id)}
                           />
                         </div>
                         {isFocused && (

--- a/src/components/DecisionProvider.tsx
+++ b/src/components/DecisionProvider.tsx
@@ -91,6 +91,14 @@ export interface DecisionContextValue extends DecisionStateValue {
   updateScore: (optionId: string, criterionId: string, value: number | null) => void;
   updateConfidence: (optionId: string, criterionId: string, confidence: Confidence) => void;
   updateReasoning: (optionId: string, criterionId: string, text: string) => void;
+  setEnrichedScore: (
+    optionId: string,
+    criterionId: string,
+    value: number,
+    source: string,
+    tier: 1 | 2 | 3,
+  ) => void;
+  restoreEnrichedValue: (optionId: string, criterionId: string) => void;
   undo: () => void;
   redo: () => void;
   setSwingPercent: (value: number) => void;
@@ -234,6 +242,18 @@ export function DecisionProvider({ children }: { children: ReactNode }) {
     [dispatch]
   );
 
+  const setEnrichedScore = useCallback(
+    (optionId: string, criterionId: string, value: number, source: string, tier: 1 | 2 | 3) =>
+      dispatch({ type: "SET_ENRICHED_SCORE", optionId, criterionId, value, source, tier }),
+    [dispatch]
+  );
+
+  const restoreEnrichedValue = useCallback(
+    (optionId: string, criterionId: string) =>
+      dispatch({ type: "RESTORE_ENRICHED_VALUE", optionId, criterionId }),
+    [dispatch]
+  );
+
   const undo = useCallback(() => {
     dispatch({ type: "UNDO" });
     announceRef.current("Undone");
@@ -343,6 +363,8 @@ export function DecisionProvider({ children }: { children: ReactNode }) {
       updateScore,
       updateConfidence,
       updateReasoning,
+      setEnrichedScore,
+      restoreEnrichedValue,
       undo,
       redo,
       setSwingPercent,
@@ -366,6 +388,8 @@ export function DecisionProvider({ children }: { children: ReactNode }) {
       updateScore,
       updateConfidence,
       updateReasoning,
+      setEnrichedScore,
+      restoreEnrichedValue,
       undo,
       redo,
       setSwingPercent,

--- a/src/components/ScoreProvenanceIndicator.tsx
+++ b/src/components/ScoreProvenanceIndicator.tsx
@@ -1,0 +1,94 @@
+/**
+ * Score provenance indicator — visual badge showing whether a score
+ * was manually entered, auto-enriched, or user-overridden.
+ *
+ * Rendered alongside score input cells in the decision matrix.
+ *
+ * @module components/ScoreProvenanceIndicator
+ */
+
+"use client";
+
+import { Database, User, RotateCcw } from "lucide-react";
+import type { ScoreMetadata } from "@/lib/types";
+import { provenanceLabel } from "@/lib/provenance";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function restoreLabel(meta: ScoreMetadata): string {
+  if (meta.enrichedValue === undefined) return "Restore enriched value";
+  return `Restore enriched value (${meta.enrichedValue})`;
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface ScoreProvenanceIndicatorProps {
+  /** Metadata for this score cell (undefined = manual) */
+  readonly metadata: ScoreMetadata | undefined;
+  /** Callback to restore the original enriched value */
+  readonly onRestore?: () => void;
+  /** Whether the restore action is available */
+  readonly canRestore?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/**
+ * Compact visual indicator for score provenance.
+ *
+ * - **Manual** (default): no indicator rendered
+ * - **Enriched**: blue database icon with source tooltip
+ * - **Overridden**: amber user icon with original value tooltip + restore button
+ */
+export function ScoreProvenanceIndicator({
+  metadata,
+  onRestore,
+  canRestore = false,
+}: ScoreProvenanceIndicatorProps) {
+  // Manual scores show no indicator
+  if (!metadata || metadata.provenance === "manual") return null;
+
+  const label = provenanceLabel(metadata);
+
+  if (metadata.provenance === "enriched") {
+    return (
+      <span
+        className="inline-flex items-center text-blue-500 dark:text-blue-400"
+        title={label}
+        aria-label={label}
+      >
+        <Database className="h-3 w-3" aria-hidden="true" />
+      </span>
+    );
+  }
+
+  // Overridden
+  return (
+    <span className="inline-flex items-center gap-0.5">
+      <span
+        className="inline-flex items-center text-amber-500 dark:text-amber-400"
+        title={label}
+        aria-label={label}
+      >
+        <User className="h-3 w-3" aria-hidden="true" />
+      </span>
+      {canRestore && onRestore && (
+        <button
+          type="button"
+          onClick={onRestore}
+          className="inline-flex items-center rounded p-0.5 text-gray-400 hover:text-blue-600 hover:bg-blue-50 dark:hover:text-blue-400 dark:hover:bg-blue-900/30 focus:outline-none focus:ring-1 focus:ring-blue-500 transition-colors"
+          title="Restore enriched value"
+          aria-label={restoreLabel(metadata)}
+        >
+          <RotateCcw className="h-3 w-3" aria-hidden="true" />
+        </button>
+      )}
+    </span>
+  );
+}

--- a/src/lib/decision-reducer.ts
+++ b/src/lib/decision-reducer.ts
@@ -13,9 +13,16 @@
  * @see https://github.com/ericsocrat/decision-os/issues/77
  */
 
-import type { Confidence, ConfidenceStrategy, Criterion, Decision, Option, ScoreMatrix, ScoreValue } from "./types";
+import type { Confidence, ConfidenceStrategy, Criterion, Decision, Option, ScoreMatrix, ScoreMetadataMatrix, ScoreValue } from "./types";
 import { generateId } from "./utils";
 import { resolveScoreValue } from "./scoring";
+import {
+  createEnrichedMetadata,
+  createOverrideMetadata,
+  setMetadataCell,
+  removeOptionMetadata,
+  removeCriterionMetadata,
+} from "./provenance";
 
 // ---------------------------------------------------------------------------
 // State
@@ -86,6 +93,17 @@ export type DecisionAction =
   // Scores
   | { type: "UPDATE_SCORE"; optionId: string; criterionId: string; value: number | null }
   | { type: "UPDATE_CONFIDENCE"; optionId: string; criterionId: string; confidence: Confidence }
+
+  // Score provenance
+  | {
+      type: "SET_ENRICHED_SCORE";
+      optionId: string;
+      criterionId: string;
+      value: number;
+      source: string;
+      tier: 1 | 2 | 3;
+    }
+  | { type: "RESTORE_ENRICHED_VALUE"; optionId: string; criterionId: string }
 
   // Reasoning
   | {
@@ -193,6 +211,7 @@ function applyDecisionMutation(decision: Decision, action: DecisionAction): Deci
         options: decision.options.filter((o) => o.id !== action.optionId),
         scores: newScores,
         reasoning: newReasoning,
+        scoreMetadata: removeOptionMetadata(decision.scoreMetadata, action.optionId),
       });
     }
 
@@ -232,6 +251,7 @@ function applyDecisionMutation(decision: Decision, action: DecisionAction): Deci
         criteria: decision.criteria.filter((c) => c.id !== action.criterionId),
         scores: newScores,
         reasoning: newReasoning,
+        scoreMetadata: removeCriterionMetadata(decision.scoreMetadata, action.criterionId),
       });
     }
 
@@ -257,7 +277,71 @@ function applyDecisionMutation(decision: Decision, action: DecisionAction): Deci
             : clamped,
         };
       }
-      return stampNow({ ...decision, scores: newScores });
+      // Track provenance: if previous was enriched, mark as overridden
+      let newMetadata: ScoreMetadataMatrix | undefined = decision.scoreMetadata;
+      const existingMeta = decision.scoreMetadata?.[action.optionId]?.[action.criterionId];
+      if (existingMeta?.provenance === "enriched") {
+        newMetadata = setMetadataCell(
+          newMetadata,
+          action.optionId,
+          action.criterionId,
+          createOverrideMetadata(existingMeta),
+        );
+      }
+      return stampNow({ ...decision, scores: newScores, scoreMetadata: newMetadata });
+    }
+
+    case "SET_ENRICHED_SCORE": {
+      const newScores = { ...decision.scores };
+      if (!newScores[action.optionId]) newScores[action.optionId] = {};
+      const clamped = Math.max(0, Math.min(10, Math.round(action.value)));
+      const existing = newScores[action.optionId]?.[action.criterionId];
+      const existingConf =
+        typeof existing === "object" && existing !== null && "confidence" in existing
+          ? (existing as { value: number; confidence: Confidence }).confidence
+          : undefined;
+      newScores[action.optionId] = {
+        ...newScores[action.optionId],
+        [action.criterionId]: existingConf
+          ? { value: clamped, confidence: existingConf }
+          : clamped,
+      };
+      const newMetadata = setMetadataCell(
+        decision.scoreMetadata,
+        action.optionId,
+        action.criterionId,
+        createEnrichedMetadata(clamped, action.source, action.tier),
+      );
+      return stampNow({ ...decision, scores: newScores, scoreMetadata: newMetadata });
+    }
+
+    case "RESTORE_ENRICHED_VALUE": {
+      const meta = decision.scoreMetadata?.[action.optionId]?.[action.criterionId];
+      if (meta?.provenance !== "overridden" || meta.enrichedValue === undefined) {
+        return null; // Nothing to restore
+      }
+      const value = Math.max(0, Math.min(10, Math.round(meta.enrichedValue)));
+      const newScores = { ...decision.scores };
+      if (!newScores[action.optionId]) newScores[action.optionId] = {};
+      const existing = newScores[action.optionId]?.[action.criterionId];
+      const existingConf =
+        typeof existing === "object" && existing !== null && "confidence" in existing
+          ? (existing as { value: number; confidence: Confidence }).confidence
+          : undefined;
+      newScores[action.optionId] = {
+        ...newScores[action.optionId],
+        [action.criterionId]: existingConf
+          ? { value, confidence: existingConf }
+          : value,
+      };
+      // Restore to enriched provenance
+      const newMetadata = setMetadataCell(
+        decision.scoreMetadata,
+        action.optionId,
+        action.criterionId,
+        createEnrichedMetadata(value, meta.enrichedSource ?? "", meta.enrichedTier ?? 2),
+      );
+      return stampNow({ ...decision, scores: newScores, scoreMetadata: newMetadata });
     }
 
     case "UPDATE_CONFIDENCE": {
@@ -339,6 +423,8 @@ function classifyAction(
     case "UPDATE_SCORE":
     case "UPDATE_CONFIDENCE":
     case "SET_CONFIDENCE_STRATEGY":
+    case "SET_ENRICHED_SCORE":
+    case "RESTORE_ENRICHED_VALUE":
       return { type: "structural", timestamp: Date.now() };
     case "UPDATE_REASONING":
       return {

--- a/src/lib/provenance.ts
+++ b/src/lib/provenance.ts
@@ -1,0 +1,172 @@
+/**
+ * Score provenance tracking — pure functions for creating, querying,
+ * and updating per-cell provenance metadata.
+ *
+ * Every score cell can be:
+ * - `manual`     — entered directly by the user (default)
+ * - `enriched`   — auto-filled by the enrichment engine
+ * - `overridden` — user changed an enriched value (original preserved)
+ *
+ * @module lib/provenance
+ */
+
+import type {
+  Decision,
+  ScoreMetadata,
+  ScoreMetadataMatrix,
+  ScoreProvenance,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// Factory helpers
+// ---------------------------------------------------------------------------
+
+/** Create metadata for a manually entered score. */
+export function createManualMetadata(): ScoreMetadata {
+  return { provenance: "manual" };
+}
+
+/** Create metadata for an enrichment-sourced score. */
+export function createEnrichedMetadata(
+  value: number,
+  source: string,
+  tier: 1 | 2 | 3,
+): ScoreMetadata {
+  return {
+    provenance: "enriched",
+    enrichedValue: value,
+    enrichedSource: source,
+    enrichedTier: tier,
+  };
+}
+
+/**
+ * Create metadata for a user override of an enriched score.
+ * Preserves the original enrichment information so the value can be restored.
+ */
+export function createOverrideMetadata(
+  existing: ScoreMetadata,
+  reason?: string,
+): ScoreMetadata {
+  return {
+    provenance: "overridden",
+    enrichedValue: existing.enrichedValue,
+    enrichedSource: existing.enrichedSource,
+    enrichedTier: existing.enrichedTier,
+    overriddenAt: new Date().toISOString(),
+    overrideReason: reason,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Query helpers
+// ---------------------------------------------------------------------------
+
+/** Get the provenance for a specific cell, defaulting to `"manual"`. */
+export function getProvenance(
+  decision: Readonly<Decision>,
+  optionId: string,
+  criterionId: string,
+): ScoreProvenance {
+  return decision.scoreMetadata?.[optionId]?.[criterionId]?.provenance ?? "manual";
+}
+
+/** Get the full metadata for a specific cell (if any). */
+export function getMetadata(
+  decision: Readonly<Decision>,
+  optionId: string,
+  criterionId: string,
+): ScoreMetadata | undefined {
+  return decision.scoreMetadata?.[optionId]?.[criterionId];
+}
+
+/**
+ * Check whether a cell has an enriched value that can be restored.
+ * Only `"overridden"` cells with a saved `enrichedValue` qualify.
+ */
+export function canRestoreEnriched(
+  decision: Readonly<Decision>,
+  optionId: string,
+  criterionId: string,
+): boolean {
+  const meta = getMetadata(decision, optionId, criterionId);
+  return meta?.provenance === "overridden" && meta.enrichedValue !== undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Immutable matrix update helpers
+// ---------------------------------------------------------------------------
+
+/** Set metadata for a single cell, returning a new matrix. */
+export function setMetadataCell(
+  matrix: ScoreMetadataMatrix | undefined,
+  optionId: string,
+  criterionId: string,
+  metadata: ScoreMetadata,
+): ScoreMetadataMatrix {
+  const current = matrix ?? {};
+  const optionRow = current[optionId];
+  return {
+    ...current,
+    [optionId]: {
+      ...optionRow,
+      [criterionId]: metadata,
+    },
+  };
+}
+
+/** Remove metadata for a deleted option. */
+export function removeOptionMetadata(
+  matrix: ScoreMetadataMatrix | undefined,
+  optionId: string,
+): ScoreMetadataMatrix | undefined {
+  if (!matrix?.[optionId]) return matrix;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { [optionId]: _removed, ...rest } = matrix;
+  return Object.keys(rest).length > 0 ? rest : undefined;
+}
+
+/** Remove metadata for a deleted criterion across all options. */
+export function removeCriterionMetadata(
+  matrix: ScoreMetadataMatrix | undefined,
+  criterionId: string,
+): ScoreMetadataMatrix | undefined {
+  if (!matrix) return undefined;
+  let changed = false;
+  const result: ScoreMetadataMatrix = {};
+  for (const [optId, cells] of Object.entries(matrix)) {
+    if (cells[criterionId]) {
+      changed = true;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { [criterionId]: _removed, ...rest } = cells;
+      if (Object.keys(rest).length > 0) {
+        result[optId] = rest;
+      }
+    } else {
+      result[optId] = cells;
+    }
+  }
+  if (!changed) return matrix;
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+/**
+ * Build a display label for a score cell's provenance.
+ * Used in tooltips and screen-reader announcements.
+ */
+export function provenanceLabel(meta: ScoreMetadata | undefined): string {
+  if (!meta || meta.provenance === "manual") return "Manually entered";
+  if (meta.provenance === "enriched") {
+    const parts = ["Enriched"];
+    if (meta.enrichedSource) parts.push(`from ${meta.enrichedSource}`);
+    if (meta.enrichedTier) parts.push(`(Tier ${meta.enrichedTier})`);
+    return parts.join(" ");
+  }
+  // overridden
+  const parts = ["Overridden"];
+  if (meta.enrichedValue !== undefined) {
+    parts.push(`from ${meta.enrichedValue}`);
+  }
+  if (meta.enrichedSource) parts.push(`· source: ${meta.enrichedSource}`);
+  return parts.join(" ");
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -57,6 +57,31 @@ export type ScoreValue = number | ScoredCell | null;
  */
 export type ScoreMatrix = Record<string, Record<string, ScoreValue>>;
 
+// ---------------------------------------------------------------------------
+// Score provenance
+// ---------------------------------------------------------------------------
+
+/** Tracks where a score value originated */
+export type ScoreProvenance = "manual" | "enriched" | "overridden";
+
+/** Per-cell metadata tracking the origin and history of a score */
+export interface ScoreMetadata {
+  provenance: ScoreProvenance;
+  /** Original enriched value (preserved when user overrides) */
+  enrichedValue?: number;
+  /** Data provider that supplied the enriched value */
+  enrichedSource?: string;
+  /** Tier of the enriched data (1=live, 2=bundled, 3=estimated) */
+  enrichedTier?: 1 | 2 | 3;
+  /** ISO timestamp when the user overrode an enriched score */
+  overriddenAt?: string;
+  /** Optional explanation for why the user overrode the score */
+  overrideReason?: string;
+}
+
+/** Matrix of per-cell provenance metadata: optionId → criterionId → ScoreMetadata */
+export type ScoreMetadataMatrix = Record<string, Record<string, ScoreMetadata>>;
+
 /** A complete decision with all its data */
 export interface Decision {
   id: string;
@@ -67,6 +92,8 @@ export interface Decision {
   scores: ScoreMatrix;
   /** Optional per-score reasoning notes: optionId → criterionId → text */
   reasoning?: Record<string, Record<string, string>>;
+  /** Optional per-score provenance metadata: optionId → criterionId → ScoreMetadata */
+  scoreMetadata?: ScoreMetadataMatrix;
   /** Strategy for how per-score confidence affects results (default: "none") */
   confidenceStrategy?: ConfidenceStrategy;
   createdAt: string; // ISO 8601


### PR DESCRIPTION
## Summary

Implements score provenance tracking and user override UI (Issue #109) — tracks whether each score cell was manually entered, auto-enriched, or user-overridden.

## Changes

### New: `src/lib/provenance.ts` (~170 lines)
- `ScoreProvenance` type: `"manual" | "enriched" | "overridden"`
- Factory helpers: `createManualMetadata()`, `createEnrichedMetadata()`, `createOverrideMetadata()`
- Query helpers: `getProvenance()`, `getMetadata()`, `canRestoreEnriched()`
- Matrix mutation helpers: `setMetadataCell()`, `removeOptionMetadata()`, `removeCriterionMetadata()`
- Display label generator: `provenanceLabel()`

### Modified: `src/lib/types.ts`
- Added `ScoreProvenance`, `ScoreMetadata`, `ScoreMetadataMatrix` types
- Added optional `scoreMetadata?: ScoreMetadataMatrix` to `Decision` interface

### Modified: `src/lib/decision-reducer.ts`
- New `SET_ENRICHED_SCORE` action — sets score + enriched provenance metadata
- New `RESTORE_ENRICHED_VALUE` action — restores overridden score to original enriched value
- Extended `UPDATE_SCORE` — auto-detects when editing enriched cell → marks as overridden
- `REMOVE_OPTION` / `REMOVE_CRITERION` — clean up scoreMetadata on deletion

### Modified: `src/components/DecisionProvider.tsx`
- Added `setEnrichedScore()` and `restoreEnrichedValue()` convenience wrappers
- Exposed in `DecisionContextValue` interface

### New: `src/components/ScoreProvenanceIndicator.tsx` (~90 lines)
- Enriched indicator: blue database icon with source/tier tooltip
- Overridden indicator: amber user icon with override details
- Restore button: appears on overridden cells with saved enriched value

### Modified: `src/components/DecisionBuilder.tsx`
- Added `ScoreProvenanceIndicator` alongside score cells in the matrix

### Tests
- `src/__tests__/provenance.test.ts` — 21 unit tests for all provenance logic
- `src/__tests__/components/ScoreProvenanceIndicator.test.tsx` — 8 component tests

## Test Results
- 29 new tests, all passing
- 1213 total tests across 72 files (0 regressions)

Closes #109
