### PR TITLE
fix: achieve zero lint errors and warnings across codebase

### DIFF
--- a/src/__tests__/components/CompositeConfidence.test.tsx
+++ b/src/__tests__/components/CompositeConfidence.test.tsx
@@ -11,9 +11,6 @@ import {
 } from "@/lib/composite-confidence";
 import { assessDecisionQuality } from "@/lib/decision-quality";
 import { computeConsensus } from "@/lib/consensus";
-import { computeResults } from "@/lib/scoring";
-import { computeTopsisResults } from "@/lib/topsis";
-import { computeRegretResults } from "@/lib/regret";
 import { CompositeConfidenceIndicator } from "@/components/CompositeConfidenceIndicator";
 import type { Decision } from "@/lib/types";
 

--- a/src/__tests__/components/ConfidenceStrategySelector.test.tsx
+++ b/src/__tests__/components/ConfidenceStrategySelector.test.tsx
@@ -7,7 +7,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ConfidenceStrategySelector } from "@/components/ConfidenceStrategySelector";
-import type { ConfidenceStrategy } from "@/lib/types";
 
 describe("ConfidenceStrategySelector", () => {
   it("renders all three strategy options", () => {
@@ -65,9 +64,7 @@ describe("ConfidenceStrategySelector", () => {
 
   it("shows descriptions for each strategy", () => {
     render(<ConfidenceStrategySelector value="none" onChange={vi.fn()} />);
-    expect(
-      screen.getByText(/confidence is shown but does not affect scores/i)
-    ).toBeInTheDocument();
+    expect(screen.getByText(/confidence is shown but does not affect scores/i)).toBeInTheDocument();
     expect(screen.getByText(/low-confidence scores are reduced/i)).toBeInTheDocument();
     expect(screen.getByText(/widens the range for sensitivity/i)).toBeInTheDocument();
   });

--- a/src/__tests__/components/DecisionQuality.test.tsx
+++ b/src/__tests__/components/DecisionQuality.test.tsx
@@ -7,7 +7,7 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { assessDecisionQuality, type QualityAssessment } from "@/lib/decision-quality";
+import { assessDecisionQuality } from "@/lib/decision-quality";
 import { QualityBar } from "@/components/QualityBar";
 import type { Decision } from "@/lib/types";
 

--- a/src/__tests__/components/FrameworkComparison.test.tsx
+++ b/src/__tests__/components/FrameworkComparison.test.tsx
@@ -1,11 +1,8 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { FrameworkComparison } from "@/components/FrameworkComparison";
-import { computeConsensus, ALL_ALGORITHMS, type AlgorithmId } from "@/lib/consensus";
-import { computeResults } from "@/lib/scoring";
-import { computeTopsisResults } from "@/lib/topsis";
-import { computeRegretResults } from "@/lib/regret";
+import { computeConsensus } from "@/lib/consensus";
 import type { Decision } from "@/lib/types";
 
 // ---------------------------------------------------------------------------
@@ -78,17 +75,7 @@ function tinyDecision(): Decision {
 }
 
 function renderComparison(decision: Decision) {
-  const results = computeResults(decision);
-  const topsisResults = computeTopsisResults(decision);
-  const regretResults = computeRegretResults(decision);
-  return render(
-    <FrameworkComparison
-      decision={decision}
-      results={results}
-      topsisResults={topsisResults}
-      regretResults={regretResults}
-    />
-  );
+  return render(<FrameworkComparison decision={decision} />);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/__tests__/components/WhatIfPanel.test.tsx
+++ b/src/__tests__/components/WhatIfPanel.test.tsx
@@ -8,7 +8,7 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent, within } from "@testing-library/react";
 import { WhatIfPanel } from "@/components/WhatIfPanel";
 import { computeResults } from "@/lib/scoring";
-import type { Decision, DecisionResults } from "@/lib/types";
+import type { Decision } from "@/lib/types";
 
 // ---------------------------------------------------------------------------
 // Test fixtures

--- a/src/__tests__/confidence-scoring.test.ts
+++ b/src/__tests__/confidence-scoring.test.ts
@@ -20,7 +20,7 @@ import {
   normalizeWeights,
   CONFIDENCE_MULTIPLIERS,
 } from "@/lib/scoring";
-import type { Confidence, ConfidenceStrategy, Decision, Criterion, ScoreMatrix } from "@/lib/types";
+import type { Decision, Criterion, ScoreMatrix } from "@/lib/types";
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -261,8 +261,8 @@ describe("computeResults with confidence strategy", () => {
     const decision = makeDecision({
       criteria: [{ id: "c1", name: "C1", weight: 100, type: "benefit" }],
       scores: {
-        o1: { c1: { value: 10, confidence: "low" } },  // penalized: 10*0.5=5
-        o2: { c1: { value: 7, confidence: "high" } },   // penalized: 7*1.0=7
+        o1: { c1: { value: 10, confidence: "low" } }, // penalized: 10*0.5=5
+        o2: { c1: { value: 7, confidence: "high" } }, // penalized: 7*1.0=7
       },
       confidenceStrategy: "penalize",
     });

--- a/src/__tests__/consensus.test.ts
+++ b/src/__tests__/consensus.test.ts
@@ -1,12 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  computeConsensus,
-  kendallW,
-  spearmanCorrelation,
-  ALL_ALGORITHMS,
-  type AlgorithmId,
-  type ConsensusResult,
-} from "@/lib/consensus";
+import { computeConsensus, kendallW, spearmanCorrelation, ALL_ALGORITHMS } from "@/lib/consensus";
 import type { Decision } from "@/lib/types";
 
 // ---------------------------------------------------------------------------

--- a/src/__tests__/i18n.test.ts
+++ b/src/__tests__/i18n.test.ts
@@ -3,22 +3,20 @@
  * locale detection, fallback behaviour, and pluralization helpers.
  */
 
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { interpolate, translate, detectLocale } from "@/lib/i18n";
 
 // ── interpolate ────────────────────────────────────────────────────
 
 describe("interpolate", () => {
   it("replaces a single placeholder", () => {
-    expect(interpolate("Hello {name}!", { name: "World" })).toBe(
-      "Hello World!",
-    );
+    expect(interpolate("Hello {name}!", { name: "World" })).toBe("Hello World!");
   });
 
   it("replaces multiple different placeholders", () => {
-    expect(
-      interpolate("{filled}/{total} scores filled", { filled: 3, total: 5 }),
-    ).toBe("3/5 scores filled");
+    expect(interpolate("{filled}/{total} scores filled", { filled: 3, total: 5 })).toBe(
+      "3/5 scores filled"
+    );
   });
 
   it("leaves unknown placeholders untouched", () => {
@@ -30,15 +28,11 @@ describe("interpolate", () => {
   });
 
   it("returns the template unchanged when no placeholders exist", () => {
-    expect(interpolate("No placeholders here", { foo: "bar" })).toBe(
-      "No placeholders here",
-    );
+    expect(interpolate("No placeholders here", { foo: "bar" })).toBe("No placeholders here");
   });
 
   it("replaces the same placeholder appearing multiple times", () => {
-    expect(interpolate("{x} + {x} = {result}", { x: 2, result: 4 })).toBe(
-      "2 + 2 = 4",
-    );
+    expect(interpolate("{x} + {x} = {result}", { x: 2, result: 4 })).toBe("2 + 2 = 4");
   });
 });
 
@@ -54,9 +48,7 @@ describe("translate", () => {
   });
 
   it("performs interpolation when params are provided", () => {
-    expect(translate("en", "header.switchTheme", { mode: "dark" })).toBe(
-      "Switch to dark mode",
-    );
+    expect(translate("en", "header.switchTheme", { mode: "dark" })).toBe("Switch to dark mode");
   });
 
   it("falls back to English for empty translations (es stub)", () => {
@@ -151,9 +143,7 @@ describe("translation file completeness", () => {
   it("fr.json values are non-empty strings", async () => {
     const fr = await import("@/lib/i18n/fr.json");
     for (const ns of Object.values(fr.default)) {
-      for (const [key, value] of Object.entries(
-        ns as Record<string, string>,
-      )) {
+      for (const [key, value] of Object.entries(ns as Record<string, string>)) {
         expect(value, `fr key "${key}" should not be empty`).not.toBe("");
       }
     }

--- a/src/__tests__/performance.test.ts
+++ b/src/__tests__/performance.test.ts
@@ -22,16 +22,13 @@ import { generateId } from "@/lib/utils";
  * Generate a synthetic decision with the given dimensions.
  * Scores are randomized between 1–10.
  */
-function createLargeDecision(
-  optionCount: number,
-  criterionCount: number,
-): Decision {
+function createLargeDecision(optionCount: number, criterionCount: number): Decision {
   const options: Option[] = Array.from(
     { length: optionCount },
     (_, i): Option => ({
       id: generateId(),
       name: `Option ${String(i + 1)}`,
-    }),
+    })
   );
 
   const criteria: Criterion[] = Array.from(
@@ -41,7 +38,7 @@ function createLargeDecision(
       name: `Criterion ${String(i + 1)}`,
       weight: Math.round(100 / criterionCount),
       type: i % 3 === 0 ? "cost" : "benefit",
-    }),
+    })
   );
 
   const scores: Decision["scores"] = {};
@@ -86,7 +83,6 @@ describe("Performance benchmarks", () => {
       const elapsed = measureMs(() => {
         computeResults(decision);
       });
-      // eslint-disable-next-line no-console
       console.log(`  computeResults(10×10): ${elapsed.toFixed(2)}ms`);
       expect(elapsed).toBeLessThan(100);
     });
@@ -95,7 +91,6 @@ describe("Performance benchmarks", () => {
       const elapsed = measureMs(() => {
         sensitivityAnalysis(decision, 20);
       });
-      // eslint-disable-next-line no-console
       console.log(`  sensitivityAnalysis(10×10): ${elapsed.toFixed(2)}ms`);
       expect(elapsed).toBeLessThan(100);
     });
@@ -105,7 +100,6 @@ describe("Performance benchmarks", () => {
         computeTopsisResults(decision);
         computeRegretResults(decision);
       });
-      // eslint-disable-next-line no-console
       console.log(`  TOPSIS+Regret(10×10): ${elapsed.toFixed(2)}ms`);
       expect(elapsed).toBeLessThan(100);
     });
@@ -120,7 +114,6 @@ describe("Performance benchmarks", () => {
       const elapsed = measureMs(() => {
         computeResults(decision);
       });
-      // eslint-disable-next-line no-console
       console.log(`  computeResults(20×20): ${elapsed.toFixed(2)}ms`);
       expect(elapsed).toBeLessThan(500);
     });
@@ -132,7 +125,6 @@ describe("Performance benchmarks", () => {
         computeRegretResults(decision);
         sensitivityAnalysis(decision, 20);
       });
-      // eslint-disable-next-line no-console
       console.log(`  all algorithms(20×20): ${elapsed.toFixed(2)}ms`);
       expect(elapsed).toBeLessThan(500);
     });
@@ -145,7 +137,6 @@ describe("Performance benchmarks", () => {
       const elapsed = measureMs(() => {
         createLargeDecision(10, 10);
       });
-      // eslint-disable-next-line no-console
       console.log(`  createLargeDecision(10×10): ${elapsed.toFixed(2)}ms`);
       expect(elapsed).toBeLessThan(50);
     });
@@ -154,7 +145,6 @@ describe("Performance benchmarks", () => {
       const elapsed = measureMs(() => {
         createLargeDecision(20, 20);
       });
-      // eslint-disable-next-line no-console
       console.log(`  createLargeDecision(20×20): ${elapsed.toFixed(2)}ms`);
       expect(elapsed).toBeLessThan(100);
     });

--- a/src/components/FrameworkComparison.tsx
+++ b/src/components/FrameworkComparison.tsx
@@ -11,9 +11,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import type { Decision, DecisionResults } from "@/lib/types";
-import type { TopsisResults } from "@/lib/topsis";
-import type { RegretResults } from "@/lib/regret";
+import type { Decision } from "@/lib/types";
 import {
   computeConsensus,
   type AlgorithmId,
@@ -169,17 +167,9 @@ function buildRecommendation(consensus: ConsensusResult): string {
 
 interface FrameworkComparisonProps {
   decision: Decision;
-  results: DecisionResults;
-  topsisResults: TopsisResults;
-  regretResults: RegretResults;
 }
 
-export function FrameworkComparison({
-  decision,
-  results,
-  topsisResults,
-  regretResults,
-}: FrameworkComparisonProps) {
+export function FrameworkComparison({ decision }: FrameworkComparisonProps) {
   const [enabledAlgorithms, setEnabledAlgorithms] = useState<Set<AlgorithmId>>(
     () => new Set(ALL_ALGORITHMS)
   );

--- a/src/components/ResultsView.tsx
+++ b/src/components/ResultsView.tsx
@@ -23,7 +23,7 @@ import { buildShareLink } from "@/lib/share";
 import { normalizeWeights } from "@/lib/scoring";
 import type { TopsisResults } from "@/lib/topsis";
 import type { RegretResults } from "@/lib/regret";
-import type { Decision, DecisionResults, ConfidenceStrategy } from "@/lib/types";
+import type { Decision, DecisionResults } from "@/lib/types";
 import type { ValidationResult } from "@/hooks/useValidation";
 import type { CompletenessResult } from "@/lib/completeness";
 import { BiasWarnings } from "./BiasWarnings";
@@ -48,7 +48,15 @@ interface ResultsViewProps {
 }
 
 export function ResultsView({ validation, completeness, onSwitchToBuilder }: ResultsViewProps) {
-  const { decision, results, topsisResults, regretResults, setConfidenceStrategy, updateCriterion, updateScore } = useDecision();
+  const {
+    decision,
+    results,
+    topsisResults,
+    regretResults,
+    setConfidenceStrategy,
+    updateCriterion,
+    updateScore,
+  } = useDecision();
   const [shareStatus, setShareStatus] = useState<string>("");
   const [bannerDismissed, setBannerDismissed] = useState(false);
   const [whatIfOpen, setWhatIfOpen] = useState(false);
@@ -408,12 +416,7 @@ export function ResultsView({ validation, completeness, onSwitchToBuilder }: Res
             decision={decision}
           />
         ) : scoringMethod === "compare" ? (
-          <FrameworkComparison
-            decision={decision}
-            results={results}
-            topsisResults={topsisResults}
-            regretResults={regretResults}
-          />
+          <FrameworkComparison decision={decision} />
         ) : (
           <RegretRankings regretResults={regretResults} decision={decision} />
         )}

--- a/src/components/ScoreChart.tsx
+++ b/src/components/ScoreChart.tsx
@@ -77,14 +77,15 @@ function ScoreChartInner({ optionResults }: ScoreChartProps) {
     return optionResults[0].criterionScores.map((cs) => cs.criterionName);
   }, [optionResults]);
 
-  if (optionResults.length === 0) return null;
-
-  // Build accessible summary for screen readers
+  // Build accessible summary for screen readers (must be before early return to satisfy Rules of Hooks)
   const chartSummary = useMemo(() => {
+    if (optionResults.length === 0) return "";
     const sorted = [...optionResults].sort((a, b) => a.rank - b.rank);
     const topOption = sorted[0];
     return `Ranked scores: ${sorted.map((r) => `${r.optionName} (${r.totalScore.toFixed(1)})`).join(", ")}. Top choice: ${topOption.optionName} with score ${topOption.totalScore.toFixed(2)}.`;
   }, [optionResults]);
+
+  if (optionResults.length === 0) return null;
 
   return (
     <div className="space-y-6">
@@ -162,7 +163,9 @@ function ScoreChartInner({ optionResults }: ScoreChartProps) {
             <th scope="col">Total Score</th>
             <th scope="col">Rank</th>
             {criteriaNames.map((name) => (
-              <th key={name} scope="col">{name}</th>
+              <th key={name} scope="col">
+                {name}
+              </th>
             ))}
           </tr>
         </thead>

--- a/src/components/WhatIfPanel.tsx
+++ b/src/components/WhatIfPanel.tsx
@@ -15,24 +15,9 @@
 
 "use client";
 
-import {
-  useState,
-  useMemo,
-  useCallback,
-  useEffect,
-  useRef,
-  type ReactNode,
-} from "react";
-import {
-  X,
-  RotateCcw,
-  Check,
-  ArrowUp,
-  ArrowDown,
-  Minus,
-  FlaskConical,
-} from "lucide-react";
-import type { Decision, DecisionResults, OptionResult } from "@/lib/types";
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
+import { X, RotateCcw, Check, ArrowUp, ArrowDown, Minus, FlaskConical } from "lucide-react";
+import type { Decision, DecisionResults } from "@/lib/types";
 import { computeResults } from "@/lib/scoring";
 import { resolveScoreValue } from "@/lib/scoring";
 
@@ -59,9 +44,7 @@ function cloneWeights(decision: Decision): number[] {
   return decision.criteria.map((c) => c.weight);
 }
 
-function cloneScores(
-  decision: Decision
-): Record<string, Record<string, number | null>> {
+function cloneScores(decision: Decision): Record<string, Record<string, number | null>> {
   const out: Record<string, Record<string, number | null>> = {};
   for (const opt of decision.options) {
     out[opt.id] = {};
@@ -88,9 +71,7 @@ function buildWhatIfDecision(
     scores: Object.fromEntries(
       Object.entries(scores).map(([optId, critScores]) => [
         optId,
-        Object.fromEntries(
-          Object.entries(critScores).map(([critId, val]) => [critId, val])
-        ),
+        Object.fromEntries(Object.entries(critScores).map(([critId, val]) => [critId, val])),
       ])
     ),
   };
@@ -132,12 +113,7 @@ function RankDelta({ original, current }: { original: number; current: number })
 // Component
 // ---------------------------------------------------------------------------
 
-export function WhatIfPanel({
-  decision,
-  originalResults,
-  onApply,
-  onClose,
-}: WhatIfPanelProps) {
+export function WhatIfPanel({ decision, originalResults, onApply, onClose }: WhatIfPanelProps) {
   // ── Local sandbox state ─────────────────────────────────
   const [weights, setWeights] = useState(() => cloneWeights(decision));
   const [scores, setScores] = useState(() => cloneScores(decision));
@@ -180,12 +156,9 @@ export function WhatIfPanel({
   }, [onClose]);
 
   // ── Handlers ────────────────────────────────────────────
-  const handleWeightChange = useCallback(
-    (index: number, value: number) => {
-      setWeights((prev) => prev.map((w, i) => (i === index ? value : w)));
-    },
-    []
-  );
+  const handleWeightChange = useCallback((index: number, value: number) => {
+    setWeights((prev) => prev.map((w, i) => (i === index ? value : w)));
+  }, []);
 
   const handleScoreChange = useCallback(
     (optionId: string, criterionId: string, value: number | null) => {
@@ -299,9 +272,7 @@ export function WhatIfPanel({
 
           {/* ── Score Matrix ─────────────────────────────── */}
           <section>
-            <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
-              Scores
-            </h3>
+            <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Scores</h3>
             <div className="overflow-x-auto">
               <table className="w-full text-sm" data-testid="whatif-score-matrix">
                 <thead>
@@ -321,10 +292,7 @@ export function WhatIfPanel({
                 </thead>
                 <tbody>
                   {decision.options.map((opt) => (
-                    <tr
-                      key={opt.id}
-                      className="border-b border-gray-100 dark:border-gray-700/50"
-                    >
+                    <tr key={opt.id} className="border-b border-gray-100 dark:border-gray-700/50">
                       <td className="py-2 pr-3 text-gray-700 dark:text-gray-300 font-medium truncate max-w-[120px]">
                         {opt.name}
                       </td>
@@ -376,9 +344,7 @@ export function WhatIfPanel({
                       key={r.optionId}
                       className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300"
                     >
-                      <span className="font-mono text-xs text-gray-400 w-5">
-                        #{r.rank}
-                      </span>
+                      <span className="font-mono text-xs text-gray-400 w-5">#{r.rank}</span>
                       <span className="flex-1 truncate">{r.optionName}</span>
                       <span className="font-mono text-xs text-gray-500">
                         {r.totalScore.toFixed(2)}
@@ -401,9 +367,7 @@ export function WhatIfPanel({
                         key={r.optionId}
                         className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300"
                       >
-                        <span className="font-mono text-xs text-gray-400 w-5">
-                          #{r.rank}
-                        </span>
+                        <span className="font-mono text-xs text-gray-400 w-5">#{r.rank}</span>
                         <span className="flex-1 truncate">{r.optionName}</span>
                         <RankDelta original={origRank} current={r.rank} />
                         <span className="font-mono text-xs text-gray-500">

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -26,8 +26,10 @@ export const MAX_TEXTAREA_LENGTH = 5_000;
  * Does NOT strip HTML entities — React's JSX escaping handles those.
  */
 export function stripControlChars(input: string): string {
-  // eslint-disable-next-line no-control-regex
-  return input.replaceAll(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u009F\u200B-\u200F\u2028-\u202E\uFEFF]/g, "");
+  return input.replaceAll(
+    /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u009F\u200B-\u200F\u2028-\u202E\uFEFF]/g,
+    ""
+  );
 }
 
 /**
@@ -39,9 +41,7 @@ export function stripControlChars(input: string): string {
  * 4. Enforces maximum length
  */
 export function sanitizeText(input: string, maxLength = MAX_TEXT_LENGTH): string {
-  const cleaned = stripControlChars(input)
-    .replaceAll(/\s+/g, " ")
-    .trim();
+  const cleaned = stripControlChars(input).replaceAll(/\s+/g, " ").trim();
   return cleaned.slice(0, maxLength);
 }
 
@@ -54,10 +54,7 @@ export function sanitizeText(input: string, maxLength = MAX_TEXT_LENGTH): string
  * 4. Trims leading/trailing whitespace
  * 5. Enforces maximum length
  */
-export function sanitizeMultilineText(
-  input: string,
-  maxLength = MAX_TEXTAREA_LENGTH,
-): string {
+export function sanitizeMultilineText(input: string, maxLength = MAX_TEXTAREA_LENGTH): string {
   const cleaned = stripControlChars(input)
     .replaceAll(/\r\n?/g, "\n")
     .replaceAll(/\n{3,}/g, "\n\n")
@@ -69,12 +66,7 @@ export function sanitizeMultilineText(
  * Sanitize a numeric value, clamping it to the given range.
  * Returns `fallback` if the value is NaN or non-finite.
  */
-export function sanitizeNumber(
-  value: unknown,
-  min: number,
-  max: number,
-  fallback: number,
-): number {
+export function sanitizeNumber(value: unknown, min: number, max: number, fallback: number): number {
   const num = Number(value);
   if (!Number.isFinite(num)) return fallback;
   return Math.min(Math.max(num, min), max);


### PR DESCRIPTION
## Summary

Eliminates all lint errors (1) and warnings (28) to achieve a fully clean `npm run lint` output.

## Changes

### Critical Fix
- **ScoreChart.tsx**: Fixed React Hooks rule violation — `useMemo` (`chartSummary`) was called conditionally after an early `return null`, violating Rules of Hooks. Moved the hook before the guard with an empty-array fallback.

### Interface Cleanup
- **FrameworkComparison.tsx**: Removed unused props (`results`, `topsisResults`, `regretResults`) from the component interface. The consensus engine computes its own results via `computeConsensus(decision, algos)`, making these props redundant.
- **ResultsView.tsx**: Updated `<FrameworkComparison>` call site to stop passing removed props.

### Unused Import Removal (Source)
| File | Removed |
|------|---------|
| `ResultsView.tsx` | `ConfidenceStrategy` type |
| `WhatIfPanel.tsx` | `ReactNode`, `OptionResult` type |
| `FrameworkComparison.tsx` | `DecisionResults`, `TopsisResults`, `RegretResults` types |

### Unused Import Removal (Tests)
| File | Removed |
|------|---------|
| `CompositeConfidence.test.tsx` | `computeResults`, `computeTopsisResults`, `computeRegretResults` |
| `ConfidenceStrategySelector.test.tsx` | `ConfidenceStrategy` type |
| `DecisionQuality.test.tsx` | `QualityAssessment` type |
| `FrameworkComparison.test.tsx` | `beforeEach`, `ALL_ALGORITHMS`, `AlgorithmId`, `computeResults`, `computeTopsisResults`, `computeRegretResults` |
| `WhatIfPanel.test.tsx` | `DecisionResults` type |
| `confidence-scoring.test.ts` | `Confidence`, `ConfidenceStrategy` types |
| `consensus.test.ts` | `AlgorithmId`, `ConsensusResult` types |
| `i18n.test.ts` | `vi` |

### Directive Cleanup
| File | Removed |
|------|---------|
| `sanitize.ts` | 1 unused `eslint-disable-next-line no-control-regex` |
| `performance.test.ts` | 7 unused `eslint-disable-next-line no-console` directives |

## Verification

| Check | Result |
|-------|--------|
| `npm run lint` | 0 errors, 0 warnings |
| `npx tsc --noEmit` | 0 errors |
| `npx vitest run` | 1365 tests passed (80 files) |
| `npm run build` | Clean production build (Next.js 16.1.6 / Turbopack) |

## Files Changed
14 files across `src/components/`, `src/lib/`, and `src/__tests__/`