### PR TITLE
perf: rendering + computation optimizations

### DIFF
--- a/src/__tests__/components/DecisionBuilder.test.tsx
+++ b/src/__tests__/components/DecisionBuilder.test.tsx
@@ -7,6 +7,7 @@ import { screen } from "@testing-library/react";
 import { renderWithProviders } from "../test-utils";
 import { DecisionBuilder } from "@/components/DecisionBuilder";
 import type { ValidationResult } from "@/hooks/useValidation";
+import type { CompletenessResult } from "@/lib/completeness";
 
 // Mock showToast since it depends on global state
 vi.mock("@/components/Toast", () => ({
@@ -24,61 +25,69 @@ const emptyValidation: ValidationResult = {
   byField: new Map(),
 };
 
+const defaultCompleteness: CompletenessResult = {
+  filled: 0,
+  total: 0,
+  ratio: 1,
+  percent: 100,
+  tier: "blue",
+};
+
 beforeEach(() => {
   localStorage.clear();
 });
 
 describe("DecisionBuilder", () => {
   it("renders Decision Details heading", () => {
-    renderWithProviders(<DecisionBuilder validation={emptyValidation} />);
+    renderWithProviders(<DecisionBuilder validation={emptyValidation} completeness={defaultCompleteness} />);
     expect(screen.getByText("Decision Details")).toBeInTheDocument();
   });
 
   it("renders title input with initial demo value", () => {
-    renderWithProviders(<DecisionBuilder validation={emptyValidation} />);
+    renderWithProviders(<DecisionBuilder validation={emptyValidation} completeness={defaultCompleteness} />);
     const titleInput = screen.getByLabelText(/title/i);
     expect(titleInput).toBeInTheDocument();
     expect((titleInput as HTMLInputElement).value.length).toBeGreaterThan(0);
   });
 
   it("renders description textarea", () => {
-    renderWithProviders(<DecisionBuilder validation={emptyValidation} />);
+    renderWithProviders(<DecisionBuilder validation={emptyValidation} completeness={defaultCompleteness} />);
     const desc = screen.getByPlaceholderText(/brief context/i);
     expect(desc).toBeInTheDocument();
   });
 
   it("renders Options section with Add Option button", () => {
-    renderWithProviders(<DecisionBuilder validation={emptyValidation} />);
+    renderWithProviders(<DecisionBuilder validation={emptyValidation} completeness={defaultCompleteness} />);
     expect(screen.getByText("Options")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /add option/i })).toBeInTheDocument();
   }, 15_000);
 
   it("renders Criteria section with Add Criterion button", () => {
-    renderWithProviders(<DecisionBuilder validation={emptyValidation} />);
+    renderWithProviders(<DecisionBuilder validation={emptyValidation} completeness={defaultCompleteness} />);
     expect(screen.getByText("Criteria")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /add criterion/i })).toBeInTheDocument();
   });
 
   it("renders Scores Matrix section", () => {
-    renderWithProviders(<DecisionBuilder validation={emptyValidation} />);
+    renderWithProviders(<DecisionBuilder validation={emptyValidation} completeness={defaultCompleteness} />);
     expect(screen.getByText(/scores matrix/i)).toBeInTheDocument();
     expect(screen.getByRole("grid", { name: /scores matrix/i })).toBeInTheDocument();
   });
 
   it("renders Undo and Redo buttons", () => {
-    renderWithProviders(<DecisionBuilder validation={emptyValidation} />);
+    renderWithProviders(<DecisionBuilder validation={emptyValidation} completeness={defaultCompleteness} />);
     expect(screen.getByRole("button", { name: /undo/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /redo/i })).toBeInTheDocument();
   });
 
   it("Undo button is disabled when no history", () => {
-    renderWithProviders(<DecisionBuilder validation={emptyValidation} />);
+    renderWithProviders(<DecisionBuilder validation={emptyValidation} completeness={defaultCompleteness} />);
     const undoBtn = screen.getByRole("button", { name: /undo/i });
     expect(undoBtn).toBeDisabled();
   });
 
   it("adds an option when Add Option is clicked", async () => {
-    const { user } = renderWithProviders(<DecisionBuilder validation={emptyValidation} />);
+    const { user } = renderWithProviders(<DecisionBuilder validation={emptyValidation} completeness={defaultCompleteness} />);
     const inputs = screen.getAllByRole("textbox");
     const initialCount = inputs.length;
     await user.click(screen.getByRole("button", { name: /add option/i }));
@@ -87,7 +96,7 @@ describe("DecisionBuilder", () => {
   }, 15_000);
 
   it("renders score inputs in the grid", () => {
-    renderWithProviders(<DecisionBuilder validation={emptyValidation} />);
+    renderWithProviders(<DecisionBuilder validation={emptyValidation} completeness={defaultCompleteness} />);
     const grid = screen.getByRole("grid");
     const scoreInputs = grid.querySelectorAll('input[type="number"]');
     // Demo data has 3 options × 4 criteria = 12 score inputs
@@ -104,19 +113,19 @@ describe("DecisionBuilder", () => {
         ["title", [{ field: "title", severity: "error", message: "Decision title is required" }]],
       ]),
     };
-    renderWithProviders(<DecisionBuilder validation={validation} />);
+    renderWithProviders(<DecisionBuilder validation={validation} completeness={defaultCompleteness} />);
     expect(screen.getByText("Decision title is required")).toBeInTheDocument();
   });
 
   it("renders description toggle buttons for options", () => {
-    renderWithProviders(<DecisionBuilder validation={emptyValidation} />);
+    renderWithProviders(<DecisionBuilder validation={emptyValidation} completeness={defaultCompleteness} />);
     // Demo data has 3 options with descriptions → should show "Edit description"
     const editBtns = screen.getAllByText("Edit description");
     expect(editBtns.length).toBeGreaterThanOrEqual(1);
   });
 
   it("renders description toggle buttons for criteria", () => {
-    renderWithProviders(<DecisionBuilder validation={emptyValidation} />);
+    renderWithProviders(<DecisionBuilder validation={emptyValidation} completeness={defaultCompleteness} />);
     // Demo data has 4 criteria with descriptions → "Edit description" buttons
     const editBtns = screen.getAllByText("Edit description");
     // At least some should be from criteria
@@ -124,7 +133,7 @@ describe("DecisionBuilder", () => {
   });
 
   it("expands description textarea when toggle clicked", async () => {
-    renderWithProviders(<DecisionBuilder validation={emptyValidation} />);
+    renderWithProviders(<DecisionBuilder validation={emptyValidation} completeness={defaultCompleteness} />);
     // Demo data auto-expands descriptions that are non-empty
     // Find a textarea (should be auto-expanded for demo descriptions)
     const textareas = screen.getAllByRole("textbox");
@@ -133,14 +142,14 @@ describe("DecisionBuilder", () => {
   });
 
   it("shows character counter on expanded descriptions", () => {
-    renderWithProviders(<DecisionBuilder validation={emptyValidation} />);
+    renderWithProviders(<DecisionBuilder validation={emptyValidation} completeness={defaultCompleteness} />);
     // Demo data has descriptions that auto-expand, so counters should be visible
     const counters = screen.getAllByText(/\/500$/);
     expect(counters.length).toBeGreaterThanOrEqual(1);
   });
 
   it("shows criterion description tooltip in score matrix header", () => {
-    renderWithProviders(<DecisionBuilder validation={emptyValidation} />);
+    renderWithProviders(<DecisionBuilder validation={emptyValidation} completeness={defaultCompleteness} />);
     // Demo criteria have descriptions, so tooltips should exist
     const tooltips = screen.getAllByRole("tooltip");
     expect(tooltips.length).toBeGreaterThanOrEqual(1);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,6 +35,7 @@ import {
   Activity,
   GitCompareArrows,
   Dices,
+  Keyboard,
   Upload,
   HelpCircle,
 } from "lucide-react";
@@ -395,62 +396,54 @@ function AppContent() {
           aria-labelledby="tab-builder"
           className={activeTab === "builder" ? "" : "hidden"}
         >
-          {isLoading ? <DecisionSkeleton /> : <DecisionBuilder validation={validation} />}
+          {isLoading ? <DecisionSkeleton /> : <DecisionBuilder validation={validation} completeness={completeness} />}
         </div>
-        <div
-          id="panel-results"
-          role="tabpanel"
-          aria-labelledby="tab-results"
-          className={activeTab === "results" ? "" : "hidden"}
-        >
-          <ErrorBoundary fallback={(reset) => <TabErrorFallback tab="Results" onReset={reset} />}>
-            <ResultsView
-              validation={validation}
-              completeness={completeness}
-              onSwitchToBuilder={() => setActiveTab("builder")}
-            />
-          </ErrorBoundary>
-        </div>
-        <div
-          id="panel-sensitivity"
-          role="tabpanel"
-          aria-labelledby="tab-sensitivity"
-          className={activeTab === "sensitivity" ? "" : "hidden"}
-        >
-          <ErrorBoundary
-            fallback={(reset) => <TabErrorFallback tab="Sensitivity" onReset={reset} />}
-          >
-            <Suspense fallback={<TabPanelSkeleton label="Sensitivity" />}>
-              <SensitivityView />
-            </Suspense>
-          </ErrorBoundary>
-        </div>
-        <div
-          id="panel-compare"
-          role="tabpanel"
-          aria-labelledby="tab-compare"
-          className={activeTab === "compare" ? "" : "hidden"}
-        >
-          <ErrorBoundary fallback={(reset) => <TabErrorFallback tab="Compare" onReset={reset} />}>
-            <Suspense fallback={<TabPanelSkeleton label="Compare" />}>
-              <CompareView />
-            </Suspense>
-          </ErrorBoundary>
-        </div>
-        <div
-          id="panel-montecarlo"
-          role="tabpanel"
-          aria-labelledby="tab-montecarlo"
-          className={activeTab === "montecarlo" ? "" : "hidden"}
-        >
-          <ErrorBoundary
-            fallback={(reset) => <TabErrorFallback tab="Monte Carlo" onReset={reset} />}
-          >
-            <Suspense fallback={<TabPanelSkeleton label="Monte Carlo" />}>
-              <MonteCarloView />
-            </Suspense>
-          </ErrorBoundary>
-        </div>
+        {activeTab === "results" && (
+          <div id="panel-results" role="tabpanel" aria-labelledby="tab-results">
+            <ErrorBoundary
+              fallback={(reset) => <TabErrorFallback tab="Results" onReset={reset} />}
+            >
+              <ResultsView
+                validation={validation}
+                completeness={completeness}
+                onSwitchToBuilder={() => setActiveTab("builder")}
+              />
+            </ErrorBoundary>
+          </div>
+        )}
+        {activeTab === "sensitivity" && (
+          <div id="panel-sensitivity" role="tabpanel" aria-labelledby="tab-sensitivity">
+            <ErrorBoundary
+              fallback={(reset) => <TabErrorFallback tab="Sensitivity" onReset={reset} />}
+            >
+              <Suspense fallback={<TabPanelSkeleton label="Sensitivity" />}>
+                <SensitivityView />
+              </Suspense>
+            </ErrorBoundary>
+          </div>
+        )}
+        {activeTab === "compare" && (
+          <div id="panel-compare" role="tabpanel" aria-labelledby="tab-compare">
+            <ErrorBoundary
+              fallback={(reset) => <TabErrorFallback tab="Compare" onReset={reset} />}
+            >
+              <Suspense fallback={<TabPanelSkeleton label="Compare" />}>
+                <CompareView />
+              </Suspense>
+            </ErrorBoundary>
+          </div>
+        )}
+        {activeTab === "montecarlo" && (
+          <div id="panel-montecarlo" role="tabpanel" aria-labelledby="tab-montecarlo">
+            <ErrorBoundary
+              fallback={(reset) => <TabErrorFallback tab="Monte Carlo" onReset={reset} />}
+            >
+              <Suspense fallback={<TabPanelSkeleton label="Monte Carlo" />}>
+                <MonteCarloView />
+              </Suspense>
+            </ErrorBoundary>
+          </div>
+        )}
       </main>
 
       {/* Footer */}

--- a/src/components/DecisionBuilder.tsx
+++ b/src/components/DecisionBuilder.tsx
@@ -22,8 +22,8 @@ import { showToast } from "./Toast";
 import { formatRelativeTime } from "@/lib/utils";
 import type { CriterionType } from "@/lib/types";
 import type { ValidationResult } from "@/hooks/useValidation";
-import { useCallback, useMemo, useRef, useState } from "react";
-import { computeCompleteness } from "@/lib/completeness";
+import { memo, useCallback, useMemo, useRef, useState } from "react";
+import { type CompletenessResult } from "@/lib/completeness";
 import { readScore, resolveConfidence } from "@/lib/scoring";
 import { ConfidenceDot } from "./ConfidenceDot";
 import { CompletionRing } from "./CompletionRing";
@@ -58,9 +58,10 @@ import { CriterionTooltip } from "./CriterionTooltip";
 
 interface DecisionBuilderProps {
   validation: ValidationResult;
+  completeness: CompletenessResult;
 }
 
-export function DecisionBuilder({ validation }: DecisionBuilderProps) {
+export const DecisionBuilder = memo(function DecisionBuilder({ validation, completeness }: DecisionBuilderProps) {
   const { decision, canUndo, canRedo } = useDecisionData();
   const {
     updateTitle,
@@ -82,7 +83,6 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
   } = useActions();
 
   const gridRef = useRef<HTMLTableElement>(null);
-  const completeness = useMemo(() => computeCompleteness(decision), [decision]);
   const [autoNormalize, setAutoNormalize] = useState(false);
   const biasDetection = useBiasDetection(decision);
 
@@ -845,4 +845,4 @@ export function DecisionBuilder({ validation }: DecisionBuilderProps) {
       />
     </div>
   );
-}
+});

--- a/src/components/DecisionProvider.tsx
+++ b/src/components/DecisionProvider.tsx
@@ -272,8 +272,8 @@ export function DecisionProvider({ children }: Readonly<{ children: ReactNode }>
   const topsisResults = useMemo(() => computeTopsisResults(state.decision), [state.decision]);
   const regretResults = useMemo(() => computeRegretResults(state.decision), [state.decision]);
   const sensitivity = useMemo(
-    () => sensitivityAnalysis(state.decision, state.swingPercent),
-    [state.decision, state.swingPercent]
+    () => sensitivityAnalysis(state.decision, state.swingPercent, results),
+    [state.decision, state.swingPercent, results]
   );
 
   // ── Convenience action wrappers ──────────────────────────

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -192,7 +192,13 @@ export function scoreOption(
   normalizedWeights: number[],
   strategy: ConfidenceStrategy = "none"
 ): OptionResult {
-  const criterionScores: CriterionScore[] = criteria.map((criterion, i) => {
+  // Single-pass: build criterion scores and accumulate weighted sum simultaneously
+  const criterionScores: CriterionScore[] = [];
+  let scoredWeightSum = 0;
+  let weightedSum = 0;
+
+  for (let i = 0; i < criteria.length; i++) {
+    const criterion = criteria[i];
     const raw = readScore(scores, optionId, criterion.id);
     const numericRaw = raw ?? 0;
     const eff = effectiveScore(numericRaw, criterion.type);
@@ -201,7 +207,7 @@ export function scoreOption(
     const mult = confidenceMultiplier(conf, strategy);
     const adjusted = eff * mult;
 
-    return {
+    criterionScores.push({
       criterionId: criterion.id,
       criterionName: criterion.name,
       rawScore: numericRaw,
@@ -211,23 +217,13 @@ export function scoreOption(
       isNull: raw === null,
       confidence: conf ?? undefined,
       confidenceMultiplier: mult,
-    };
-  });
+    });
 
-  // Accumulate only scored criteria; normalize by their weight sum
-  let scoredWeightSum = 0;
-  let weightedSum = 0;
-
-  criteria.forEach((criterion, i) => {
-    const raw = readScore(scores, optionId, criterion.id);
     if (raw !== null) {
-      const eff = effectiveScore(raw, criterion.type);
-      const conf = resolveConfidence(scores[optionId]?.[criterion.id]);
-      const mult = confidenceMultiplier(conf, strategy);
-      weightedSum += eff * mult * normalizedWeights[i];
-      scoredWeightSum += normalizedWeights[i];
+      weightedSum += adjusted * nw;
+      scoredWeightSum += nw;
     }
-  });
+  }
 
   const totalScore = roundDisplay(scoredWeightSum > 0 ? weightedSum / scoredWeightSum : 0);
 
@@ -322,9 +318,10 @@ export function computeTopDrivers(criteria: Criterion[], normalizedWeights: numb
  */
 export function sensitivityAnalysis(
   decision: Decision,
-  swingPercent: number = 20
+  swingPercent: number = 20,
+  precomputedBase?: DecisionResults
 ): SensitivityAnalysis {
-  const baseResults = computeResults(decision);
+  const baseResults = precomputedBase ?? computeResults(decision);
   if (baseResults.optionResults.length === 0) {
     return { decisionId: decision.id, points: [], summary: "No options to analyze." };
   }


### PR DESCRIPTION
## Summary

5 performance optimizations targeting both render efficiency and the computational hot path.

## Changes

### 1. Conditional Tab Rendering (HIGH impact)
Tab panels previously rendered all 5 tabs simultaneously via CSS `hidden`, which meant:
- `lazy()` dynamic imports fired **immediately on page load** — defeating code splitting
- All sub-component hooks ran for hidden panels
- Every `AppContent` state change re-rendered all 5 panels

Now only the active tab mounts. Builder stays always-mounted (primary editing surface).

### 2. `scoreOption()` Single-Pass (HIGH impact)
Previously iterated criteria **twice**: once for `criterionScores` array, once for `weightedSum` accumulation with identical computations. For Monte Carlo (10k iterations × 4 options × 5 criteria × 2 passes) = **~400k redundant operations eliminated**.

### 3. Pre-computed Base Results for `sensitivityAnalysis()` (MEDIUM impact)
`sensitivityAnalysis()` internally called `computeResults()` for the base case, but the provider already memoizes this. Now accepts optional `precomputedBase` parameter — saves one full scoring pass per decision change.

### 4. Deduplicate `computeCompleteness` (MEDIUM impact)
`computeCompleteness(decision)` was computed in both `page.tsx` (for tab badge) and `DecisionBuilder` (for completion ring). Now computed once in `page.tsx` and passed as prop.

### 5. `React.memo` on `DecisionBuilder` (MEDIUM impact)
849-line component with expensive render tree (DnD, sortable lists, score matrix) no longer re-renders on unrelated state changes (tab switch, modal toggle, drag overlay). Props (`validation`, `completeness`) only change when decision changes.

## Testing

- ✅ 1502/1502 unit tests pass
- ✅ No TypeScript errors

Closes #202