### PR TITLE
feat: AHP pairwise comparison wizard (#96)

### DIFF
--- a/src/__tests__/ahp.test.ts
+++ b/src/__tests__/ahp.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildPairwiseMatrix,
+  deriveWeights,
+  lambdaMax,
+  consistencyIndex,
+  consistencyRatio,
+  isConsistent,
+  weightsTo100,
+  computeAHP,
+  pairCount,
+  generatePairs,
+  saatyLabel,
+} from "@/lib/ahp";
+import type { PairwiseComparison } from "@/lib/ahp";
+
+// ---------------------------------------------------------------------------
+// buildPairwiseMatrix
+// ---------------------------------------------------------------------------
+
+describe("buildPairwiseMatrix", () => {
+  it("produces identity matrix when all comparisons are equal (empty)", () => {
+    const ids = ["a", "b", "c"];
+    const m = buildPairwiseMatrix(ids, []);
+    expect(m).toEqual([
+      [1, 1, 1],
+      [1, 1, 1],
+      [1, 1, 1],
+    ]);
+  });
+
+  it("sets reciprocal values for a single comparison", () => {
+    const ids = ["x", "y"];
+    const comps: PairwiseComparison[] = [
+      { criterionA: "x", criterionB: "y", value: 5 },
+    ];
+    const m = buildPairwiseMatrix(ids, comps);
+    expect(m[0][1]).toBe(5);
+    expect(m[1][0]).toBeCloseTo(1 / 5);
+    expect(m[0][0]).toBe(1);
+    expect(m[1][1]).toBe(1);
+  });
+
+  it("clamps values to Saaty range [1/9, 9]", () => {
+    const ids = ["a", "b"];
+    const comps: PairwiseComparison[] = [
+      { criterionA: "a", criterionB: "b", value: 20 },
+    ];
+    const m = buildPairwiseMatrix(ids, comps);
+    expect(m[0][1]).toBe(9);
+    expect(m[1][0]).toBeCloseTo(1 / 9);
+  });
+
+  it("ignores comparisons with unknown criterion ids", () => {
+    const ids = ["a", "b"];
+    const comps: PairwiseComparison[] = [
+      { criterionA: "a", criterionB: "UNKNOWN", value: 3 },
+    ];
+    const m = buildPairwiseMatrix(ids, comps);
+    expect(m[0][1]).toBe(1);
+  });
+
+  it("handles single criterion", () => {
+    const m = buildPairwiseMatrix(["only"], []);
+    expect(m).toEqual([[1]]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deriveWeights
+// ---------------------------------------------------------------------------
+
+describe("deriveWeights", () => {
+  it("returns empty array for empty matrix", () => {
+    expect(deriveWeights([])).toEqual([]);
+  });
+
+  it("returns [1] for single criterion", () => {
+    expect(deriveWeights([[1]])).toEqual([1]);
+  });
+
+  it("returns equal weights for identity matrix", () => {
+    const m = buildPairwiseMatrix(["a", "b", "c"], []);
+    const w = deriveWeights(m);
+    expect(w).toHaveLength(3);
+    for (const v of w) {
+      expect(v).toBeCloseTo(1 / 3, 5);
+    }
+  });
+
+  it("gives higher weight to more important criterion", () => {
+    const ids = ["a", "b"];
+    const comps: PairwiseComparison[] = [
+      { criterionA: "a", criterionB: "b", value: 5 },
+    ];
+    const m = buildPairwiseMatrix(ids, comps);
+    const w = deriveWeights(m);
+    expect(w[0]).toBeGreaterThan(w[1]);
+    expect(w[0] + w[1]).toBeCloseTo(1, 5);
+  });
+
+  it("produces weights summing to 1 for a 4x4 matrix", () => {
+    const ids = ["a", "b", "c", "d"];
+    const comps: PairwiseComparison[] = [
+      { criterionA: "a", criterionB: "b", value: 3 },
+      { criterionA: "a", criterionB: "c", value: 5 },
+      { criterionA: "a", criterionB: "d", value: 7 },
+      { criterionA: "b", criterionB: "c", value: 3 },
+      { criterionA: "b", criterionB: "d", value: 5 },
+      { criterionA: "c", criterionB: "d", value: 3 },
+    ];
+    const m = buildPairwiseMatrix(ids, comps);
+    const w = deriveWeights(m);
+    expect(w.reduce((s, v) => s + v, 0)).toBeCloseTo(1, 5);
+    // Expected priority order: a > b > c > d
+    expect(w[0]).toBeGreaterThan(w[1]);
+    expect(w[1]).toBeGreaterThan(w[2]);
+    expect(w[2]).toBeGreaterThan(w[3]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lambdaMax
+// ---------------------------------------------------------------------------
+
+describe("lambdaMax", () => {
+  it("equals n for a perfectly consistent matrix", () => {
+    const ids = ["a", "b", "c"];
+    const comps: PairwiseComparison[] = [
+      { criterionA: "a", criterionB: "b", value: 2 },
+      { criterionA: "a", criterionB: "c", value: 4 },
+      { criterionA: "b", criterionB: "c", value: 2 },
+    ];
+    const m = buildPairwiseMatrix(ids, comps);
+    const w = deriveWeights(m);
+    const lm = lambdaMax(m, w);
+    expect(lm).toBeCloseTo(3, 2);
+  });
+
+  it("returns 1 for single criterion", () => {
+    expect(lambdaMax([[1]], [1])).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// consistencyIndex & consistencyRatio
+// ---------------------------------------------------------------------------
+
+describe("consistencyIndex", () => {
+  it("is 0 for matrices with n <= 2", () => {
+    expect(consistencyIndex([[1]], [1])).toBe(0);
+    expect(consistencyIndex([[1, 3], [1 / 3, 1]], [0.75, 0.25])).toBe(0);
+  });
+
+  it("is near 0 for a perfectly consistent matrix", () => {
+    const ids = ["a", "b", "c"];
+    const comps: PairwiseComparison[] = [
+      { criterionA: "a", criterionB: "b", value: 3 },
+      { criterionA: "a", criterionB: "c", value: 9 },
+      { criterionA: "b", criterionB: "c", value: 3 },
+    ];
+    const m = buildPairwiseMatrix(ids, comps);
+    const w = deriveWeights(m);
+    expect(consistencyIndex(m, w)).toBeCloseTo(0, 2);
+  });
+});
+
+describe("consistencyRatio", () => {
+  it("is 0 for n <= 2", () => {
+    expect(consistencyRatio([[1, 5], [0.2, 1]], [0.83, 0.17])).toBe(0);
+  });
+
+  it("is below 0.1 for consistent judgments", () => {
+    const ids = ["a", "b", "c"];
+    const comps: PairwiseComparison[] = [
+      { criterionA: "a", criterionB: "b", value: 3 },
+      { criterionA: "a", criterionB: "c", value: 5 },
+      { criterionA: "b", criterionB: "c", value: 2 },
+    ];
+    const m = buildPairwiseMatrix(ids, comps);
+    const w = deriveWeights(m);
+    const cr = consistencyRatio(m, w);
+    expect(cr).toBeLessThan(0.1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isConsistent
+// ---------------------------------------------------------------------------
+
+describe("isConsistent", () => {
+  it("returns true for CR < 0.1", () => {
+    expect(isConsistent(0)).toBe(true);
+    expect(isConsistent(0.05)).toBe(true);
+    expect(isConsistent(0.099)).toBe(true);
+  });
+
+  it("returns false for CR >= 0.1", () => {
+    expect(isConsistent(0.1)).toBe(false);
+    expect(isConsistent(0.5)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// weightsTo100
+// ---------------------------------------------------------------------------
+
+describe("weightsTo100", () => {
+  it("returns empty for empty input", () => {
+    expect(weightsTo100([])).toEqual([]);
+  });
+
+  it("sums to exactly 100", () => {
+    const w100 = weightsTo100([0.333, 0.333, 0.334]);
+    expect(w100.reduce((s, v) => s + v, 0)).toBe(100);
+  });
+
+  it("handles uneven weights", () => {
+    const w100 = weightsTo100([0.5, 0.3, 0.2]);
+    expect(w100).toEqual([50, 30, 20]);
+  });
+
+  it("uses largest-remainder for rounding", () => {
+    const w100 = weightsTo100([0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]);
+    expect(w100.reduce((s, v) => s + v, 0)).toBe(100);
+    for (const v of w100) {
+      expect(v).toBe(10);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeAHP (high-level)
+// ---------------------------------------------------------------------------
+
+describe("computeAHP", () => {
+  it("produces consistent result for a well-formed comparison set", () => {
+    const ids = ["a", "b", "c"];
+    const comps: PairwiseComparison[] = [
+      { criterionA: "a", criterionB: "b", value: 3 },
+      { criterionA: "a", criterionB: "c", value: 5 },
+      { criterionA: "b", criterionB: "c", value: 2 },
+    ];
+    const result = computeAHP(ids, comps);
+
+    expect(result.isConsistent).toBe(true);
+    expect(result.consistencyRatio).toBeLessThan(0.1);
+    expect(result.weights).toHaveLength(3);
+    expect(result.weights100).toHaveLength(3);
+    expect(result.weights100.reduce((s, v) => s + v, 0)).toBe(100);
+    expect(result.weights[0]).toBeGreaterThan(result.weights[1]);
+    expect(result.weights[1]).toBeGreaterThan(result.weights[2]);
+  });
+
+  it("flags inconsistent judgments", () => {
+    const ids = ["a", "b", "c"];
+    const comps: PairwiseComparison[] = [
+      { criterionA: "a", criterionB: "b", value: 9 },
+      { criterionA: "b", criterionB: "c", value: 9 },
+      { criterionA: "a", criterionB: "c", value: 1 / 9 }, // contradictory
+    ];
+    const result = computeAHP(ids, comps);
+    expect(result.isConsistent).toBe(false);
+    expect(result.consistencyRatio).toBeGreaterThan(0.1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pairCount & generatePairs
+// ---------------------------------------------------------------------------
+
+describe("pairCount", () => {
+  it("returns 0 for 0 or 1 criteria", () => {
+    expect(pairCount(0)).toBe(0);
+    expect(pairCount(1)).toBe(0);
+  });
+
+  it("returns correct count for n criteria", () => {
+    expect(pairCount(2)).toBe(1);
+    expect(pairCount(3)).toBe(3);
+    expect(pairCount(5)).toBe(10);
+  });
+});
+
+describe("generatePairs", () => {
+  it("generates all unique pairs in order", () => {
+    const pairs = generatePairs(["a", "b", "c"]);
+    expect(pairs).toEqual([
+      { a: "a", b: "b" },
+      { a: "a", b: "c" },
+      { a: "b", b: "c" },
+    ]);
+  });
+
+  it("returns empty for single criterion", () => {
+    expect(generatePairs(["x"])).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// saatyLabel
+// ---------------------------------------------------------------------------
+
+describe("saatyLabel", () => {
+  it("returns 'Equal' for 1", () => {
+    expect(saatyLabel(1)).toBe("Equal");
+  });
+
+  it("returns descriptive labels for scale values", () => {
+    expect(saatyLabel(3)).toBe("Moderately more");
+    expect(saatyLabel(5)).toBe("Strongly more");
+    expect(saatyLabel(7)).toBe("Very strongly more");
+    expect(saatyLabel(9)).toBe("Extremely more");
+  });
+});

--- a/src/__tests__/components/AHPWizard.test.tsx
+++ b/src/__tests__/components/AHPWizard.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+import { renderWithProviders } from "../test-utils";
+import { AHPWizard } from "@/components/AHPWizard";
+
+describe("AHPWizard", () => {
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    onClose.mockClear();
+    // Seed the demo decision (5 criteria) via localStorage
+    globalThis.localStorage.clear();
+  });
+
+  it("renders the wizard with header and progress", () => {
+    renderWithProviders(<AHPWizard onClose={onClose} />);
+
+    expect(screen.getByText("AHP Weight Wizard")).toBeInTheDocument();
+    expect(screen.getByText(/Comparison 1 of/)).toBeInTheDocument();
+  });
+
+  it("shows all pairs count for 5 demo criteria (10 pairs)", () => {
+    renderWithProviders(<AHPWizard onClose={onClose} />);
+
+    // 5 criteria → 10 pairs
+    expect(screen.getByText(/of 10/)).toBeInTheDocument();
+  });
+
+  it("displays consistency ratio", () => {
+    renderWithProviders(<AHPWizard onClose={onClose} />);
+
+    // Default all-equal → CR = 0.000, consistent
+    expect(screen.getByText(/CR =/)).toBeInTheDocument();
+    expect(screen.getByText("Consistent")).toBeInTheDocument();
+  });
+
+  it("shows derived weights section", () => {
+    renderWithProviders(<AHPWizard onClose={onClose} />);
+
+    expect(screen.getByText("Derived Weights")).toBeInTheDocument();
+    // Each criterion name appears in comparison step AND weight preview
+    expect(screen.getAllByText("Cost of Living").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Job Opportunities").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("navigates between comparisons with next/back buttons", async () => {
+    const { user } = renderWithProviders(<AHPWizard onClose={onClose} />);
+
+    expect(screen.getByText("Comparison 1 of 10")).toBeInTheDocument();
+
+    const nextBtn = screen.getByLabelText("Next comparison");
+    await user.click(nextBtn);
+    expect(screen.getByText("Comparison 2 of 10")).toBeInTheDocument();
+
+    const backBtn = screen.getByLabelText("Previous comparison");
+    await user.click(backBtn);
+    expect(screen.getByText("Comparison 1 of 10")).toBeInTheDocument();
+  });
+
+  it("disables back button on first step", () => {
+    renderWithProviders(<AHPWizard onClose={onClose} />);
+
+    const backBtn = screen.getByLabelText("Previous comparison");
+    expect(backBtn).toBeDisabled();
+  });
+
+  it("calls onClose when close button is clicked", async () => {
+    const { user } = renderWithProviders(<AHPWizard onClose={onClose} />);
+
+    const closeBtn = screen.getByLabelText("Close AHP wizard");
+    await user.click(closeBtn);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("apply weights button is present and enabled for consistent matrix", () => {
+    renderWithProviders(<AHPWizard onClose={onClose} />);
+
+    // Default all-equal → consistent → Apply should be enabled
+    const applyBtn = screen.getByLabelText("Apply derived weights");
+    expect(applyBtn).toBeEnabled();
+  });
+
+  it("shows 'Applied' text after clicking apply", async () => {
+    const { user } = renderWithProviders(<AHPWizard onClose={onClose} />);
+
+    const applyBtn = screen.getByLabelText("Apply derived weights");
+    await user.click(applyBtn);
+    expect(screen.getByText("Applied")).toBeInTheDocument();
+  });
+
+  it("has accessible slider for comparison input", () => {
+    renderWithProviders(<AHPWizard onClose={onClose} />);
+
+    const slider = screen.getByRole("slider");
+    expect(slider).toBeInTheDocument();
+    expect(slider).toHaveAttribute("aria-label");
+  });
+
+  it("updates comparison label when slider changes", () => {
+    renderWithProviders(<AHPWizard onClose={onClose} />);
+
+    // Default value displays "1 — Equal"
+    expect(screen.getByText(/1 — Equal/)).toBeInTheDocument();
+
+    // Move slider to position 12 → Saaty value 5 → "Strongly more"
+    const slider = screen.getByRole("slider");
+    fireEvent.change(slider, { target: { value: "12" } });
+
+    // Should show the new comparison label
+    expect(screen.getByText(/Strongly more/)).toBeInTheDocument();
+  });
+});

--- a/src/components/AHPWizard.tsx
+++ b/src/components/AHPWizard.tsx
@@ -1,0 +1,360 @@
+/**
+ * AHP Pairwise Comparison Wizard
+ *
+ * Step-by-step UI for deriving criterion weights via the Analytic Hierarchy
+ * Process. Users compare each unique pair of criteria on the Saaty 1–9 scale,
+ * then apply the derived weights to the decision.
+ */
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import {
+  ArrowLeft,
+  ArrowRight,
+  CheckCircle2,
+  AlertTriangle,
+  Scale,
+  X,
+} from "lucide-react";
+import { useDecision } from "./DecisionProvider";
+import {
+  computeAHP,
+  generatePairs,
+  pairCount,
+  saatyLabel,
+} from "@/lib/ahp";
+import type { PairwiseComparison } from "@/lib/ahp";
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface AHPWizardProps {
+  readonly onClose: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Saaty-scale slider config
+// ---------------------------------------------------------------------------
+
+/** Discrete stops: [1/9, 1/8, …, 1/2, 1, 2, …, 9] mapped to a 0–16 range. */
+const SLIDER_STOPS = [
+  1 / 9, 1 / 8, 1 / 7, 1 / 6, 1 / 5, 1 / 4, 1 / 3, 1 / 2,
+  1,
+  2, 3, 4, 5, 6, 7, 8, 9,
+] as const;
+
+function sliderIndexToValue(index: number): number {
+  return SLIDER_STOPS[Math.round(index)] ?? 1;
+}
+
+function valueToSliderIndex(value: number): number {
+  let best = 8; // default to center (1)
+  let bestDist = Infinity;
+  for (let i = 0; i < SLIDER_STOPS.length; i++) {
+    const dist = Math.abs(SLIDER_STOPS[i] - value);
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = i;
+    }
+  }
+  return best;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatComparisonValue(value: number): string {
+  if (value >= 1) return `${Math.round(value)}`;
+  return `1/${Math.round(1 / value)}`;
+}
+
+function crColorClass(cr: number): string {
+  if (cr < 0.05) return "text-green-600 dark:text-green-400";
+  if (cr < 0.1) return "text-yellow-600 dark:text-yellow-400";
+  return "text-red-600 dark:text-red-400";
+}
+
+function crBgClass(cr: number): string {
+  if (cr < 0.05) return "bg-green-50 dark:bg-green-950 border-green-200 dark:border-green-800";
+  if (cr < 0.1) return "bg-yellow-50 dark:bg-yellow-950 border-yellow-200 dark:border-yellow-800";
+  return "bg-red-50 dark:bg-red-950 border-red-200 dark:border-red-800";
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function AHPWizard({ onClose }: Readonly<AHPWizardProps>) {
+  const { decision, updateCriterion } = useDecision();
+
+  const criterionIds = useMemo(
+    () => decision.criteria.map((c) => c.id),
+    [decision.criteria],
+  );
+
+  const criterionNames = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const c of decision.criteria) {
+      map.set(c.id, c.name);
+    }
+    return map;
+  }, [decision.criteria]);
+
+  const pairs = useMemo(() => generatePairs(criterionIds), [criterionIds]);
+  const totalPairs = pairCount(criterionIds.length);
+
+  // Comparison values keyed "criterionA::criterionB" → value (Saaty scale)
+  const [values, setValues] = useState<Map<string, number>>(() => {
+    const m = new Map<string, number>();
+    for (const p of pairs) {
+      m.set(`${p.a}::${p.b}`, 1);
+    }
+    return m;
+  });
+
+  const [currentStep, setCurrentStep] = useState(0);
+  const [applied, setApplied] = useState(false);
+
+  // Build comparisons from the values map
+  const comparisons: PairwiseComparison[] = useMemo(
+    () =>
+      pairs.map((p) => ({
+        criterionA: p.a,
+        criterionB: p.b,
+        value: values.get(`${p.a}::${p.b}`) ?? 1,
+      })),
+    [pairs, values],
+  );
+
+  // Compute AHP result on every change
+  const result = useMemo(
+    () => computeAHP(criterionIds, comparisons),
+    [criterionIds, comparisons],
+  );
+
+  // Current pair for the step view
+  const currentPair = pairs[currentStep] as { a: string; b: string } | undefined;
+  const currentKey = currentPair ? `${currentPair.a}::${currentPair.b}` : "";
+  const currentValue = values.get(currentKey) ?? 1;
+
+  const handleSliderChange = useCallback(
+    (sliderIndex: number) => {
+      if (!currentKey) return;
+      const val = sliderIndexToValue(sliderIndex);
+      setValues((prev) => {
+        const next = new Map(prev);
+        next.set(currentKey, val);
+        return next;
+      });
+    },
+    [currentKey],
+  );
+
+  const handleApply = useCallback(() => {
+    const w100 = result.weights100;
+    for (let i = 0; i < criterionIds.length; i++) {
+      updateCriterion(criterionIds[i], { weight: w100[i] });
+    }
+    setApplied(true);
+  }, [result.weights100, criterionIds, updateCriterion]);
+
+  // Edge case: less than 2 criteria
+  if (criterionIds.length < 2) {
+    return (
+      <section
+        className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 shadow-lg"
+        aria-label="AHP Wizard"
+      >
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          AHP requires at least 2 criteria. Add more criteria first.
+        </p>
+        <button
+          onClick={onClose}
+          className="mt-4 rounded-md bg-gray-600 px-4 py-2 text-sm text-white hover:bg-gray-700 transition-colors"
+        >
+          Close
+        </button>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg overflow-hidden"
+      aria-label="AHP Pairwise Comparison Wizard"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-gray-200 dark:border-gray-700 px-5 py-3">
+        <div className="flex items-center gap-2">
+          <Scale className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+          <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100">
+            AHP Weight Wizard
+          </h3>
+        </div>
+        <button
+          onClick={onClose}
+          className="rounded-md p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+          aria-label="Close AHP wizard"
+        >
+          <X className="h-5 w-5" />
+        </button>
+      </div>
+
+      {/* Progress */}
+      <div className="px-5 pt-4">
+        <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400 mb-1">
+          <span>
+            Comparison {currentStep + 1} of {totalPairs}
+          </span>
+          <span>{Math.round(((currentStep + 1) / totalPairs) * 100)}%</span>
+        </div>
+        <div className="h-1.5 w-full rounded-full bg-gray-200 dark:bg-gray-700">
+          <div
+            className="h-1.5 rounded-full bg-blue-500 dark:bg-blue-400 transition-all duration-300"
+            style={{ width: `${((currentStep + 1) / totalPairs) * 100}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Comparison Step */}
+      {currentPair && (
+        <div className="px-5 py-5">
+          <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
+            How much more important is…
+          </p>
+
+          <div className="flex items-center justify-between gap-4 mb-4">
+            <span
+              className={`text-sm font-medium flex-1 text-right ${currentValue >= 1 ? "text-blue-700 dark:text-blue-300" : "text-gray-700 dark:text-gray-300"}`}
+            >
+              {criterionNames.get(currentPair.a)}
+            </span>
+            <span className="text-xs text-gray-400 dark:text-gray-500">vs</span>
+            <span
+              className={`text-sm font-medium flex-1 text-left ${currentValue < 1 ? "text-blue-700 dark:text-blue-300" : "text-gray-700 dark:text-gray-300"}`}
+            >
+              {criterionNames.get(currentPair.b)}
+            </span>
+          </div>
+
+          {/* Slider */}
+          <div className="space-y-2">
+            <input
+              type="range"
+              min={0}
+              max={SLIDER_STOPS.length - 1}
+              step={1}
+              value={valueToSliderIndex(currentValue)}
+              onChange={(e) => handleSliderChange(Number(e.target.value))}
+              className="w-full accent-blue-600"
+              aria-label={`Importance of ${criterionNames.get(currentPair.a)} vs ${criterionNames.get(currentPair.b)}`}
+            />
+            <div className="flex justify-between text-[10px] text-gray-400 dark:text-gray-500">
+              <span>← {criterionNames.get(currentPair.b)} more</span>
+              <span>Equal</span>
+              <span>{criterionNames.get(currentPair.a)} more →</span>
+            </div>
+            <p className="text-center text-sm font-medium text-gray-700 dark:text-gray-300 mt-1">
+              {formatComparisonValue(currentValue)} — {saatyLabel(currentValue)}
+              {currentValue > 1 && (
+                <span className="text-xs text-gray-400 dark:text-gray-500">
+                  {" "}({criterionNames.get(currentPair.a)})
+                </span>
+              )}
+              {currentValue < 1 && (
+                <span className="text-xs text-gray-400 dark:text-gray-500">
+                  {" "}({criterionNames.get(currentPair.b)})
+                </span>
+              )}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Consistency Indicator */}
+      <div className={`mx-5 mb-4 rounded-md border p-3 ${crBgClass(result.consistencyRatio)}`}>
+        <div className="flex items-center gap-2">
+          {result.isConsistent ? (
+            <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400 shrink-0" />
+          ) : (
+            <AlertTriangle className="h-4 w-4 text-red-600 dark:text-red-400 shrink-0" />
+          )}
+          <span className={`text-sm font-medium ${crColorClass(result.consistencyRatio)}`}>
+            CR = {result.consistencyRatio.toFixed(3)}
+          </span>
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            {result.isConsistent ? "Consistent" : "Inconsistent — revise judgments"}
+          </span>
+        </div>
+      </div>
+
+      {/* Preview weights */}
+      <div className="mx-5 mb-4">
+        <p className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">
+          Derived Weights
+        </p>
+        <div className="space-y-1">
+          {criterionIds.map((id, i) => (
+            <div key={id} className="flex items-center gap-2 text-sm">
+              <span className="flex-1 text-gray-700 dark:text-gray-300 truncate">
+                {criterionNames.get(id)}
+              </span>
+              <div className="w-24 h-2 rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-blue-500 dark:bg-blue-400 transition-all duration-300"
+                  style={{ width: `${(result.weights[i] ?? 0) * 100}%` }}
+                />
+              </div>
+              <span className="w-10 text-right text-xs text-gray-500 dark:text-gray-400 tabular-nums">
+                {result.weights100[i]}%
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Navigation & Actions */}
+      <div className="flex items-center justify-between border-t border-gray-200 dark:border-gray-700 px-5 py-3">
+        <button
+          onClick={() => setCurrentStep((s) => Math.max(0, s - 1))}
+          disabled={currentStep === 0}
+          className="inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          aria-label="Previous comparison"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back
+        </button>
+
+        <div className="flex items-center gap-2">
+          {applied ? (
+            <span className="inline-flex items-center gap-1 text-sm text-green-600 dark:text-green-400">
+              <CheckCircle2 className="h-4 w-4" />
+              Applied
+            </span>
+          ) : (
+            <button
+              onClick={handleApply}
+              className="rounded-md bg-blue-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              disabled={!result.isConsistent}
+              aria-label="Apply derived weights"
+            >
+              Apply Weights
+            </button>
+          )}
+        </div>
+
+        <button
+          onClick={() => setCurrentStep((s) => Math.min(totalPairs - 1, s + 1))}
+          disabled={currentStep >= totalPairs - 1}
+          className="inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          aria-label="Next comparison"
+        >
+          Next
+          <ArrowRight className="h-4 w-4" />
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/DecisionBuilder.tsx
+++ b/src/components/DecisionBuilder.tsx
@@ -16,6 +16,7 @@ import {
   Redo2,
   ChevronDown,
   ChevronUp,
+  Scale,
 } from "lucide-react";
 import { showToast } from "./Toast";
 import { formatRelativeTime } from "@/lib/utils";
@@ -37,6 +38,7 @@ import { MobileScoreCards } from "./MobileScoreCards";
 import { ScoreProvenanceIndicator } from "./ScoreProvenanceIndicator";
 import { ConfidenceIndicator } from "./ConfidenceIndicator";
 import { getMetadata, canRestoreEnriched } from "@/lib/provenance";
+import { AHPWizard } from "./AHPWizard";
 
 interface DecisionBuilderProps {
   validation: ValidationResult;
@@ -87,6 +89,8 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
       currentScore: readScore(decision.scores, focusedCell.optionId, focusedCell.criterionId),
     };
   }, [focusedCell, decision.options, decision.scores]);
+
+  const [showAHP, setShowAHP] = useState(false);
 
   /** Track which option/criterion descriptions are expanded */
   const [expandedDescs, setExpandedDescs] = useState<Set<string>>(() => {
@@ -571,6 +575,24 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
           />
           Auto-normalize weights to 100%
         </label>
+
+        {/* AHP Wizard */}
+        {decision.criteria.length >= 2 && (
+          <div className="mt-3">
+            {showAHP ? (
+              <AHPWizard onClose={() => setShowAHP(false)} />
+            ) : (
+              <button
+                type="button"
+                onClick={() => setShowAHP(true)}
+                className="inline-flex items-center gap-2 rounded-md border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-950 px-3 py-2 text-sm font-medium text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900 transition-colors"
+              >
+                <Scale className="h-4 w-4" />
+                Derive weights with AHP wizard
+              </button>
+            )}
+          </div>
+        )}
       </section>
 
       {/* Scores Matrix */}

--- a/src/lib/ahp.ts
+++ b/src/lib/ahp.ts
@@ -1,0 +1,301 @@
+/**
+ * AHP (Analytic Hierarchy Process) — Pairwise Comparison Engine
+ *
+ * Implements the Saaty AHP method for deriving criterion weights from
+ * pairwise comparisons. Uses the power method to approximate the principal
+ * eigenvector and computes the Consistency Ratio (CR) to validate judgment
+ * coherence.
+ *
+ * Reference: Saaty, T. L. (1980). The Analytic Hierarchy Process.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A single pairwise comparison on the Saaty 1–9 scale. */
+export interface PairwiseComparison {
+  readonly criterionA: string;
+  readonly criterionB: string;
+  /** 1–9 means A is `value`× more important than B. Reciprocal stored for B vs A. */
+  readonly value: number;
+}
+
+/** Full n×n reciprocal matrix. */
+export type PairwiseMatrix = readonly (readonly number[])[];
+
+/** Result of the AHP computation. */
+export interface AHPResult {
+  /** Derived priority weights (sum ≈ 1). Order matches input criterionIds. */
+  readonly weights: readonly number[];
+  /** Weights scaled to 0–100 integers (sum = 100). */
+  readonly weights100: readonly number[];
+  /** Principal eigenvalue. */
+  readonly lambdaMax: number;
+  /** Consistency Index: (λmax − n) / (n − 1). */
+  readonly consistencyIndex: number;
+  /** Consistency Ratio: CI / RI(n). */
+  readonly consistencyRatio: number;
+  /** True when CR < 0.1 (acceptable). */
+  readonly isConsistent: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Random Index (RI) for matrices of size 1–15 (Saaty, 1980).
+ * Index 0 is unused; RI[n] gives the value for an n×n matrix.
+ */
+const RANDOM_INDEX: readonly number[] = [
+  0,     // 0 (unused)
+  0,     // 1
+  0,     // 2
+  0.58,  // 3
+  0.9,   // 4
+  1.12,  // 5
+  1.24,  // 6
+  1.32,  // 7
+  1.41,  // 8
+  1.45,  // 9
+  1.49,  // 10
+  1.51,  // 11
+  1.48,  // 12
+  1.56,  // 13
+  1.57,  // 14
+  1.59,  // 15
+];
+
+/** Maximum number of power-method iterations. */
+const MAX_ITERATIONS = 100;
+
+/** Convergence threshold for the power method. */
+const CONVERGENCE_EPSILON = 1e-8;
+
+// ---------------------------------------------------------------------------
+// Matrix Construction
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the n×n reciprocal pairwise matrix from a list of comparisons.
+ *
+ * Any missing pair defaults to 1 (equal importance).
+ * The matrix is always reciprocal: M[i][j] = 1 / M[j][i].
+ */
+export function buildPairwiseMatrix(
+  criterionIds: readonly string[],
+  comparisons: readonly PairwiseComparison[],
+): PairwiseMatrix {
+  const n = criterionIds.length;
+  const indexMap = new Map(criterionIds.map((id, i) => [id, i]));
+
+  // Initialize identity matrix
+  const matrix: number[][] = Array.from({ length: n }, () => new Array<number>(n).fill(1));
+
+  for (const comp of comparisons) {
+    const i = indexMap.get(comp.criterionA);
+    const j = indexMap.get(comp.criterionB);
+    if (i === undefined || j === undefined || i === j) continue;
+
+    const v = Math.max(1 / 9, Math.min(9, comp.value));
+    matrix[i][j] = v;
+    matrix[j][i] = 1 / v;
+  }
+
+  return matrix;
+}
+
+// ---------------------------------------------------------------------------
+// Weight Derivation — Power Method
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive priority weights from a pairwise matrix using the power method
+ * (iterative eigenvector approximation).
+ *
+ * Returns a normalized weight vector that sums to 1.
+ */
+export function deriveWeights(matrix: PairwiseMatrix): number[] {
+  const n = matrix.length;
+  if (n === 0) return [];
+  if (n === 1) return [1];
+
+  let vector = new Array<number>(n).fill(1 / n);
+
+  for (let iter = 0; iter < MAX_ITERATIONS; iter++) {
+    // Multiply matrix × vector
+    const next: number[] = new Array<number>(n).fill(0);
+    for (let i = 0; i < n; i++) {
+      for (let j = 0; j < n; j++) {
+        next[i] += matrix[i][j] * vector[j];
+      }
+    }
+
+    // Normalize
+    const sum = next.reduce((s, v) => s + v, 0);
+    for (let i = 0; i < n; i++) {
+      next[i] /= sum;
+    }
+
+    // Check convergence
+    let maxDiff = 0;
+    for (let i = 0; i < n; i++) {
+      maxDiff = Math.max(maxDiff, Math.abs(next[i] - vector[i]));
+    }
+    vector = next;
+
+    if (maxDiff < CONVERGENCE_EPSILON) break;
+  }
+
+  return vector;
+}
+
+// ---------------------------------------------------------------------------
+// Consistency Check
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the principal eigenvalue (λmax) from a matrix and its eigenvector.
+ */
+export function lambdaMax(matrix: PairwiseMatrix, weights: readonly number[]): number {
+  const n = matrix.length;
+  if (n <= 1) return n;
+
+  let lambda = 0;
+  for (let i = 0; i < n; i++) {
+    let rowSum = 0;
+    for (let j = 0; j < n; j++) {
+      rowSum += matrix[i][j] * weights[j];
+    }
+    lambda += rowSum / weights[i];
+  }
+  return lambda / n;
+}
+
+/**
+ * Compute the Consistency Index: CI = (λmax − n) / (n − 1).
+ */
+export function consistencyIndex(matrix: PairwiseMatrix, weights: readonly number[]): number {
+  const n = matrix.length;
+  if (n <= 2) return 0;
+  const lm = lambdaMax(matrix, weights);
+  return (lm - n) / (n - 1);
+}
+
+/**
+ * Compute the Consistency Ratio: CR = CI / RI(n).
+ * Returns 0 for n ≤ 2 (always consistent).
+ */
+export function consistencyRatio(matrix: PairwiseMatrix, weights: readonly number[]): number {
+  const n = matrix.length;
+  if (n <= 2) return 0;
+  const ri = n < RANDOM_INDEX.length ? RANDOM_INDEX[n] : RANDOM_INDEX.at(-1) ?? 1.59;
+  if (ri === 0) return 0;
+  return consistencyIndex(matrix, weights) / ri;
+}
+
+/**
+ * Returns true when the consistency ratio is acceptable (CR < 0.1).
+ */
+export function isConsistent(cr: number): boolean {
+  return cr < 0.1;
+}
+
+// ---------------------------------------------------------------------------
+// Weights → 0–100 Integer Scale
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert normalized weights (sum ≈ 1) to integer weights summing to 100.
+ * Uses largest-remainder method to avoid rounding drift.
+ */
+export function weightsTo100(weights: readonly number[]): number[] {
+  if (weights.length === 0) return [];
+
+  const scaled = weights.map((w) => w * 100);
+  const floored = scaled.map(Math.floor);
+  let remainder = 100 - floored.reduce((s, v) => s + v, 0);
+
+  // Distribute remainder to entries with largest fractional parts
+  const fractionals = scaled.map((v, i) => ({ i, frac: v - floored[i] }));
+  fractionals.sort((a, b) => b.frac - a.frac);
+
+  for (const { i } of fractionals) {
+    if (remainder <= 0) break;
+    floored[i] += 1;
+    remainder -= 1;
+  }
+
+  return floored;
+}
+
+// ---------------------------------------------------------------------------
+// High-Level API
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the full AHP computation: build matrix → derive weights → check consistency.
+ */
+export function computeAHP(
+  criterionIds: readonly string[],
+  comparisons: readonly PairwiseComparison[],
+): AHPResult {
+  const matrix = buildPairwiseMatrix(criterionIds, comparisons);
+  const weights = deriveWeights(matrix);
+  const lm = lambdaMax(matrix, weights);
+  const ci = consistencyIndex(matrix, weights);
+  const cr = consistencyRatio(matrix, weights);
+
+  return {
+    weights,
+    weights100: weightsTo100(weights),
+    lambdaMax: lm,
+    consistencyIndex: ci,
+    consistencyRatio: cr,
+    isConsistent: isConsistent(cr),
+  };
+}
+
+/**
+ * Return the total number of pairwise comparisons needed for n criteria.
+ */
+export function pairCount(n: number): number {
+  if (n < 2) return 0;
+  return (n * (n - 1)) / 2;
+}
+
+/**
+ * Generate all unique pairs of criterion ids in stable order.
+ */
+export function generatePairs(
+  criterionIds: readonly string[],
+): readonly { a: string; b: string }[] {
+  const pairs: { a: string; b: string }[] = [];
+  for (let i = 0; i < criterionIds.length; i++) {
+    for (let j = i + 1; j < criterionIds.length; j++) {
+      pairs.push({ a: criterionIds[i], b: criterionIds[j] });
+    }
+  }
+  return pairs;
+}
+
+/**
+ * Saaty scale label for a numeric value.
+ */
+export function saatyLabel(value: number): string {
+  const abs = Math.abs(value);
+  if (abs <= 1) return "Equal";
+  const rounded = Math.round(abs);
+  switch (rounded) {
+    case 2: return "Slightly more";
+    case 3: return "Moderately more";
+    case 4: return "Moderate-to-strong";
+    case 5: return "Strongly more";
+    case 6: return "Strong-to-very-strong";
+    case 7: return "Very strongly more";
+    case 8: return "Very-to-extremely strong";
+    case 9: return "Extremely more";
+    default: return "Equal";
+  }
+}


### PR DESCRIPTION
## Summary

Implements AHP (Analytic Hierarchy Process) pairwise comparison wizard for mathematically consistent weight derivation (Issue #96).

## Changes

### New: `src/lib/ahp.ts` (~260 lines)
- **Types**: `PairwiseComparison`, `PairwiseMatrix`, `AHPResult`
- **Matrix**: `buildPairwiseMatrix()` — reciprocal matrix from comparisons (Saaty 1–9 scale)
- **Weights**: `deriveWeights()` — power method eigenvector approximation (100 iterations, ε=1e-8)
- **Consistency**: `lambdaMax()`, `consistencyIndex()`, `consistencyRatio()`, `isConsistent()` (CR < 0.1)
- **Utilities**: `weightsTo100()` (largest-remainder), `pairCount()`, `generatePairs()`, `saatyLabel()`
- Random Index (RI) table for n=1..15 (Saaty, 1980)

### New: `src/components/AHPWizard.tsx` (~280 lines)
- Step-by-step UI for n*(n-1)/2 pairwise comparisons
- Discrete slider (1/9 → 9 on Saaty scale) with criterion labels
- Real-time consistency ratio display with green/yellow/red color coding
- Live weight preview with progress bars
- "Apply Weights" button (disabled when CR ≥ 0.1)
- Full ARIA labels, dark mode support

### Modified: `src/components/DecisionBuilder.tsx`
- Added "Derive weights with AHP wizard" button in weights section
- Inline AHPWizard panel (shows when ≥ 2 criteria exist)

### Tests
- **30 unit tests** for `ahp.ts`: matrix construction, weight derivation, consistency checks, utilities
- **11 component tests** for `AHPWizard.tsx`: rendering, navigation, slider, apply, a11y

## Test Results
- 41 new tests, all passing
- 1263 total tests across 75 files (0 regressions)

Closes #96
