### PR TITLE
feat(a11y): add accessible criterion description tooltips

### DIFF
--- a/src/__tests__/components/CriterionTooltip.test.tsx
+++ b/src/__tests__/components/CriterionTooltip.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for CriterionTooltip component.
+ *
+ * Verifies accessible, keyboard-navigable, touch-friendly tooltip behavior.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CriterionTooltip } from "@/components/CriterionTooltip";
+
+function renderTooltip(props?: Partial<{ description: string; criterionName: string }>) {
+  const user = userEvent.setup();
+  const result = render(
+    <CriterionTooltip
+      description={props?.description ?? "Measures overall quality"}
+      criterionName={props?.criterionName ?? "Quality"}
+    />
+  );
+  return { user, ...result };
+}
+
+describe("CriterionTooltip", () => {
+  it("renders a button with accessible label", () => {
+    renderTooltip();
+    const btn = screen.getByRole("button", { name: "Description for Quality" });
+    expect(btn).toBeInTheDocument();
+  });
+
+  it("tooltip is hidden by default", () => {
+    renderTooltip();
+    const tooltip = screen.getByRole("tooltip", { hidden: true });
+    expect(tooltip).toHaveClass("invisible");
+  });
+
+  it("shows tooltip on focus (keyboard / touch tap)", async () => {
+    const { user } = renderTooltip();
+    await user.tab();
+    const tooltip = screen.getByRole("tooltip");
+    expect(tooltip).not.toHaveClass("invisible");
+  });
+
+  it("hides tooltip on blur", async () => {
+    const { user } = renderTooltip();
+    await user.tab(); // focus
+    expect(screen.getByRole("tooltip")).not.toHaveClass("invisible");
+    await user.tab(); // blur away
+    // Wait for hide timeout
+    await new Promise((r) => setTimeout(r, 200));
+    expect(screen.getByRole("tooltip", { hidden: true })).toHaveClass("invisible");
+  });
+
+  it("hides tooltip on Escape key", async () => {
+    const { user } = renderTooltip();
+    await user.tab(); // focus to show
+    expect(screen.getByRole("tooltip")).not.toHaveClass("invisible");
+    await user.keyboard("{Escape}");
+    expect(screen.getByRole("tooltip", { hidden: true })).toHaveClass("invisible");
+  });
+
+  it("has aria-expanded attribute that tracks open state", async () => {
+    const { user } = renderTooltip();
+    const btn = screen.getByRole("button", { name: "Description for Quality" });
+    expect(btn).toHaveAttribute("aria-expanded", "false");
+    await user.tab();
+    expect(btn).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("has aria-describedby linking to tooltip", () => {
+    renderTooltip();
+    const btn = screen.getByRole("button", { name: "Description for Quality" });
+    const tooltip = screen.getByRole("tooltip", { hidden: true });
+    expect(btn.getAttribute("aria-describedby")).toBe(tooltip.id);
+  });
+
+  it("displays the description text", () => {
+    renderTooltip({ description: "Custom description text" });
+    expect(screen.getByRole("tooltip", { hidden: true })).toHaveTextContent(
+      "Custom description text"
+    );
+  });
+});

--- a/src/components/CriterionTooltip.tsx
+++ b/src/components/CriterionTooltip.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useCallback, useId, useRef, useState } from "react";
+import { Info } from "lucide-react";
+
+interface CriterionTooltipProps {
+  /** The description text to show in the tooltip. */
+  readonly description: string;
+  /** The criterion name (used for aria-label). */
+  readonly criterionName: string;
+}
+
+/**
+ * Accessible, keyboard-navigable tooltip for criterion descriptions.
+ *
+ * - Shows on hover, focus, AND touch (tap focuses button → shows tooltip).
+ * - Uses `aria-describedby` + `role="tooltip"` for screen readers.
+ * - Smooth fade-in/out via CSS transitions.
+ * - Auto-dismisses on Escape key or blur.
+ */
+export function CriterionTooltip({ description, criterionName }: CriterionTooltipProps) {
+  const [open, setOpen] = useState(false);
+  const tooltipId = useId();
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const show = useCallback(() => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    setOpen(true);
+  }, []);
+
+  const hide = useCallback(() => {
+    // Small delay to allow moving from trigger to tooltip
+    timeoutRef.current = setTimeout(() => setOpen(false), 150);
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape" && open) {
+        e.preventDefault();
+        setOpen(false);
+      }
+    },
+    [open]
+  );
+
+  return (
+    <span className="relative inline-flex items-center" onMouseEnter={show} onMouseLeave={hide}>
+      <button
+        type="button"
+        className="inline-flex items-center justify-center rounded p-0.5 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors"
+        aria-label={`Description for ${criterionName}`}
+        aria-describedby={tooltipId}
+        aria-expanded={open}
+        onFocus={show}
+        onBlur={hide}
+        onKeyDown={handleKeyDown}
+      >
+        <Info className="h-3.5 w-3.5" />
+      </button>
+      <span
+        id={tooltipId}
+        role="tooltip"
+        className={`absolute left-1/2 top-full z-20 mt-1 -translate-x-1/2 w-48 rounded-md bg-gray-900 dark:bg-gray-700 px-3 py-2 text-[11px] font-normal normal-case tracking-normal text-white shadow-lg text-left transition-opacity duration-150 pointer-events-none ${
+          open ? "opacity-100" : "opacity-0 invisible"
+        }`}
+      >
+        {description}
+      </span>
+    </span>
+  );
+}

