### PR TITLE
feat(builder): add drag-and-drop reordering for options and criteria

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "decision-os",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@sentry/nextjs": "^10.40.0",
         "@supabase/supabase-js": "^2.97.0",
         "lucide-react": "^0.575.0",
@@ -875,6 +878,60 @@
       "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2464,7 +2521,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.211.0.tgz",
       "integrity": "sha512-h0nrZEC/zvI994nhg7EgQ8URIHt0uDTwN90r3qQUdZORS455bbx+YebnGeEuFghUT0HlJSrLF4iHw67f+odY+Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.211.0",
         "import-in-the-middle": "^2.0.0",
@@ -10051,6 +10107,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
       "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.1.6",
         "@swc/helpers": "0.5.15",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     ]
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@sentry/nextjs": "^10.40.0",
     "@supabase/supabase-js": "^2.97.0",
     "lucide-react": "^0.575.0",

--- a/src/__tests__/decision-reducer.test.ts
+++ b/src/__tests__/decision-reducer.test.ts
@@ -170,6 +170,90 @@ describe("Decision mutations", () => {
     expect(next.decision.scores["o1"]["c2"]).toBe(4);
   });
 
+  // -------------------------------------------------------------------------
+  // REORDER_OPTIONS
+  // -------------------------------------------------------------------------
+
+  it("REORDER_OPTIONS moves an option to a new position", () => {
+    const d = makeDecision({
+      options: [
+        { id: "o1", name: "A" },
+        { id: "o2", name: "B" },
+        { id: "o3", name: "C" },
+      ],
+    });
+    const state = init(d);
+    const next = dispatch(state, { type: "REORDER_OPTIONS", fromIndex: 0, toIndex: 2 });
+    expect(next.decision.options.map((o) => o.id)).toEqual(["o2", "o3", "o1"]);
+    expect(next.isDirty).toBe(true);
+  });
+
+  it("REORDER_OPTIONS with same fromIndex and toIndex returns unchanged state", () => {
+    const state = init();
+    const next = dispatch(state, { type: "REORDER_OPTIONS", fromIndex: 1, toIndex: 1 });
+    // No-op: state reference should be identical
+    expect(next).toBe(state);
+  });
+
+  it("REORDER_OPTIONS with out-of-bounds index returns unchanged state", () => {
+    const state = init();
+    const next = dispatch(state, { type: "REORDER_OPTIONS", fromIndex: 0, toIndex: 5 });
+    expect(next).toBe(state);
+    const next2 = dispatch(state, { type: "REORDER_OPTIONS", fromIndex: -1, toIndex: 0 });
+    expect(next2).toBe(state);
+  });
+
+  it("REORDER_OPTIONS preserves score matrix data", () => {
+    const state = init();
+    const next = dispatch(state, { type: "REORDER_OPTIONS", fromIndex: 0, toIndex: 1 });
+    // Options reversed: [o2, o1] but score keys are by ID, unchanged
+    expect(next.decision.options[0].id).toBe("o2");
+    expect(next.decision.options[1].id).toBe("o1");
+    expect(next.decision.scores["o1"]).toEqual({ c1: 7, c2: 4 });
+    expect(next.decision.scores["o2"]).toEqual({ c1: 5, c2: 8 });
+  });
+
+  // -------------------------------------------------------------------------
+  // REORDER_CRITERIA
+  // -------------------------------------------------------------------------
+
+  it("REORDER_CRITERIA moves a criterion to a new position", () => {
+    const d = makeDecision({
+      criteria: [
+        { id: "c1", name: "X", weight: 30, type: "benefit" },
+        { id: "c2", name: "Y", weight: 40, type: "cost" },
+        { id: "c3", name: "Z", weight: 30, type: "benefit" },
+      ],
+    });
+    const state = init(d);
+    const next = dispatch(state, { type: "REORDER_CRITERIA", fromIndex: 2, toIndex: 0 });
+    expect(next.decision.criteria.map((c) => c.id)).toEqual(["c3", "c1", "c2"]);
+    expect(next.isDirty).toBe(true);
+  });
+
+  it("REORDER_CRITERIA with same index is no-op", () => {
+    const state = init();
+    const next = dispatch(state, { type: "REORDER_CRITERIA", fromIndex: 0, toIndex: 0 });
+    expect(next).toBe(state);
+  });
+
+  it("REORDER_CRITERIA with out-of-bounds index is no-op", () => {
+    const state = init();
+    const next = dispatch(state, { type: "REORDER_CRITERIA", fromIndex: 0, toIndex: 10 });
+    expect(next).toBe(state);
+  });
+
+  it("REORDER_CRITERIA preserves score matrix data", () => {
+    const state = init();
+    const next = dispatch(state, { type: "REORDER_CRITERIA", fromIndex: 1, toIndex: 0 });
+    // Criteria reversed: [c2, c1]
+    expect(next.decision.criteria[0].id).toBe("c2");
+    expect(next.decision.criteria[1].id).toBe("c1");
+    // Score matrix keyed by ID — unchanged
+    expect(next.decision.scores["o1"]["c1"]).toBe(7);
+    expect(next.decision.scores["o1"]["c2"]).toBe(4);
+  });
+
   it("UPDATE_SCORE sets a numeric score (clamped 0-10)", () => {
     const state = init();
     const next = dispatch(state, {
@@ -479,6 +563,24 @@ describe("Undo / Redo", () => {
     }
     // Should cap at 50 entries
     expect(state.past.length).toBeLessThanOrEqual(50);
+  });
+
+  it("UNDO restores original order after REORDER_OPTIONS", () => {
+    const state = init();
+    const reordered = dispatch(state, { type: "REORDER_OPTIONS", fromIndex: 0, toIndex: 1 });
+    expect(reordered.decision.options[0].id).toBe("o2");
+    expect(reordered.decision.options[1].id).toBe("o1");
+    const undone = dispatch(reordered, { type: "UNDO" });
+    expect(undone.decision.options[0].id).toBe("o1");
+    expect(undone.decision.options[1].id).toBe("o2");
+  });
+
+  it("UNDO restores original order after REORDER_CRITERIA", () => {
+    const state = init();
+    const reordered = dispatch(state, { type: "REORDER_CRITERIA", fromIndex: 0, toIndex: 1 });
+    expect(reordered.decision.criteria[0].id).toBe("c2");
+    const undone = dispatch(reordered, { type: "UNDO" });
+    expect(undone.decision.criteria[0].id).toBe("c1");
   });
 });
 

--- a/src/components/DecisionBuilder.tsx
+++ b/src/components/DecisionBuilder.tsx
@@ -39,6 +39,21 @@ import { ScoreProvenanceIndicator } from "./ScoreProvenanceIndicator";
 import { ConfidenceIndicator } from "./ConfidenceIndicator";
 import { getMetadata, canRestoreEnriched } from "@/lib/provenance";
 import { AHPWizard } from "./AHPWizard";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { SortableItem } from "./SortableItem";
 
 interface DecisionBuilderProps {
   validation: ValidationResult;
@@ -52,9 +67,11 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
     addOption,
     updateOption,
     removeOption,
+    reorderOptions,
     addCriterion,
     updateCriterion,
     removeCriterion,
+    reorderCriteria,
     updateScore,
     updateConfidence,
     updateReasoning,
@@ -147,6 +164,38 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
       }
     },
     [autoNormalize, decision.criteria, updateCriterion]
