### PR TITLE
fix: stale E2E selectors, hooks ordering, type safety, semantic HTML

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -94,7 +94,7 @@ test.describe("Accessibility — axe-core scans", () => {
 
   test("New empty decision has no a11y violations", async ({ page }) => {
     // Create a new decision
-    await page.getByRole("button", { name: "Create new decision" }).click();
+    await page.getByRole("button", { name: "New" }).click();
 
     const results = await new AxeBuilder({ page })
       .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -19,7 +19,7 @@ test.describe("Decision OS — Smoke Tests", () => {
     await expect(page).toHaveTitle(/Decision OS/);
     await expect(page.locator("h1")).toContainText("Decision OS");
     // Demo decision should be selected
-    await expect(page.locator('select[aria-label="Select decision"]')).toBeVisible();
+    await expect(page.getByRole("combobox", { name: "Select decision" })).toBeVisible();
   });
 
   test("tab navigation works", async ({ page }) => {
@@ -83,11 +83,10 @@ test.describe("Decision OS — Smoke Tests", () => {
   });
 
   test("New Decision creates empty decision", async ({ page }) => {
-    await page.locator('button[aria-label="Create new decision"]').click();
+    await page.getByRole("button", { name: "New" }).click();
     // The select should now have an "Untitled Decision" option
-    await expect(
-      page.locator('select[aria-label="Select decision"] option:has-text("Untitled Decision")')
-    ).toBeAttached();
+    const selector = page.getByRole("combobox", { name: "Select decision" });
+    await expect(selector).toContainText("Untitled Decision");
   });
 
   test("404 page renders for unknown route", async ({ page }) => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -58,13 +58,13 @@ const MonteCarloView = lazy(() =>
 );
 
 /** Skeleton fallback for lazy-loaded tab panels */
-function TabPanelSkeleton({ label }: { label: string }) {
+function TabPanelSkeleton({ label }: Readonly<{ label: string }>) {
   return (
-    <div className="animate-pulse space-y-4 py-6" role="status" aria-label={`Loading ${label}…`}>
+    <output className="block animate-pulse space-y-4 py-6" aria-label={`Loading ${label}…`}>
       <div className="h-6 w-48 rounded bg-gray-200 dark:bg-gray-700" />
       <div className="h-64 rounded-lg bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700" />
       <div className="h-4 w-32 rounded bg-gray-200 dark:bg-gray-700" />
-    </div>
+    </output>
   );
 }
 

--- a/src/components/CoachmarkOverlay.tsx
+++ b/src/components/CoachmarkOverlay.tsx
@@ -59,14 +59,9 @@ export function CoachmarkOverlay({ step, onNext, onDismiss }: CoachmarkOverlayPr
   const cardRef = useRef<HTMLDivElement>(null);
   const [position, setPosition] = useState<Position | null>(null);
 
-  if (step === "idle") return null;
-
-  const config = STEPS[step];
-  const stepNum = step === "step1" ? 1 : step === "step2" ? 2 : 3;
-
   // Position the coachmark relative to the target element's tab button
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const updatePosition = useCallback(() => {
+    if (step === "idle") return;
     // Position relative to the corresponding tab button
     const tabId =
       step === "step1" ? "tab-results" : step === "step2" ? "tab-builder" : "tab-sensitivity";
@@ -93,8 +88,8 @@ export function CoachmarkOverlay({ step, onNext, onDismiss }: CoachmarkOverlayPr
     });
   }, [step]);
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
+    if (step === "idle") return;
     updatePosition();
     window.addEventListener("resize", updatePosition);
     window.addEventListener("scroll", updatePosition, true);
@@ -102,11 +97,11 @@ export function CoachmarkOverlay({ step, onNext, onDismiss }: CoachmarkOverlayPr
       window.removeEventListener("resize", updatePosition);
       window.removeEventListener("scroll", updatePosition, true);
     };
-  }, [updatePosition]);
+  }, [step, updatePosition]);
 
   // Escape key handler — always active while overlay is visible
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
+    if (step === "idle") return;
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         e.preventDefault();
@@ -115,11 +110,11 @@ export function CoachmarkOverlay({ step, onNext, onDismiss }: CoachmarkOverlayPr
     };
     document.addEventListener("keydown", handleEscape);
     return () => document.removeEventListener("keydown", handleEscape);
-  }, [onDismiss]);
+  }, [step, onDismiss]);
 
   // Focus trap: focus the card when it appears and trap Tab
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
+    if (step === "idle") return;
     const card = cardRef.current;
     if (!card) return;
 
@@ -147,6 +142,11 @@ export function CoachmarkOverlay({ step, onNext, onDismiss }: CoachmarkOverlayPr
     document.addEventListener("keydown", handleTrap);
     return () => document.removeEventListener("keydown", handleTrap);
   }, [step, position]);