--- a/src/components/DecisionBuilder.tsx
+++ b/src/components/DecisionBuilder.tsx
@@ -54,6 +54,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { SortableItem } from "./SortableItem";
+import { CriterionTooltip } from "./CriterionTooltip";
 
 interface DecisionBuilderProps {
   validation: ValidationResult;
@@ -547,6 +548,12 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
                         maxLength={80}
                         aria-invalid={!!critWarning || undefined}
                       />
+                      {crit.description && (
+                        <CriterionTooltip
+                          description={crit.description}
+                          criterionName={crit.name}
+                        />
+                      )}
                       <select
                         value={crit.type}
                         onChange={(e) =>
@@ -714,21 +721,13 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
                     scope="col"
                     className="text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider px-3 py-2 border-b border-gray-200 dark:border-gray-700"
                   >
-                    <div className="group relative inline-block">
-                      <span
-                        tabIndex={crit.description ? 0 : undefined}
-                        aria-describedby={crit.description ? `crit-tooltip-${crit.id}` : undefined}
-                      >
-                        {crit.name}
-                      </span>
+                    <div className="inline-flex items-center gap-1">
+                      <span>{crit.name}</span>
                       {crit.description && (
-                        <div
-                          id={`crit-tooltip-${crit.id}`}
-                          role="tooltip"
-                          className="absolute left-1/2 top-full z-20 mt-1 -translate-x-1/2 hidden group-hover:block group-focus-within:block w-48 rounded-md bg-gray-900 dark:bg-gray-700 px-3 py-2 text-[11px] font-normal normal-case tracking-normal text-white shadow-lg text-left"
-                        >
-                          {crit.description}
-                        </div>
+                        <CriterionTooltip
+                          description={crit.description}
+                          criterionName={crit.name}
+                        />
                       )}
                     </div>
                     <span


### PR DESCRIPTION
## Summary

Adds fully accessible, keyboard-navigable criterion description tooltips across all surfaces — replacing the previous CSS-only hover implementation.

## Changes

### New Component: `CriterionTooltip.tsx`
- Shows on hover (mouseEnter/mouseLeave) AND keyboard focus (focus/blur)
- Touch-friendly: tap to focus → show, tap elsewhere → blur → dismiss
- Escape key dismisses tooltip
- `aria-describedby` links button to `role="tooltip"` element
- `aria-expanded` tracks open state
- Smooth opacity transition (`duration-150`)
- Accessible `<button>` trigger with `aria-label`

### Score Matrix Headers (`DecisionBuilder.tsx`)
- **Before**: CSS-only `group-hover:block / group-focus-within:block` with `tabIndex` on `<span>` (lint warning)
- **After**: Uses `CriterionTooltip` component with proper `<button>` trigger
- Removes `tabIndex` on non-interactive element (fixes accessibility lint warning)

### Criteria Editing Section (`DecisionBuilder.tsx`)
- Added `CriterionTooltip` next to criterion name input when a description exists
- Users can now see criterion descriptions without expanding the textarea

### Tests: `CriterionTooltip.test.tsx` (8 tests)
- Renders accessible button with label
- Tooltip hidden by default
- Shows on focus (keyboard/touch)
- Hides on blur (with timeout)
- Hides on Escape key
- `aria-expanded` tracks state
- `aria-describedby` links to tooltip
- Displays description text

## Verification
- ✅ Lint: 0 errors, 0 source warnings
- ✅ TypeScript: 0 errors
- ✅ Tests: 81 files, 1383 passed (was 1375)
- ✅ Build: success

Closes #188