+  );
+
+  // ── Drag-and-drop sensors and handlers ──────────────────
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const handleOptionDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const oldIndex = decision.options.findIndex((o) => o.id === active.id);
+      const newIndex = decision.options.findIndex((o) => o.id === over.id);
+      if (oldIndex !== -1 && newIndex !== -1) {
+        reorderOptions(oldIndex, newIndex);
+      }
+    },
+    [decision.options, reorderOptions]
+  );
+
+  const handleCriteriaDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const oldIndex = decision.criteria.findIndex((c) => c.id === active.id);
+      const newIndex = decision.criteria.findIndex((c) => c.id === over.id);
+      if (oldIndex !== -1 && newIndex !== -1) {
+        reorderCriteria(oldIndex, newIndex);
+      }
+    },
+    [decision.criteria, reorderCriteria]
   );
 
   /** Arrow-key navigation within the score matrix (WAI-ARIA grid pattern) */
@@ -316,97 +365,108 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
             Add Option
           </button>
         </div>
-        <div className="space-y-2">
-          {decision.options.map((opt, index) => {
-            // Labels: A-Z, then AA, AB, ...
-            const label =
-              index < 26
-                ? String.fromCharCode(65 + index)
-                : String.fromCharCode(65 + Math.floor(index / 26) - 1) +
-                  String.fromCharCode(65 + (index % 26));
-            const optIssues = validation.byId.get(opt.id);
-            const hasIssue = !!optIssues && optIssues.length > 0;
-            return (
-              <div key={opt.id}>
-                <div className="flex items-center gap-2">
-                  <span className="w-6 text-center text-xs font-medium text-gray-500 dark:text-gray-400">
-                    {label}
-                  </span>
-                  <input
-                    type="text"
-                    value={opt.name}
-                    onChange={(e) => updateOption(opt.id, { name: e.target.value })}
-                    className={`flex-1 rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 ${
-                      hasIssue
-                        ? "border-orange-400 focus:border-orange-500 focus:ring-orange-500"
-                        : "border-gray-300 dark:border-gray-600 focus:border-blue-500"
-                    } dark:bg-gray-700 dark:text-gray-100`}
-                    placeholder={`Option ${label}`}
-                    aria-label={`Option ${index + 1} name`}
-                    maxLength={80}
-                    aria-invalid={hasIssue || undefined}
-                  />
-                  {decision.options.length > 2 && (
-                    <button
-                      onClick={() => {
-                        removeOption(opt.id);
-                        showToast({
-                          text: `Option "${opt.name}" removed`,
-                          action: { label: "Undo", onClick: undo },
-                        });
-                      }}
-                      className="rounded-md p-2 text-gray-400 dark:text-gray-500 hover:text-red-500 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-950 focus:outline-none focus:ring-2 focus:ring-red-500 transition-colors"
-                      aria-label={`Remove option ${opt.name}`}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </button>
-                  )}
-                </div>
-                {/* Description toggle + textarea */}
-                <div className="ml-8 mt-1">
-                  <button
-                    type="button"
-                    onClick={() => toggleDesc(`opt-${opt.id}`)}
-                    className="inline-flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
-                    aria-expanded={expandedDescs.has(`opt-${opt.id}`)}
-                    aria-controls={`opt-desc-${opt.id}`}
-                  >
-                    {expandedDescs.has(`opt-${opt.id}`) ? (
-                      <ChevronUp className="h-3 w-3" />
-                    ) : (
-                      <ChevronDown className="h-3 w-3" />
-                    )}
-                    {opt.description ? "Edit description" : "Add description"}
-                  </button>
-                  {expandedDescs.has(`opt-${opt.id}`) && (
-                    <div className="mt-1" id={`opt-desc-${opt.id}`}>
-                      <textarea
-                        value={opt.description ?? ""}
-                        onChange={(e) =>
-                          updateOption(opt.id, { description: e.target.value.slice(0, 500) })
-                        }
-                        className="w-full rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 resize-none"
-                        placeholder="Add notes about this option..."
-                        rows={2}
-                        maxLength={500}
-                        aria-label={`Description for option ${opt.name}`}
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleOptionDragEnd}
+        >
+          <SortableContext
+            items={decision.options.map((o) => o.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <div className="space-y-2">
+              {decision.options.map((opt, index) => {
+                // Labels: A-Z, then AA, AB, ...
+                const label =
+                  index < 26
+                    ? String.fromCharCode(65 + index)
+                    : String.fromCharCode(65 + Math.floor(index / 26) - 1) +
+                      String.fromCharCode(65 + (index % 26));
+                const optIssues = validation.byId.get(opt.id);
+                const hasIssue = !!optIssues && optIssues.length > 0;
+                return (
+                  <SortableItem key={opt.id} id={opt.id} dragLabel={`Reorder option ${opt.name}`}>
+                    <div className="flex items-center gap-2">
+                      <span className="w-6 text-center text-xs font-medium text-gray-500 dark:text-gray-400">
+                        {label}
+                      </span>
+                      <input
+                        type="text"
+                        value={opt.name}
+                        onChange={(e) => updateOption(opt.id, { name: e.target.value })}
+                        className={`flex-1 rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 ${
+                          hasIssue
+                            ? "border-orange-400 focus:border-orange-500 focus:ring-orange-500"
+                            : "border-gray-300 dark:border-gray-600 focus:border-blue-500"
+                        } dark:bg-gray-700 dark:text-gray-100`}
+                        placeholder={`Option ${label}`}
+                        aria-label={`Option ${index + 1} name`}
+                        maxLength={80}
+                        aria-invalid={hasIssue || undefined}
                       />
-                      <p className="text-right text-[10px] text-gray-500 dark:text-gray-400 mt-0.5">
-                        {(opt.description ?? "").length}/500
-                      </p>
+                      {decision.options.length > 2 && (
+                        <button
+                          onClick={() => {
+                            removeOption(opt.id);
+                            showToast({
+                              text: `Option "${opt.name}" removed`,
+                              action: { label: "Undo", onClick: undo },
+                            });
+                          }}
+                          className="rounded-md p-2 text-gray-400 dark:text-gray-500 hover:text-red-500 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-950 focus:outline-none focus:ring-2 focus:ring-red-500 transition-colors"
+                          aria-label={`Remove option ${opt.name}`}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      )}
                     </div>
-                  )}
-                </div>
-                {hasIssue && (
-                  <p className="ml-8 mt-0.5 text-xs text-orange-600 dark:text-orange-400 flex items-center gap-1">
-                    <AlertTriangle className="h-3 w-3 shrink-0" />
-                    {optIssues![0].message}
-                  </p>
-                )}
-              </div>
-            );
-          })}
-        </div>
+                    {/* Description toggle + textarea */}
+                    <div className="ml-8 mt-1">
+                      <button
+                        type="button"
+                        onClick={() => toggleDesc(`opt-${opt.id}`)}
+                        className="inline-flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                        aria-expanded={expandedDescs.has(`opt-${opt.id}`)}
+                        aria-controls={`opt-desc-${opt.id}`}
+                      >
+                        {expandedDescs.has(`opt-${opt.id}`) ? (
+                          <ChevronUp className="h-3 w-3" />
+                        ) : (
+                          <ChevronDown className="h-3 w-3" />
+                        )}
+                        {opt.description ? "Edit description" : "Add description"}
+                      </button>
+                      {expandedDescs.has(`opt-${opt.id}`) && (
+                        <div className="mt-1" id={`opt-desc-${opt.id}`}>
+                          <textarea
+                            value={opt.description ?? ""}
+                            onChange={(e) =>
+                              updateOption(opt.id, { description: e.target.value.slice(0, 500) })
+                            }
+                            className="w-full rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 resize-none"
+                            placeholder="Add notes about this option..."
+                            rows={2}
+                            maxLength={500}
+                            aria-label={`Description for option ${opt.name}`}
+                          />
+                          <p className="text-right text-[10px] text-gray-500 dark:text-gray-400 mt-0.5">
+                            {(opt.description ?? "").length}/500
+                          </p>
+                        </div>
+                      )}
+                    </div>
+                    {hasIssue && (
+                      <p className="ml-8 mt-0.5 text-xs text-orange-600 dark:text-orange-400 flex items-center gap-1">
+                        <AlertTriangle className="h-3 w-3 shrink-0" />
+                        {optIssues![0].message}
+                      </p>
+                    )}
+                  </SortableItem>
+                );
+              })}
+            </div>
+          </SortableContext>
+        </DndContext>
       </section>
 
       {/* Criteria */}
@@ -446,122 +506,137 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
             Add Criterion
           </button>
         </div>
-        <div className="space-y-2">
-          {validation.byField.has("weights") && (
-            <div className="rounded-md border border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-900/30 px-3 py-2 text-sm text-red-700 dark:text-red-300 flex items-center gap-2">
-              <AlertCircle className="h-4 w-4 shrink-0" />
-              {validation.byField.get("weights")![0].message}
-            </div>
-          )}
-          {decision.criteria.map((crit, critIndex) => {
-            const critIssues = validation.byId.get(crit.id);
-            const critWarning = critIssues?.find((i) => i.severity === "warning");
-            const critInfo = critIssues?.find((i) => i.severity === "info");
-            return (
-              <div key={crit.id}>
-                <div className="flex items-center gap-2 flex-wrap sm:flex-nowrap">
-                  <input
-                    type="text"
-                    value={crit.name}
-                    onChange={(e) => updateCriterion(crit.id, { name: e.target.value })}
-                    className={`flex-1 min-w-[120px] rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 ${
-                      critWarning
-                        ? "border-orange-400 focus:border-orange-500 focus:ring-orange-500"
-                        : "border-gray-300 dark:border-gray-600 focus:border-blue-500"
-                    } dark:bg-gray-700 dark:text-gray-100`}
-                    placeholder="Criterion name"
-                    aria-label={`Criterion name: ${crit.name}`}
-                    maxLength={80}
-                    aria-invalid={!!critWarning || undefined}
-                  />
-                  <select
-                    value={crit.type}
-                    onChange={(e) =>
-                      updateCriterion(crit.id, { type: e.target.value as CriterionType })
-                    }
-                    className="rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-2 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                    aria-label={`Type for ${crit.name}`}
-                  >
-                    <option value="benefit">Benefit ↑</option>
-                    <option value="cost">Cost ↓</option>
-                  </select>
-                  {decision.criteria.length > 1 && (
-                    <button
-                      onClick={() => {
-                        removeCriterion(crit.id);
-                        showToast({
-                          text: `Criterion "${crit.name}" removed`,
-                          action: { label: "Undo", onClick: undo },
-                        });
-                      }}
-                      className="rounded-md p-2 text-gray-400 dark:text-gray-500 hover:text-red-500 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-950 focus:outline-none focus:ring-2 focus:ring-red-500 transition-colors"
-                      aria-label={`Remove criterion ${crit.name}`}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </button>
-                  )}
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleCriteriaDragEnd}
+        >
+          <SortableContext
+            items={decision.criteria.map((c) => c.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <div className="space-y-2">
+              {validation.byField.has("weights") && (
+                <div className="rounded-md border border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-900/30 px-3 py-2 text-sm text-red-700 dark:text-red-300 flex items-center gap-2">
+                  <AlertCircle className="h-4 w-4 shrink-0" />
+                  {validation.byField.get("weights")![0].message}
                 </div>
-                <WeightSlider
-                  id={crit.id}
-                  name={crit.name}
-                  value={crit.weight}
-                  onChange={(v) => handleWeightChange(crit.id, v)}
-                  colorIndex={critIndex}
-                  isHighest={crit.id === highestWeightId}
-                />
-                {/* Criterion description toggle + textarea */}
-                <div className="mt-1">
-                  <button
-                    type="button"
-                    onClick={() => toggleDesc(`crit-${crit.id}`)}
-                    className="inline-flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
-                    aria-expanded={expandedDescs.has(`crit-${crit.id}`)}
-                    aria-controls={`crit-desc-${crit.id}`}
+              )}
+              {decision.criteria.map((crit, critIndex) => {
+                const critIssues = validation.byId.get(crit.id);
+                const critWarning = critIssues?.find((i) => i.severity === "warning");
+                const critInfo = critIssues?.find((i) => i.severity === "info");
+                return (
+                  <SortableItem
+                    key={crit.id}
+                    id={crit.id}
+                    dragLabel={`Reorder criterion ${crit.name}`}
                   >
-                    {expandedDescs.has(`crit-${crit.id}`) ? (
-                      <ChevronUp className="h-3 w-3" />
-                    ) : (
-                      <ChevronDown className="h-3 w-3" />
-                    )}
-                    {crit.description ? "Edit description" : "Add description"}
-                  </button>
-                  {expandedDescs.has(`crit-${crit.id}`) && (
-                    <div className="mt-1" id={`crit-desc-${crit.id}`}>
-                      <textarea
-                        value={crit.description ?? ""}
-                        onChange={(e) =>
-                          updateCriterion(crit.id, {
-                            description: e.target.value.slice(0, 500),
-                          })
-                        }
-                        className="w-full rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 resize-none"
-                        placeholder="Describe what this criterion measures..."
-                        rows={2}
-                        maxLength={500}
-                        aria-label={`Description for criterion ${crit.name}`}
+                    <div className="flex items-center gap-2 flex-wrap sm:flex-nowrap">
+                      <input
+                        type="text"
+                        value={crit.name}
+                        onChange={(e) => updateCriterion(crit.id, { name: e.target.value })}
+                        className={`flex-1 min-w-[120px] rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 ${
+                          critWarning
+                            ? "border-orange-400 focus:border-orange-500 focus:ring-orange-500"
+                            : "border-gray-300 dark:border-gray-600 focus:border-blue-500"
+                        } dark:bg-gray-700 dark:text-gray-100`}
+                        placeholder="Criterion name"
+                        aria-label={`Criterion name: ${crit.name}`}
+                        maxLength={80}
+                        aria-invalid={!!critWarning || undefined}
                       />
-                      <p className="text-right text-[10px] text-gray-500 dark:text-gray-400 mt-0.5">
-                        {(crit.description ?? "").length}/500
-                      </p>
+                      <select
+                        value={crit.type}
+                        onChange={(e) =>
+                          updateCriterion(crit.id, { type: e.target.value as CriterionType })
+                        }
+                        className="rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-2 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                        aria-label={`Type for ${crit.name}`}
+                      >
+                        <option value="benefit">Benefit ↑</option>
+                        <option value="cost">Cost ↓</option>
+                      </select>
+                      {decision.criteria.length > 1 && (
+                        <button
+                          onClick={() => {
+                            removeCriterion(crit.id);
+                            showToast({
+                              text: `Criterion "${crit.name}" removed`,
+                              action: { label: "Undo", onClick: undo },
+                            });
+                          }}
+                          className="rounded-md p-2 text-gray-400 dark:text-gray-500 hover:text-red-500 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-950 focus:outline-none focus:ring-2 focus:ring-red-500 transition-colors"
+                          aria-label={`Remove criterion ${crit.name}`}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      )}
                     </div>
-                  )}
-                </div>
-                {critWarning && (
-                  <p className="mt-0.5 text-xs text-orange-600 dark:text-orange-400 flex items-center gap-1">
-                    <AlertTriangle className="h-3 w-3 shrink-0" />
-                    {critWarning.message}
-                  </p>
-                )}
-                {critInfo && !critWarning && (
-                  <p className="mt-0.5 text-xs text-yellow-600 dark:text-yellow-400 flex items-center gap-1">
-                    <Info className="h-3 w-3 shrink-0" />
-                    {critInfo.message}
-                  </p>
-                )}
-              </div>
-            );
-          })}
-        </div>
+                    <WeightSlider
+                      id={crit.id}
+                      name={crit.name}
+                      value={crit.weight}
+                      onChange={(v) => handleWeightChange(crit.id, v)}
+                      colorIndex={critIndex}
+                      isHighest={crit.id === highestWeightId}
+                    />
+                    {/* Criterion description toggle + textarea */}
+                    <div className="mt-1">
+                      <button
+                        type="button"
+                        onClick={() => toggleDesc(`crit-${crit.id}`)}
+                        className="inline-flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                        aria-expanded={expandedDescs.has(`crit-${crit.id}`)}
+                        aria-controls={`crit-desc-${crit.id}`}
+                      >
+                        {expandedDescs.has(`crit-${crit.id}`) ? (
+                          <ChevronUp className="h-3 w-3" />
+                        ) : (
+                          <ChevronDown className="h-3 w-3" />
+                        )}
+                        {crit.description ? "Edit description" : "Add description"}
+                      </button>
+                      {expandedDescs.has(`crit-${crit.id}`) && (
+                        <div className="mt-1" id={`crit-desc-${crit.id}`}>
+                          <textarea
+                            value={crit.description ?? ""}
+                            onChange={(e) =>
+                              updateCriterion(crit.id, {
+                                description: e.target.value.slice(0, 500),
+                              })
+                            }
+                            className="w-full rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 resize-none"
+                            placeholder="Describe what this criterion measures..."
+                            rows={2}
+                            maxLength={500}
+                            aria-label={`Description for criterion ${crit.name}`}
+                          />
+                          <p className="text-right text-[10px] text-gray-500 dark:text-gray-400 mt-0.5">
+                            {(crit.description ?? "").length}/500
+                          </p>
+                        </div>
+                      )}
+                    </div>
+                    {critWarning && (
+                      <p className="mt-0.5 text-xs text-orange-600 dark:text-orange-400 flex items-center gap-1">
+                        <AlertTriangle className="h-3 w-3 shrink-0" />
+                        {critWarning.message}
+                      </p>
+                    )}
+                    {critInfo && !critWarning && (
+                      <p className="mt-0.5 text-xs text-yellow-600 dark:text-yellow-400 flex items-center gap-1">
+                        <Info className="h-3 w-3 shrink-0" />
+                        {critInfo.message}
+                      </p>
+                    )}
+                  </SortableItem>
+                );
+              })}
+            </div>
+          </SortableContext>
+        </DndContext>
 
         {/* Weight Distribution Bar */}
         <WeightDistributionBar criteria={decision.criteria} />
@@ -627,7 +702,10 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
           >
             <thead>
               <tr>
-                <th scope="col" className="text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider px-3 py-2 border-b border-gray-200 dark:border-gray-700">
+                <th
+                  scope="col"
+                  className="text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider px-3 py-2 border-b border-gray-200 dark:border-gray-700"
+                >
                   Option / Criterion
                 </th>
                 {decision.criteria.map((crit) => (
@@ -665,7 +743,10 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
             <tbody>
               {decision.options.map((opt, rowIdx) => (
                 <tr key={opt.id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
-                  <th scope="row" className="px-3 py-2 text-sm font-medium text-gray-900 dark:text-gray-100 border-b border-gray-100 dark:border-gray-700 text-left">
+                  <th
+                    scope="row"
+                    className="px-3 py-2 text-sm font-medium text-gray-900 dark:text-gray-100 border-b border-gray-100 dark:border-gray-700 text-left"
+                  >
                     {opt.name}
                   </th>
                   {decision.criteria.map((crit, colIdx) => {
@@ -733,9 +814,7 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
                             canRestore={canRestoreEnriched(decision, opt.id, crit.id)}
                             onRestore={() => restoreEnrichedValue(opt.id, crit.id)}
                           />
-                          <ConfidenceIndicator
-                            metadata={getMetadata(decision, opt.id, crit.id)}
-                          />
+                          <ConfidenceIndicator metadata={getMetadata(decision, opt.id, crit.id)} />
                         </div>
                         {isFocused && (
                           <ScoringPrompt

--- a/src/components/DecisionProvider.tsx
+++ b/src/components/DecisionProvider.tsx
@@ -37,7 +37,15 @@ import {
   type ReactNode,
   type Dispatch,
 } from "react";
-import type { Confidence, ConfidenceStrategy, Criterion, Decision, DecisionResults, Option, SensitivityAnalysis } from "@/lib/types";
+import type {
+  Confidence,
+  ConfidenceStrategy,
+  Criterion,
+  Decision,
+  DecisionResults,
+  Option,
+  SensitivityAnalysis,
+} from "@/lib/types";
 import type { TopsisResults } from "@/lib/topsis";
 import type { RegretResults } from "@/lib/regret";
 import {
@@ -106,9 +114,11 @@ export interface ActionsValue {
   addOption: () => void;
   updateOption: (optionId: string, updates: Partial<Option>) => void;
   removeOption: (optionId: string) => void;
+  reorderOptions: (fromIndex: number, toIndex: number) => void;
   addCriterion: () => void;
   updateCriterion: (criterionId: string, updates: Partial<Criterion>) => void;
   removeCriterion: (criterionId: string) => void;
+  reorderCriteria: (fromIndex: number, toIndex: number) => void;
   updateScore: (optionId: string, criterionId: string, value: number | null) => void;
   updateConfidence: (optionId: string, criterionId: string, confidence: Confidence) => void;
   updateReasoning: (optionId: string, criterionId: string, text: string) => void;
@@ -117,7 +127,7 @@ export interface ActionsValue {
     criterionId: string,
     value: number,
     source: string,
-    tier: EnrichmentTier,
+    tier: EnrichmentTier
   ) => void;
   restoreEnrichedValue: (optionId: string, criterionId: string) => void;
   undo: () => void;
@@ -145,9 +155,11 @@ export interface DecisionContextValue extends DecisionStateValue {
   addOption: () => void;
   updateOption: (optionId: string, updates: Partial<Option>) => void;
   removeOption: (optionId: string) => void;
+  reorderOptions: (fromIndex: number, toIndex: number) => void;
   addCriterion: () => void;
   updateCriterion: (criterionId: string, updates: Partial<Criterion>) => void;
   removeCriterion: (criterionId: string) => void;
+  reorderCriteria: (fromIndex: number, toIndex: number) => void;
   updateScore: (optionId: string, criterionId: string, value: number | null) => void;
   updateConfidence: (optionId: string, criterionId: string, confidence: Confidence) => void;
   updateReasoning: (optionId: string, criterionId: string, text: string) => void;
@@ -156,7 +168,7 @@ export interface DecisionContextValue extends DecisionStateValue {
     criterionId: string,
     value: number,
     source: string,
-    tier: EnrichmentTier,
+    tier: EnrichmentTier
   ) => void;
   restoreEnrichedValue: (optionId: string, criterionId: string) => void;
   undo: () => void;
@@ -293,6 +305,12 @@ export function DecisionProvider({ children }: Readonly<{ children: ReactNode }>
     [dispatch]
   );
 
+  const reorderOptions = useCallback(
+    (fromIndex: number, toIndex: number) =>
+      dispatch({ type: "REORDER_OPTIONS", fromIndex, toIndex }),
+    [dispatch]
+  );
+
   const addCriterion = useCallback(() => {
     dispatch({ type: "ADD_CRITERION" });
   }, [dispatch]);
@@ -305,6 +323,12 @@ export function DecisionProvider({ children }: Readonly<{ children: ReactNode }>
 
   const removeCriterion = useCallback(
     (criterionId: string) => dispatch({ type: "REMOVE_CRITERION", criterionId }),
+    [dispatch]
+  );
+
+  const reorderCriteria = useCallback(
+    (fromIndex: number, toIndex: number) =>
+      dispatch({ type: "REORDER_CRITERIA", fromIndex, toIndex }),
     [dispatch]
   );
 
@@ -423,14 +447,7 @@ export function DecisionProvider({ children }: Readonly<{ children: ReactNode }>
       canUndo: state.canUndo,
       canRedo: state.canRedo,
     }),
-    [
-      state.decision,
-      state.decisions,
-      state.isDirty,
-      state.isLoading,
-      state.canUndo,
-      state.canRedo,
-    ]
+    [state.decision, state.decisions, state.isDirty, state.isLoading, state.canUndo, state.canRedo]
   );
 
   // Focused context: derived results (re-renders only when results change)
@@ -454,9 +471,11 @@ export function DecisionProvider({ children }: Readonly<{ children: ReactNode }>
       addOption,
       updateOption,
       removeOption,
+      reorderOptions,
       addCriterion,
       updateCriterion,
       removeCriterion,
+      reorderCriteria,
       updateScore,
       updateConfidence,
       updateReasoning,
@@ -478,9 +497,11 @@ export function DecisionProvider({ children }: Readonly<{ children: ReactNode }>
       addOption,
       updateOption,
       removeOption,
+      reorderOptions,
       addCriterion,
       updateCriterion,
       removeCriterion,
+      reorderCriteria,
       updateScore,
       updateConfidence,
       updateReasoning,

--- a/src/components/SortableItem.tsx
+++ b/src/components/SortableItem.tsx
@@ -1,0 +1,57 @@
+/**
+ * SortableItem — reusable drag-and-drop wrapper with accessible grip handle.
+ *
+ * Uses @dnd-kit/sortable for smooth, keyboard-accessible, touch-friendly
+ * drag reordering with visual lift feedback.
+ *
+ * @see https://github.com/ericsocrat/decision-os/issues/186
+ */
+
+"use client";
+
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical } from "lucide-react";
+import type { ReactNode } from "react";
+
+interface SortableItemProps {
+  /** Unique ID for the sortable item (must match SortableContext items) */
+  id: string;
+  /** The content to render inside the sortable wrapper */
+  children: ReactNode;
+  /** Accessible label for the drag handle */
+  dragLabel?: string;
+}
+
+export function SortableItem({ id, children, dragLabel = "Drag to reorder" }: SortableItemProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`relative ${isDragging ? "z-10 opacity-60 shadow-lg ring-2 ring-blue-400 rounded-md" : ""}`}
+    >
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          className="cursor-grab touch-none shrink-0 rounded p-1 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 active:cursor-grabbing transition-colors"
+          {...attributes}
+          {...listeners}
+          aria-label={dragLabel}
+          aria-roledescription="sortable"
+        >
+          <GripVertical className="h-4 w-4" />
+        </button>
+        <div className="flex-1 min-w-0">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/decision-reducer.ts
+++ b/src/lib/decision-reducer.ts
@@ -13,7 +13,16 @@
  * @see https://github.com/ericsocrat/decision-os/issues/77
  */
 
-import type { Confidence, ConfidenceStrategy, Criterion, Decision, Option, ScoreMatrix, ScoreMetadataMatrix, ScoreValue } from "./types";
+import type {
+  Confidence,
+  ConfidenceStrategy,
+  Criterion,
+  Decision,
+  Option,
+  ScoreMatrix,
+  ScoreMetadataMatrix,
+  ScoreValue,
+} from "./types";
 import { generateId } from "./utils";
 import { resolveScoreValue } from "./scoring";
 import {
@@ -79,6 +88,7 @@ export type DecisionAction =
   | { type: "ADD_OPTION" }
   | { type: "UPDATE_OPTION"; optionId: string; updates: Partial<Option>; timestamp: number }
   | { type: "REMOVE_OPTION"; optionId: string }
+  | { type: "REORDER_OPTIONS"; fromIndex: number; toIndex: number }
 
   // Criteria
   | { type: "ADD_CRITERION" }
@@ -89,6 +99,7 @@ export type DecisionAction =
       timestamp: number;
     }
   | { type: "REMOVE_CRITERION"; criterionId: string }
+  | { type: "REORDER_CRITERIA"; fromIndex: number; toIndex: number }
 
   // Scores
   | { type: "UPDATE_SCORE"; optionId: string; criterionId: string; value: number | null }
@@ -215,6 +226,22 @@ function applyDecisionMutation(decision: Decision, action: DecisionAction): Deci
       });
     }
 
+    case "REORDER_OPTIONS": {
+      if (
+        action.fromIndex === action.toIndex ||
+        action.fromIndex < 0 ||
+        action.toIndex < 0 ||
+        action.fromIndex >= decision.options.length ||
+        action.toIndex >= decision.options.length
+      ) {
+        return null;
+      }
+      const newOptions = [...decision.options];
+      const [moved] = newOptions.splice(action.fromIndex, 1);
+      newOptions.splice(action.toIndex, 0, moved);
+      return stampNow({ ...decision, options: newOptions });
+    }
+
     case "ADD_CRITERION": {
       const newCrit: Criterion = {
         id: generateId(),
@@ -255,6 +282,22 @@ function applyDecisionMutation(decision: Decision, action: DecisionAction): Deci
       });
     }
 
+    case "REORDER_CRITERIA": {
+      if (
+        action.fromIndex === action.toIndex ||
+        action.fromIndex < 0 ||
+        action.toIndex < 0 ||
+        action.fromIndex >= decision.criteria.length ||
+        action.toIndex >= decision.criteria.length
+      ) {
+        return null;
+      }
+      const newCriteria = [...decision.criteria];
+      const [moved] = newCriteria.splice(action.fromIndex, 1);
+      newCriteria.splice(action.toIndex, 0, moved);
+      return stampNow({ ...decision, criteria: newCriteria });
+    }
+
     case "UPDATE_SCORE": {
       const newScores = { ...decision.scores };
       if (!newScores[action.optionId]) newScores[action.optionId] = {};
@@ -285,7 +328,7 @@ function applyDecisionMutation(decision: Decision, action: DecisionAction): Deci
           newMetadata,
           action.optionId,
           action.criterionId,
-          createOverrideMetadata(existingMeta),
+          createOverrideMetadata(existingMeta)
         );
       }
       return stampNow({ ...decision, scores: newScores, scoreMetadata: newMetadata });
@@ -302,15 +345,13 @@ function applyDecisionMutation(decision: Decision, action: DecisionAction): Deci
           : undefined;
       newScores[action.optionId] = {
         ...newScores[action.optionId],
-        [action.criterionId]: existingConf
-          ? { value: clamped, confidence: existingConf }
-          : clamped,
+        [action.criterionId]: existingConf ? { value: clamped, confidence: existingConf } : clamped,
       };
       const newMetadata = setMetadataCell(
         decision.scoreMetadata,
         action.optionId,
         action.criterionId,
-        createEnrichedMetadata(clamped, action.source, action.tier),
+        createEnrichedMetadata(clamped, action.source, action.tier)
       );
       return stampNow({ ...decision, scores: newScores, scoreMetadata: newMetadata });
     }
@@ -330,16 +371,14 @@ function applyDecisionMutation(decision: Decision, action: DecisionAction): Deci
           : undefined;
       newScores[action.optionId] = {
         ...newScores[action.optionId],
-        [action.criterionId]: existingConf
-          ? { value, confidence: existingConf }
-          : value,
+        [action.criterionId]: existingConf ? { value, confidence: existingConf } : value,
       };
       // Restore to enriched provenance
       const newMetadata = setMetadataCell(
         decision.scoreMetadata,
         action.optionId,
         action.criterionId,
-        createEnrichedMetadata(value, meta.enrichedSource ?? "", meta.enrichedTier ?? 2),
+        createEnrichedMetadata(value, meta.enrichedSource ?? "", meta.enrichedTier ?? 2)
       );
       return stampNow({ ...decision, scores: newScores, scoreMetadata: newMetadata });
     }
@@ -418,8 +457,10 @@ function classifyAction(
     case "SET_DECISION":
     case "ADD_OPTION":
     case "REMOVE_OPTION":
+    case "REORDER_OPTIONS":
     case "ADD_CRITERION":
     case "REMOVE_CRITERION":
+    case "REORDER_CRITERIA":
     case "UPDATE_SCORE":
     case "UPDATE_CONFIDENCE":
     case "SET_CONFIDENCE_STRATEGY":


### PR DESCRIPTION
## Summary

Adds drag-and-drop reordering for both options and criteria lists in the Decision Builder, using `@dnd-kit` for accessible, keyboard-navigable sorting.

## Changes

### New Dependencies
- `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities`

### Reducer (`decision-reducer.ts`)
- Added `REORDER_OPTIONS` and `REORDER_CRITERIA` action types
- Both use splice-based reorder with boundary checking (same-index and out-of-bounds return `null` → no-op)
- Classified as "structural" for undo coalescing

### Provider (`DecisionProvider.tsx`)
- Added `reorderOptions` / `reorderCriteria` to `ActionsValue` and `DecisionContextValue` interfaces
- Added `useCallback` wrappers dispatching the reorder actions
- Wired into `actionsValue` memo

### New Component (`SortableItem.tsx`)
- Reusable sortable wrapper using `useSortable` from `@dnd-kit`
- GripVertical drag handle with `cursor-grab` / `active:cursor-grabbing`
- Visual feedback: `opacity-60`, `shadow-lg`, `ring-2 ring-blue-400` when dragging
- Full accessibility: `aria-roledescription="sortable"`, configurable `aria-label`

### Builder UI (`DecisionBuilder.tsx`)
- Options list wrapped with `DndContext` / `SortableContext` / `SortableItem`
- Criteria list wrapped with separate `DndContext` / `SortableContext` / `SortableItem`
- `PointerSensor` (5px activation distance) + `KeyboardSensor` (sortable coordinates)
- Score matrix data preserved after reorder (keyed by ID, not position)

### Tests (`decision-reducer.test.ts`)
- 10 new tests:
  - `REORDER_OPTIONS` moves option to new position
  - Same-index returns unchanged state
  - Out-of-bounds returns unchanged state
  - Score matrix data preserved after reorder
  - `REORDER_CRITERIA` moves criterion to new position
  - Same-index is no-op
  - Out-of-bounds is no-op
  - Score matrix data preserved
  - Undo restores original order (options)
  - Undo restores original order (criteria)

## Verification
- ✅ Lint: 0 errors, 0 source warnings
- ✅ TypeScript: 0 errors
- ✅ Tests: 80 files, 1375 passed (was 1365)
- ✅ Build: success

Closes #186