+
+  if (step === "idle") return null;
+
+  const config = STEPS[step];
+  const stepNum = step === "step1" ? 1 : step === "step2" ? 2 : 3;
 
   return (
     <div

--- a/src/components/CompareView.tsx
+++ b/src/components/CompareView.tsx
@@ -394,10 +394,11 @@ export function CompareView() {
       {/* Comparison selector */}
       <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4">
         <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3">
-          <label className="text-sm font-medium text-gray-700 dark:text-gray-300 shrink-0">
+          <label htmlFor="compare-decision-a" className="text-sm font-medium text-gray-700 dark:text-gray-300 shrink-0">
             Compare:
           </label>
           <select
+            id="compare-decision-a"
             value={decisionIdA}
             onChange={(e) => setDecisionIdA(e.target.value)}
             className="flex-1 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 min-w-0"

--- a/src/components/MonteCarloView.tsx
+++ b/src/components/MonteCarloView.tsx
@@ -355,9 +355,8 @@ export function MonteCarloView() {
       {mcResults && (
         <>
           {/* Summary banner */}
-          <section
-            className="rounded-lg border border-indigo-200 bg-indigo-50 dark:border-indigo-800 dark:bg-indigo-900/30 p-4"
-            role="status"
+          <output
+            className="block rounded-lg border border-indigo-200 bg-indigo-50 dark:border-indigo-800 dark:bg-indigo-900/30 p-4"
           >
             <div className="flex items-start gap-2">
               <TrendingUp className="h-5 w-5 text-indigo-600 shrink-0 mt-0.5" />
@@ -368,7 +367,7 @@ export function MonteCarloView() {
                 <p className="text-sm text-indigo-700 dark:text-indigo-400">{mcResults.summary}</p>
               </div>
             </div>
-          </section>
+          </output>
 
           {/* Win Probabilities */}
           <section aria-labelledby="mc-win-heading">

--- a/src/components/SensitivityView.tsx
+++ b/src/components/SensitivityView.tsx
@@ -66,13 +66,12 @@ export function SensitivityView() {
         </div>
 
         {/* Summary */}
-        <div
-          className={`rounded-lg border p-4 mb-4 ${
+        <output
+          className={`block rounded-lg border p-4 mb-4 ${
             isRobust
               ? "border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-900/30"
               : "border-yellow-200 bg-yellow-50 dark:border-yellow-800 dark:bg-yellow-900/30"
           }`}
-          role="status"
         >
           <div className="flex items-start gap-2">
             {isRobust ? (
@@ -93,7 +92,7 @@ export function SensitivityView() {
               </p>
             </div>
           </div>
-        </div>
+        </output>
 
         {/* Detailed Points */}
         <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 overflow-hidden">

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -112,13 +112,12 @@ export function translate(
 
   const [ns, k] = parts;
   const msgs = messages[locale];
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const nsObj = (msgs as any)?.[ns];
+  const nsObj = msgs[ns as keyof Messages] as Record<string, string> | undefined;
   const value: string | undefined = nsObj?.[k];
 
   // Fall back to English for empty or missing translations
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const fallback: string | undefined = (messages.en as any)?.[ns]?.[k];
+  const enNsObj = messages.en[ns as keyof Messages] as Record<string, string> | undefined;
+  const fallback: string | undefined = enNsObj?.[k];
   const resolved = value || fallback || key;
 
   return params ? interpolate(resolved, params) : resolved;


### PR DESCRIPTION
## Summary
Fixes 4 quality issues across 8 files — stale E2E selectors, React hooks rule violations, `as any` type casts, and non-semantic HTML.

## Changes

### 1. Stale E2E selectors (smoke.spec.ts, accessibility.spec.ts)
- `button[aria-label="Create new decision"]` → `getByRole("button", { name: "New" })` to match current i18n labels
- `select[aria-label="Select decision"]` → `getByRole("combobox", { name: "Select decision" })` for resilient locators
- Modernized assertion from option selector to `toContainText`

### 2. Hooks ordering (CoachmarkOverlay.tsx)
- Moved `if (step === "idle") return null` early return **after** all hooks to fix `rules-of-hooks` violations
- Added `step === "idle"` guards inside each hook callback/effect body
- **Removed 4 `eslint-disable-next-line react-hooks/rules-of-hooks` comments**

### 3. Type safety (i18n.tsx)
- Replaced `(msgs as any)?.[ns]` with `msgs[ns as keyof Messages]` typed access
- Replaced `(messages.en as any)?.[ns]?.[k]` with typed equivalent
- **Removed 2 `eslint-disable-next-line @typescript-eslint/no-explicit-any` comments**

### 4. Semantic HTML
- SensitivityView, MonteCarloView, page.tsx: `<div role="status">` / `<section role="status">` → semantic `<output>` element
- CompareView: associated `<label>` with `<select>` via `htmlFor`/`id`

## Verification
- ✅ 1502/1502 unit tests pass
- ✅ No new TypeScript compilation errors
- ✅ 6 `eslint-disable` comments removed

Closes #204