### PR TITLE
docs: update ARCHITECTURE.md and copilot-instructions.md for v1.0.0

### DIFF
--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -2,16 +2,17 @@
 
 ## Project Overview
 
-Decision OS is a structured decision-making web app. Users create decisions with options, criteria (weighted), and scores, then see rankings and sensitivity analysis. Uses localStorage by default with optional Supabase-powered auth + cloud sync (feature-flagged behind `NEXT_PUBLIC_SUPABASE_URL`).
+Decision OS is a structured decision-making web app. Users create decisions with options, criteria (weighted), and scores, then see rankings, sensitivity analysis, Monte Carlo simulations, Pareto frontiers, and multi-algorithm consensus. Uses localStorage by default with optional Supabase-powered auth + cloud sync (feature-flagged behind `NEXT_PUBLIC_SUPABASE_URL`). Supports i18n (en/es/fr), data enrichment, cognitive bias detection, and decision journaling.
 
 ## Tech Stack
 
-- **Framework**: Next.js 16 (App Router) + TypeScript (strict mode)
+- **Framework**: Next.js 16 (App Router) + TypeScript (strict mode) + React 19
 - **Styling**: Tailwind CSS 4 + utility classes (with `dark:` variants)
 - **Icons**: lucide-react
-- **Charts**: Recharts (bar + stacked breakdown)
+- **Charts**: Recharts (bar, stacked, scatter/Pareto)
 - **Auth/Cloud**: Supabase (optional, via `@supabase/supabase-js`)
 - **Compression**: lz-string (URL sharing)
+- **DnD**: @dnd-kit (drag-and-drop reordering)
 - **Testing**: Vitest + React Testing Library + Playwright E2E
 - **Linting**: ESLint + Prettier
 - **CI**: GitHub Actions (format:check → lint → typecheck → test:coverage → build → E2E)
@@ -37,76 +38,162 @@ npm run format:check  # Prettier check (used in CI)
 ```
 src/
 ├── app/              # Next.js App Router pages
-│   ├── layout.tsx    # Root layout (metadata, fonts)
-│   ├── page.tsx      # Main page (tab navigation)
+│   ├── layout.tsx    # Root layout (metadata, fonts, FOUC-prevention)
+│   ├── page.tsx      # Main page (7-tab navigation, keyboard shortcuts)
+│   ├── not-found.tsx # Custom 404 page
+│   ├── share/page.tsx# Read-only share route
 │   └── globals.css   # Tailwind imports
-├── components/       # React components
-│   ├── DecisionProvider.tsx  # State management context + URL share restore
-│   ├── DecisionBuilder.tsx   # Decision editor UI
-│   ├── Header.tsx            # App header (branding, selector, dark toggle, auth, sync)
+├── components/       # React components (50 files)
+│   ├── DecisionProvider.tsx  # 4 focused contexts + backward-compatible context
+│   ├── DecisionBuilder.tsx   # Decision editor UI (React.memo, 800+ lines)
+│   ├── Header.tsx            # App header (selector, dark toggle, auth, sync, i18n)
+│   ├── ResultsView.tsx       # Rankings, chart, export, share
+│   ├── SensitivityView.tsx   # Sensitivity analysis
+│   ├── CompareView.tsx       # Side-by-side decision comparison
+│   ├── MonteCarloView.tsx    # Monte Carlo simulation config + results
+│   ├── ParetoChart.tsx       # Pareto frontier scatter plot
+│   ├── FrameworkComparison.tsx # WSM/TOPSIS/Regret side-by-side consensus
+│   ├── HybridResults.tsx     # Multi-algorithm consensus ranking table
+│   ├── AHPWizard.tsx         # Pairwise comparison wizard for AHP weights
+│   ├── WhatIfPanel.tsx       # Sandboxed what-if overlay with rank comparison
+│   ├── BiasWarnings.tsx      # Cognitive bias warning cards
+│   ├── PatternInsights.tsx   # Cross-decision pattern analysis cards
+│   ├── OutcomeTracker.tsx    # Post-decision outcome recording
+│   ├── RetrospectiveView.tsx # Decision lifecycle timeline + journal
+│   ├── EnrichmentSuggest.tsx # Data enrichment suggestion flow
+│   ├── QualityBar.tsx        # Decision quality dashboard
+│   ├── ScoreChart.tsx        # Recharts visualization (lazy-loaded)
+│   ├── ThemeProvider.tsx     # Dark/light mode context
+│   ├── ErrorBoundary.tsx     # Error boundary with error reporting
+│   ├── TabErrorFallback.tsx  # Tab-level error fallback
+│   ├── Announcer.tsx         # Live-region announcer for screen readers
+│   ├── Toast.tsx             # Imperative toast notifications (showToast)
+│   ├── TemplatePicker.tsx    # Modal template picker with focus trap
+│   ├── ImportModal.tsx       # JSON/CSV import with preview and drag-and-drop
+│   ├── ShareView.tsx         # Read-only shared decision view
 │   ├── AuthButton.tsx        # Sign in/out dropdown with OAuth providers
 │   ├── SyncStatus.tsx        # Cloud sync status indicator
 │   ├── MigrationBanner.tsx   # One-time localStorage → cloud migration prompt
-│   ├── ImportModal.tsx       # JSON/CSV import with preview and drag-and-drop
-│   ├── CompareView.tsx       # Side-by-side decision comparison with divergence analysis
-│   ├── MonteCarloView.tsx    # Monte Carlo simulation config, results, histograms
-│   ├── ResultsView.tsx       # Rankings, chart, export, share
-│   ├── SensitivityView.tsx   # Sensitivity analysis
-│   ├── ScoreChart.tsx        # Recharts visualization
-│   ├── ThemeProvider.tsx     # Dark/light mode context
-│   ├── ErrorBoundary.tsx     # Error boundary with error reporting
-│   ├── Announcer.tsx         # Live-region announcer for screen readers
-│   ├── Toast.tsx             # Imperative toast notifications (showToast)
-│   └── TemplatePicker.tsx    # Modal template picker with focus trap
-├── hooks/            # Custom React hooks
+│   ├── KeyboardShortcutsModal.tsx # Keyboard shortcuts modal with focus trap
+│   ├── CoachmarkOverlay.tsx  # 3-step onboarding tour overlay
+│   ├── LanguageSwitcher.tsx  # Locale-switching dropdown (en/es/fr)
+│   ├── MobileOverflowMenu.tsx # Kebab menu for narrow viewports
+│   ├── MobileScoreCards.tsx  # Accordion card layout for mobile scoring
+│   ├── ServiceWorkerRegistrar.tsx # SW registration + offline banner
+│   ├── ScoreSlider.tsx       # Touch-optimized 0–10 range slider
+│   ├── WeightSlider.tsx      # Range slider + number input for weights
+│   ├── WeightDistributionBar.tsx # Stacked weight percentage bar
+│   ├── CompletionRing.tsx    # SVG circular completeness indicator
+│   ├── ConfidenceDot.tsx     # Clickable confidence level dot
+│   ├── ConfidenceIndicator.tsx # Enriched-score reliability badge
+│   ├── CompositeConfidenceIndicator.tsx # Traffic-light composite badge
+│   ├── ConfidenceStrategySelector.tsx # Confidence mode selector
+│   ├── ScoreProvenanceIndicator.tsx # Manual/enriched/overridden badge
+│   ├── CriterionTooltip.tsx  # Accessible criterion description tooltip
+│   ├── ReasoningPopover.tsx  # Per-score reasoning notes popover
+│   ├── ScoringPrompt.tsx     # Contextual scoring guidance prompts
+│   ├── SortableItem.tsx      # @dnd-kit sortable drag-and-drop wrapper
+│   └── DecisionSkeleton.tsx  # Pulsing placeholder skeleton
+├── hooks/            # Custom React hooks (6 files)
 │   ├── useValidation.ts     # Memoized validation (errors/warnings/infos)
-│   ├── useAuth.ts           # Supabase auth state hook (user, session, sign in/out)
-│   └── useSync.ts           # Cloud sync status hook (auto-sync, manual trigger)
-├── lib/              # Pure logic (no React)
+│   ├── useAuth.ts           # Supabase auth state (user, session, sign in/out)
+│   ├── useSync.ts           # Cloud sync status (auto-sync, manual trigger)
+│   ├── useBiasDetection.ts  # Debounced bias detection with dismissal management
+│   ├── useMonteCarloWorker.ts # Web Worker MC with progress + cancellation
+│   └── useOnboarding.ts     # Onboarding state machine (idle → step1–3)
+├── workers/          # Web Workers
+│   └── monte-carlo.worker.ts # Off-thread Monte Carlo simulation
+├── lib/              # Pure logic, no React (37 modules)
 │   ├── types.ts      # TypeScript type definitions
-│   ├── scoring.ts    # Scoring engine (CRITICAL - see below)
+│   ├── scoring.ts    # WSM scoring engine (single-pass, sensitivity analysis)
 │   ├── validation.ts # Input validation
-│   ├── storage.ts    # localStorage CRUD
-│   ├── demo-data.ts  # Demo decision data
-│   ├── utils.ts      # Utilities
-│   ├── templates.ts  # 8 pre-built decision templates
-│   ├── import.ts     # JSON/CSV import parsing and validation
-│   ├── comparison.ts # Decision comparison engine (deltas, agreement, heatmap)
+│   ├── decision-reducer.ts # Pure reducer + typed actions + undo/redo coalescing
+│   ├── completeness.ts # Score-matrix completeness computation
+│   ├── ahp.ts        # Analytic Hierarchy Process (Saaty eigenvector, CR)
+│   ├── topsis.ts     # TOPSIS ranking (closeness coefficient)
+│   ├── regret.ts     # Minimax Regret (Savage 1951)
+│   ├── consensus.ts  # Multi-algorithm consensus (Borda count, Kendall's W)
+│   ├── composite-confidence.ts # Weighted composite confidence metric
 │   ├── monte-carlo.ts # Monte Carlo simulation engine (PRNG, perturbation)
-│   ├── share.ts      # Compact share encoding/decoding for /share route
-│   ├── supabase.ts   # Supabase client singleton (feature-flag guarded)
+│   ├── pareto.ts     # Pareto frontier (non-dominated options)
+│   ├── decision-quality.ts # Structural quality scoring + suggestions
+│   ├── bias-detection.ts # 7 cognitive biases with severity ratings
+│   ├── patterns.ts   # Cross-decision pattern recognition
+│   ├── storage.ts    # localStorage CRUD
+│   ├── cloud-storage.ts # Supabase cloud CRUD
+│   ├── sync.ts       # Bidirectional sync engine (last-write-wins)
+│   ├── supabase.ts   # Supabase client singleton
 │   ├── supabase-types.ts # Generated Supabase Database types
-│   ├── cloud-storage.ts  # Supabase cloud CRUD operations
-│   ├── sync.ts       # Bidirectional sync engine (local ↔ cloud)
-│   └── error-reporter.ts  # Production error telemetry
-└── __tests__/        # Unit tests (281 tests, 18 files)
+│   ├── rate-limiter.ts # Client-side rate limiter with exponential backoff
+│   ├── comparison.ts # Decision comparison (deltas, Spearman, heatmap)
+│   ├── share.ts      # Compact share encoding/decoding (lz-string)
+│   ├── import.ts     # JSON/CSV import parsing and validation
+│   ├── templates.ts  # 8 pre-built decision templates
+│   ├── journal.ts    # Decision journal CRUD (localStorage)
+│   ├── outcome-tracking.ts # Post-decision outcome recording
+│   ├── provenance.ts # Per-cell score provenance metadata
+│   ├── demo-data.ts  # Demo decision data
+│   ├── utils.ts      # Utilities (ID gen, URL encoding, relative time)
+│   ├── error-reporter.ts # Error telemetry (localStorage + Sentry)
+│   ├── sanitize.ts   # Input sanitization (control chars, bidi)
+│   ├── i18n.tsx      # i18n context + useTranslation() hook
+│   ├── i18n/         # Locale files (en.json, es.json, fr.json)
+│   └── data/         # Data enrichment subsystem
+│       ├── engine.ts     # 3-tier enrichment (live → bundled → estimated)
+│       ├── estimation.ts # Tier 3 estimation (income-group, regional proxy)
+│       ├── provider.ts   # Abstract DataProvider base class
+│       ├── registry.ts   # Provider registry
+│       ├── datasets/     # Bundled datasets (cost-of-living, country-risk, etc.)
+│       └── providers/    # Data providers (cost-of-living, country-risk, etc.)
+└── __tests__/        # Unit tests (1502 tests, 84 files)
     ├── scoring.test.ts
     ├── validation.test.ts
     ├── utils.test.ts
     ├── storage.test.ts
     ├── templates.test.ts
-    ├── import.test.ts        # Import module tests (30 tests)
-    ├── comparison.test.ts    # Comparison engine tests (33 tests)
-    ├── error-reporter.test.ts  # Error reporter tests (9 tests)
-    ├── monte-carlo.test.ts   # Monte Carlo engine tests (38 tests)
-    ├── share.test.ts         # Share encoding/decoding tests (23 tests)
-    ├── cloud-storage.test.ts # Cloud storage CRUD tests with mocked Supabase (13 tests)
-    ├── sync.test.ts          # Sync engine tests (9 tests)
-    ├── test-utils.tsx        # renderWithProviders helper
-    └── components/           # Component integration tests
-        ├── DecisionProvider.test.tsx
-        ├── Header.test.tsx
-        ├── DecisionBuilder.test.tsx
-        ├── ResultsView.test.tsx
-        ├── ThemeProvider.test.tsx
-        └── ErrorBoundary.test.tsx
+    ├── import.test.ts
+    ├── comparison.test.ts
+    ├── error-reporter.test.ts
+    ├── monte-carlo.test.ts
+    ├── share.test.ts
+    ├── cloud-storage.test.ts
+    ├── sync.test.ts
+    ├── decision-reducer.test.ts
+    ├── ahp.test.ts
+    ├── bias-detection.test.ts
+    ├── completeness.test.ts
+    ├── confidence-scoring.test.ts
+    ├── consensus.test.ts
+    ├── i18n.test.ts
+    ├── journal.test.ts
+    ├── outcome-tracking.test.ts
+    ├── pareto.test.ts
+    ├── patterns.test.tsx
+    ├── provenance.test.ts
+    ├── rate-limiter.test.ts
+    ├── regret.test.ts
+    ├── topsis.test.ts
+    ├── a11y.test.tsx
+    ├── csp-headers.test.ts
+    ├── performance.test.ts
+    ├── security.test.ts
+    ├── test-utils.tsx
+    ├── components/     # 32 component test files
+    ├── hooks/          # Hook tests (useAuth, useSync, useValidation)
+    └── data/           # Data enrichment tests
+e2e/                  # Playwright E2E tests (43 tests, 5 specs)
+    ├── smoke.spec.ts
+    ├── accessibility.spec.ts
+    ├── visual.spec.ts
+    ├── workflows.spec.ts
+    └── features.spec.ts
 ```
 
 ## CRITICAL RULES
 
 ### 1. Do NOT break the deterministic scoring engine
 
-The scoring engine in `src/lib/scoring.ts` is the core of the app. It MUST be deterministic: identical inputs always produce identical outputs. If you modify any function in this file:
+The scoring engine in `src/lib/scoring.ts` is the core of the app. It MUST be deterministic: identical inputs always produce identical outputs. `scoreOption()` uses a single-pass loop for efficiency. If you modify any function in this file:
 
 - Update `docs/SCORING_MODEL.md` to match
 - Update or add unit tests in `src/__tests__/scoring.test.ts`
@@ -122,7 +209,7 @@ The scoring engine in `src/lib/scoring.ts` is the core of the app. It MUST be de
 
 ### 3. Pure functions in /lib
 
-Everything in `src/lib/` must be pure functions with no React dependencies. This makes them easy to test and reuse. React-specific code goes in `src/components/`.
+Everything in `src/lib/` must be pure functions with no React dependencies, **except** `i18n.tsx` (React context). This makes them easy to test and reuse. React-specific code goes in `src/components/`.
 
 ### 4. Testing requirements
 
@@ -151,10 +238,13 @@ Everything in `src/lib/` must be pure functions with no React dependencies. This
 
 ### 7. State management
 
-- All decision state flows through `DecisionProvider` (React Context)
+- Decision state flows through `DecisionProvider` which uses `useReducer` + `decision-reducer.ts`
+- 4 focused contexts for surgical re-renders: `DecisionDataCtx`, `ResultsCtx`, `ActionsCtx`, `DecisionDispatchContext`
+- Backward-compatible `DecisionContext` combines all (use focused hooks for new code)
+- **Focused hooks**: `useDecisionData()` (data + nav), `useResultsContext()` (computed results), `useActions()` (stable action wrappers), `useDecisionDispatch()` (raw dispatch)
 - Auto-save to localStorage with 300ms debounce
-- Never mutate state directly — always spread/copy
-- Undo/redo history (50 entries max) via `undoStackRef` / `redoStackRef`
+- Never mutate state directly — dispatch typed actions through the reducer
+- Undo/redo history (50 entries max) via `undoStackRef` / `redoStackRef` with coalescing middleware
 - All mutations call `pushUndo(prev)` before state update
 - `clearHistory()` resets on decision switch
 - Use `showToast()` with `{ action: { label: "Undo", onClick: undo } }` for destructive actions
@@ -206,6 +296,31 @@ Everything in `src/lib/` must be pure functions with no React dependencies. This
 - Divergence colors: green (|Δ| ≤ 1), yellow (|Δ| 2–3), red (|Δ| ≥ 4)
 - Compare tab is the 4th tab (keyboard shortcut: `4`)
 
+### 14. Internationalization (i18n)
+
+- i18n context + `useTranslation()` hook in `src/lib/i18n.tsx`
+- Locale files in `src/lib/i18n/` (en.json, es.json, fr.json)
+- All user-facing strings must use `t("namespace.key")` — no hardcoded English
+- Locale persisted to localStorage via `LanguageSwitcher` component
+- English is the fallback locale — missing keys fall back to `en.json`
+
+### 15. MCDA algorithms
+
+- **WSM** (Weighted Sum Model) in `scoring.ts` — primary ranking algorithm
+- **TOPSIS** in `topsis.ts` — closeness to ideal/anti-ideal solutions
+- **Minimax Regret** in `regret.ts` — non-compensatory, penalizes extreme weaknesses
+- **AHP** in `ahp.ts` — derives weights from pairwise comparisons (consistency ratio must be < 0.1)
+- **Consensus** in `consensus.ts` — Borda count unification + Kendall's W concordance
+- All MCDA modules are pure functions with comprehensive unit tests
+
+### 16. Data enrichment
+
+- 3-tier fallback: live provider → bundled dataset → estimation
+- Providers and datasets in `src/lib/data/providers/` and `src/lib/data/datasets/`
+- Abstract `DataProvider` base class in `src/lib/data/provider.ts`
+- Enriched scores carry provenance metadata (source, confidence, timestamp)
+- Users can override enriched values; provenance tracks manual overrides
+
 ## Code Style
 
 - 2-space indentation
@@ -217,13 +332,12 @@ Everything in `src/lib/` must be pure functions with no React dependencies. This
 
 ## Before Committing Checklist
 
-1. `npm run test` — all tests pass
+1. `npm run test` — all 1502+ unit tests pass
 2. `npm run lint` — no lint errors
 3. `npm run format:check` — formatting correct
 4. `npm run typecheck` — no type errors
 5. `npm run build` — production build succeeds
 6. All `dark:` variants added for any new UI elements
 7. Destructive actions have confirmation dialogs
-8. `npm run typecheck` — no type errors
-9. `npm run build` — production build succeeds
-10. Manual check — app works in browser
+8. All user-facing strings use `t()` from i18n
+9. Manual check — app works in browser

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,124 +2,296 @@
 
 ## Overview
 
-Decision OS is a client-side web application built with Next.js (App Router) and TypeScript. It uses a local-first architecture — all data lives in the browser's localStorage by default, with optional Supabase-powered cloud sync for cross-device access.
+Decision OS is a client-side web application built with Next.js 16 (App Router), React 19, and TypeScript (strict mode). It uses a local-first architecture — all data lives in the browser's localStorage by default, with optional Supabase-powered cloud sync for cross-device access. The app implements multiple MCDA (Multi-Criteria Decision Analysis) algorithms, Monte Carlo simulation, cognitive bias detection, and data enrichment — all running entirely in the browser.
 
 ## High-Level Diagram
 
 ```
-┌─────────────────────────────────────────────────────────┐
-│                    Browser (Client)                     │
-│                                                         │
-│  ┌───────────────┐  ┌──────────────┐  ┌──────────────┐ │
-│  │ Decision      │  │ Results      │  │ Sensitivity  │ │
-│  │ Builder UI    │  │ View         │  │ Analysis     │ │
-│  └──────┬────────┘  └──────┬───────┘  └──────┬───────┘ │
-│         │                  │                  │         │
-│  ┌──────▼──────────────────▼──────────────────▼───────┐ │
-│  │           DecisionProvider (React Context)         │ │
-│  │         State management + auto-save               │ │
-│  └──────┬─────────────────────────────┬───────────────┘ │
-│         │                             │                 │
-│  ┌──────▼──────────┐  ┌──────────────▼───────────────┐ │
-│  │ Scoring Engine  │  │ Storage Layer (localStorage) │ │
-│  │ (Pure functions)│  │                              │ │
-│  └─────────────────┘  └──────────────────────────────┘ │
-│                                                         │
-└─────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────┐
+│                          Browser (Client)                           │
+│                                                                      │
+│  ┌─────────────┐ ┌──────────┐ ┌────────────┐ ┌──────────────────┐  │
+│  │  Decision    │ │ Results  │ │ Sensitivity│ │ Compare / MC /   │  │
+│  │  Builder     │ │ View     │ │ Analysis   │ │ Pareto / Quality │  │
+│  └──────┬───────┘ └────┬─────┘ └─────┬──────┘ └────────┬─────────┘  │
+│         │              │             │                  │            │
+│  ┌──────▼──────────────▼─────────────▼──────────────────▼─────────┐ │
+│  │              DecisionProvider (4 Focused Contexts)              │ │
+│  │  DecisionDataCtx · ResultsCtx · ActionsCtx · DispatchCtx       │ │
+│  │  + backward-compatible DecisionContext (combines all)           │ │
+│  └──────┬──────────────┬─────────────────────────┬────────────────┘ │
+│         │              │                         │                  │
+│  ┌──────▼────────┐ ┌───▼──────────────────┐ ┌───▼────────────────┐ │
+│  │ decision-     │ │ Scoring + Analytics  │ │ Storage Layer      │ │
+│  │ reducer.ts    │ │ scoring · topsis ·   │ │ localStorage       │ │
+│  │ (useReducer)  │ │ ahp · regret ·      │ │ + cloud (Supabase) │ │
+│  │ + undo/redo   │ │ consensus · pareto  │ │ + sync engine      │ │
+│  └───────────────┘ └────────────────────┘  └──────────────────────┘ │
+│                          │                                          │
+│                   ┌──────▼──────────┐                               │
+│                   │  Web Worker      │                               │
+│                   │  (Monte Carlo)   │                               │
+│                   └─────────────────┘                                │
+└──────────────────────────────────────────────────────────────────────┘
 ```
 
 ## Module Boundaries
 
-### `/src/lib/` — Core Logic (Pure, testable, no React)
+### `/src/lib/` — Core Logic (37 modules, pure, no React)
 
-| File                | Responsibility                                                        |
-| ------------------- | --------------------------------------------------------------------- |
-| `types.ts`          | TypeScript type definitions for the entire domain                     |
-| `scoring.ts`        | Deterministic scoring engine (weighted sum, sensitivity analysis)     |
-| `validation.ts`     | Input validation with structured error messages + runtime type guards |
-| `storage.ts`        | localStorage CRUD operations                                          |
-| `cloud-storage.ts`  | Supabase cloud CRUD operations (guarded, returns empty when offline)  |
-| `sync.ts`           | Bidirectional sync engine (local ↔ cloud, last-write-wins)            |
-| `supabase.ts`       | Supabase client singleton with feature-flag guard                     |
-| `supabase-types.ts` | Generated Supabase Database types for the decisions table             |
-| `demo-data.ts`      | Preloaded demo decision                                               |
-| `utils.ts`          | Utilities (ID generation, URL encoding/decoding, relative time)       |
-| `templates.ts`      | 8 pre-built decision templates with `instantiateTemplate()` factory   |
-| `import.ts`         | JSON/CSV import parsing, preview, validation, and file reading        |
-| `comparison.ts`     | Decision comparison engine (deltas, agreement score, heatmap)         |
-| `monte-carlo.ts`    | Monte Carlo simulation engine (PRNG, perturbation, distributions)     |
-| `share.ts`          | Compact share encoding/decoding (short keys, index-based scores)      |
-| `error-reporter.ts` | Production error telemetry with localStorage + Sentry forwarding      |
+#### Core Domain
 
-### `/src/components/` — React UI Components
+| File                   | Responsibility                                                                         |
+| ---------------------- | -------------------------------------------------------------------------------------- |
+| `types.ts`             | TypeScript type definitions for the entire domain                                      |
+| `scoring.ts`           | Deterministic WSM scoring engine (single-pass weighted sum, sensitivity analysis)      |
+| `validation.ts`        | Input validation with structured error messages + runtime type guards                  |
+| `decision-reducer.ts`  | Pure reducer + typed actions for decision state, with undo/redo coalescing middleware   |
+| `completeness.ts`      | Computes score-matrix completeness (filled/total counts, percentage, color tier)        |
+
+#### Multi-Criteria Analysis (MCDA)
+
+| File                      | Responsibility                                                                      |
+| ------------------------- | ------------------------------------------------------------------------------------ |
+| `ahp.ts`                  | Analytic Hierarchy Process — derives weights from pairwise comparisons (Saaty eigenvector, CR validation) |
+| `topsis.ts`               | TOPSIS ranking — closeness coefficient to ideal/anti-ideal solutions (Hwang & Yoon 1981) |
+| `regret.ts`               | Minimax Regret — non-compensatory method penalizing extreme per-criterion weaknesses (Savage 1951) |
+| `consensus.ts`            | Multi-algorithm consensus — runs WSM/TOPSIS/Regret, unifies via Borda count with Kendall's W |
+| `composite-confidence.ts` | Unifies 4 confidence signals into a single weighted composite metric                 |
+| `monte-carlo.ts`          | Monte Carlo simulation engine (seeded PRNG, perturbation, confidence distributions)  |
+| `pareto.ts`               | Pareto frontier computation — non-dominated options via O(n²) dominance testing      |
+| `decision-quality.ts`     | Structural quality scoring with actionable improvement suggestions                   |
+| `bias-detection.ts`       | Detects 7 cognitive biases (halo, anchoring, uniformity, etc.) with severity ratings |
+| `patterns.ts`             | Cross-decision pattern recognition (scoring biases, weight preferences, criterion reuse) |
+
+#### Data & Storage
+
+| File                | Responsibility                                                         |
+| ------------------- | ---------------------------------------------------------------------- |
+| `storage.ts`        | localStorage CRUD operations                                           |
+| `cloud-storage.ts`  | Supabase cloud CRUD (guarded, returns empty when offline)              |
+| `sync.ts`           | Bidirectional sync engine (local ↔ cloud, last-write-wins)             |
+| `supabase.ts`       | Supabase client singleton with feature-flag guard                      |
+| `supabase-types.ts` | Generated Supabase Database types for the decisions table              |
+| `rate-limiter.ts`   | Client-side rate limiter with exponential backoff for Supabase API calls |
+
+#### Feature Modules
+
+| File                 | Responsibility                                                              |
+| -------------------- | --------------------------------------------------------------------------- |
+| `comparison.ts`      | Decision comparison engine (deltas, Spearman agreement score, heatmap)      |
+| `share.ts`           | Compact share encoding/decoding (short keys, index-based scores, lz-string) |
+| `import.ts`          | JSON/CSV import parsing, preview, validation, and file reading              |
+| `templates.ts`       | 8 pre-built decision templates with `instantiateTemplate()` factory         |
+| `journal.ts`         | Decision journal — CRUD for structured entries (notes, reasoning, outcomes) in localStorage |
+| `outcome-tracking.ts`| Records post-decision outcomes, compares actual vs. predicted scores        |
+| `provenance.ts`      | Per-cell score provenance metadata (manual, enriched, or user-overridden)   |
+
+#### Utilities
+
+| File                | Responsibility                                                         |
+| ------------------- | ---------------------------------------------------------------------- |
+| `utils.ts`          | Utilities (ID generation, URL encoding/decoding, relative time)        |
+| `demo-data.ts`      | Preloaded demo decision                                                |
+| `error-reporter.ts` | Production error telemetry with localStorage + Sentry forwarding       |
+| `sanitize.ts`       | Input sanitization — strips control chars, zero-width, bidi overrides  |
+| `i18n.tsx`          | Internationalization context + `useTranslation()` hook (en, es, fr)    |
+
+#### Data Enrichment (`/src/lib/data/`)
+
+| File                      | Responsibility                                                       |
+| ------------------------- | -------------------------------------------------------------------- |
+| `engine.ts`               | Enrichment engine — 3-tier fallback (live → bundled → estimated), per-provider timeouts |
+| `estimation.ts`           | Tier 3 estimation — income-group proxy, regional proxy, composite strategies |
+| `provider.ts`             | Abstract `DataProvider` base class with caching and min-max normalization |
+| `registry.ts`             | Provider registry — holds all registered providers for lookup        |
+| `datasets/*.ts`           | Bundled datasets: cost-of-living, country-risk, quality-of-life, tax-efficiency, university-rankings |
+| `providers/*.ts`          | Data providers: cost-of-living, country-risk, quality-of-life, tax-efficiency, university-rankings |
+
+### `/src/components/` — React UI Components (50 files)
+
+#### Core Layout & State
 
 | File                   | Responsibility                                                              |
 | ---------------------- | --------------------------------------------------------------------------- |
-| `DecisionProvider.tsx` | React Context for state management, auto-save, URL share restore            |
-| `Header.tsx`           | App header with decision selector, create/delete/reset, dark toggle, import |
-| `DecisionBuilder.tsx`  | Title, options, criteria, scores matrix editor                              |
-| `ResultsView.tsx`      | Rankings, breakdowns, top drivers, export, chart, share                     |
-| `SensitivityView.tsx`  | Weight-swing analysis with interactive slider                               |
-| `ScoreChart.tsx`       | Recharts-based bar and stacked breakdown chart (React.memo, lazy-loaded)    |
-| `ThemeProvider.tsx`    | Dark/light mode via React Context + localStorage                            |
+| `DecisionProvider.tsx` | 4 focused contexts + backward-compatible context; auto-save; URL share restore |
+| `Header.tsx`           | App header: decision selector, create/delete/reset, dark toggle, import, i18n, auth |
 | `ErrorBoundary.tsx`    | Class-based error boundary with recovery UI and error reporting             |
+| `TabErrorFallback.tsx` | Lightweight tab-level error fallback with retry button                      |
+| `ThemeProvider.tsx`    | Dark/light mode via React Context + localStorage                            |
 | `Announcer.tsx`        | Live-region announcer for screen reader CRUD notifications                  |
-| `DecisionSkeleton.tsx` | Pulsing placeholder skeleton shown during decision switching                |
 | `Toast.tsx`            | Imperative toast notifications with auto-dismiss and undo actions           |
-| `TemplatePicker.tsx`   | Modal template picker with focus trap and card grid                         |
-| `ImportModal.tsx`      | File import dialog with CSV preview, drag-and-drop support                  |
-| `CompareView.tsx`      | Side-by-side decision comparison with divergence analysis                   |
-| `MonteCarloView.tsx`   | Monte Carlo simulation config, results, histograms, CIs                     |
-| `ShareView.tsx`        | Read-only presentation view for shared decisions                            |
-| `AuthButton.tsx`       | Sign in/out dropdown with GitHub and Google OAuth providers                 |
-| `SyncStatus.tsx`       | Cloud sync status indicator with manual retry                               |
-| `MigrationBanner.tsx`  | One-time localStorage → cloud migration prompt                              |
+| `DecisionSkeleton.tsx` | Pulsing placeholder skeleton shown during decision switching                |
+| `ServiceWorkerRegistrar.tsx` | SW registration, offline banner, new-version refresh prompt            |
 
-### `/src/hooks/` — Custom React Hooks
+#### Decision Building
 
-| File               | Responsibility                                                            |
-| ------------------ | ------------------------------------------------------------------------- |
-| `useValidation.ts` | Real-time validation hook — returns errors, warnings, infos for inline UI |
-| `useAuth.ts`       | Supabase auth state hook — user, session, sign in/out, loading            |
-| `useSync.ts`       | Cloud sync status hook — auto-sync on mount/focus, manual trigger         |
+| File                          | Responsibility                                                        |
+| ----------------------------- | --------------------------------------------------------------------- |
+| `DecisionBuilder.tsx`         | Title, options, criteria, scores matrix editor (React.memo, 800+ lines) |
+| `ScoreSlider.tsx`             | Touch-optimized 0–10 range slider with ≥44px target and color coding |
+| `WeightSlider.tsx`            | Range slider + number input for criterion weights with ARIA attributes |
+| `WeightDistributionBar.tsx`   | Stacked horizontal bar showing normalized weight percentages          |
+| `MobileScoreCards.tsx`        | Accordion card layout for mobile scoring with sliders and confidence dots |
+| `SortableItem.tsx`            | @dnd-kit/sortable drag-and-drop wrapper with accessible grip handle   |
+| `ScoringPrompt.tsx`           | Contextual scoring guidance — anchor prompts (1/5/10) and calibration |
+| `CriterionTooltip.tsx`        | Accessible hover/focus/touch tooltip for criterion descriptions       |
+| `ReasoningPopover.tsx`        | Per-score reasoning notes popover with filled-icon indicator          |
+| `CompletionRing.tsx`          | SVG circular progress indicator for score-matrix completeness         |
+| `QualityBar.tsx`              | Overall quality score bar with expandable per-check indicators        |
+
+#### Results & Analysis
+
+| File                          | Responsibility                                                        |
+| ----------------------------- | --------------------------------------------------------------------- |
+| `ResultsView.tsx`             | Rankings, breakdowns, top drivers, export, chart, share               |
+| `ScoreChart.tsx`              | Recharts bar + stacked breakdown chart (React.memo, lazy-loaded)      |
+| `SensitivityView.tsx`         | Weight-swing analysis with interactive slider                         |
+| `CompareView.tsx`             | Side-by-side decision comparison with divergence analysis             |
+| `MonteCarloView.tsx`          | Monte Carlo simulation config, results, histograms, CIs              |
+| `ParetoChart.tsx`             | Recharts scatter plot with Pareto frontier line and axis selectors    |
+| `WhatIfPanel.tsx`             | Sandboxed what-if overlay with real-time rank comparison              |
+
+#### Multi-Algorithm & Confidence
+
+| File                              | Responsibility                                                    |
+| --------------------------------- | ----------------------------------------------------------------- |
+| `FrameworkComparison.tsx`         | WSM/TOPSIS/Minimax Regret side-by-side with Kendall's W consensus |
+| `HybridResults.tsx`               | Consensus ranking table with color-coded agreement indicators     |
+| `AHPWizard.tsx`                   | Step-by-step pairwise comparison wizard for AHP weight derivation |
+| `ConfidenceDot.tsx`               | Clickable green/amber/red dot cycling through confidence levels   |
+| `ConfidenceIndicator.tsx`         | Enriched-score reliability badge (Tier 1/2/3) with tooltip        |
+| `CompositeConfidenceIndicator.tsx`| Traffic-light composite confidence badge with expandable breakdown |
+| `ConfidenceStrategySelector.tsx`  | Radio selector: display-only / penalize / widen-MC confidence modes |
+| `ScoreProvenanceIndicator.tsx`    | Manual/enriched/overridden badge with restore-enriched action     |
+
+#### Bias & Patterns
+
+| File                   | Responsibility                                                            |
+| ---------------------- | ------------------------------------------------------------------------- |
+| `BiasWarnings.tsx`     | Cognitive bias warnings as dismissible, severity-styled cards             |
+| `PatternInsights.tsx`  | Cross-decision pattern cards with confidence indicators and evidence      |
+
+#### Lifecycle & Retrospective
+
+| File                   | Responsibility                                                            |
+| ---------------------- | ------------------------------------------------------------------------- |
+| `OutcomeTracker.tsx`   | Records outcomes (chosen option, rating, notes) with prediction comparison |
+| `RetrospectiveView.tsx`| Decision lifecycle timeline with journal, milestones, and markdown export |
+
+#### Data Enrichment
+
+| File                   | Responsibility                                                            |
+| ---------------------- | ------------------------------------------------------------------------- |
+| `EnrichmentSuggest.tsx`| Suggests auto-fill data queries; users accept, dismiss, or override       |
+
+#### Import & Share
+
+| File                   | Responsibility                                                            |
+| ---------------------- | ------------------------------------------------------------------------- |
+| `ImportModal.tsx`      | File import dialog with CSV preview, drag-and-drop support                |
+| `TemplatePicker.tsx`   | Modal template picker with focus trap and card grid                       |
+| `ShareView.tsx`        | Read-only presentation view for shared decisions                          |
+
+#### Auth & Sync
+
+| File                   | Responsibility                                                            |
+| ---------------------- | ------------------------------------------------------------------------- |
+| `AuthButton.tsx`       | Sign in/out dropdown with GitHub and Google OAuth providers               |
+| `SyncStatus.tsx`       | Cloud sync status indicator with manual retry                             |
+| `MigrationBanner.tsx`  | One-time localStorage → cloud migration prompt                            |
+
+#### UX & Onboarding
+
+| File                        | Responsibility                                                       |
+| --------------------------- | -------------------------------------------------------------------- |
+| `CoachmarkOverlay.tsx`      | 3-step onboarding tour with positioned tooltips and focus trap       |
+| `KeyboardShortcutsModal.tsx`| Modal displaying global keyboard shortcuts with focus trap           |
+| `MobileOverflowMenu.tsx`   | Kebab-triggered dropdown for header actions on narrow viewports      |
+| `LanguageSwitcher.tsx`      | Locale-switching dropdown (en/es/fr) persisted to localStorage       |
+
+### `/src/hooks/` — Custom React Hooks (6 files)
+
+| File                      | Responsibility                                                         |
+| ------------------------- | ---------------------------------------------------------------------- |
+| `useValidation.ts`        | Memoized real-time validation — errors, warnings, infos for inline UI  |
+| `useAuth.ts`              | Supabase auth state — user, session, sign in/out, loading              |
+| `useSync.ts`              | Cloud sync status — auto-sync on mount/focus, manual trigger           |
+| `useBiasDetection.ts`     | Debounced (500ms) bias detection with per-type dismissal management    |
+| `useMonteCarloWorker.ts`  | Runs Monte Carlo in a Web Worker with progress, cancellation, fallback |
+| `useOnboarding.ts`        | Onboarding state machine (idle → step1–3), auto-triggers on first visit |
+
+### `/src/workers/` — Web Workers (1 file)
+
+| File                         | Responsibility                                                     |
+| ---------------------------- | ------------------------------------------------------------------ |
+| `monte-carlo.worker.ts`     | Off-main-thread Monte Carlo simulation via typed message protocol  |
 
 ### `/src/app/` — Next.js App Router
 
-| File             | Responsibility                                                |
-| ---------------- | ------------------------------------------------------------- |
-| `layout.tsx`     | Root layout with metadata, fonts, FOUC-prevention script      |
-| `page.tsx`       | Main page with tab navigation, keyboard shortcuts             |
-| `share/page.tsx` | Read-only share route — decodes and displays shared decisions |
-| `manifest.ts`    | PWA web app manifest (name, icons, theme)                     |
-| `sitemap.ts`     | Dynamic sitemap generation for SEO                            |
-| `globals.css`    | Tailwind imports and CSS variables                            |
+| File             | Responsibility                                                         |
+| ---------------- | ---------------------------------------------------------------------- |
+| `layout.tsx`     | Root layout with metadata, fonts, FOUC-prevention script               |
+| `page.tsx`       | Main page with tab navigation, keyboard shortcuts, conditional tab rendering |
+| `not-found.tsx`  | Custom 404 page                                                        |
+| `share/page.tsx` | Read-only share route — decodes and displays shared decisions          |
+| `manifest.ts`    | PWA web app manifest (name, icons, theme)                              |
+| `sitemap.ts`     | Dynamic sitemap generation for SEO                                     |
+| `globals.css`    | Tailwind imports and CSS variables                                     |
+
+### `/src/lib/i18n/` — Localization Data
+
+| File        | Responsibility       |
+| ----------- | -------------------- |
+| `en.json`   | English translations  |
+| `es.json`   | Spanish translations  |
+| `fr.json`   | French translations   |
 
 ## Design Decisions
 
 1. **Local-first with optional cloud**: All state in localStorage by default. When Supabase env vars are set, auth + cloud sync activate. Saves always go to localStorage first (instant), then to cloud (async, best-effort). See ADR-002.
 
-2. **Pure scoring engine**: All scoring functions are pure (no side effects). This makes them easy to test and reason about.
+2. **Pure scoring engine**: All scoring functions are pure (no side effects). This makes them easy to test and reason about. The WSM `scoreOption()` uses a single-pass loop to eliminate redundant iterations.
 
-3. **React Context over Redux**: For an app this size, Context + `useState` is simpler and sufficient. No unnecessary abstractions.
+3. **Focused Contexts over monolithic Context**: State is split into 4 focused contexts (`DecisionDataCtx`, `ResultsCtx`, `ActionsCtx`, `DecisionDispatchContext`) to prevent unnecessary re-renders. A backward-compatible `DecisionContext` combines all for legacy consumers. Components import only the context they need via `useDecisionData()`, `useResultsContext()`, `useActions()`, or `useDecisionDispatch()`.
 
-4. **Recharts for visualization**: Score comparison uses Recharts bar charts. Lazy-loaded via `React.lazy` + `Suspense` to keep initial bundle small. Adds ~45KB gzipped but provides responsive, accessible charts with minimal custom code.
+4. **useReducer + pure reducer**: Decision state mutations flow through `decision-reducer.ts` — a pure reducer with typed action discriminated unions. Undo/redo coalescing middleware wraps the core reducer. 50-entry history stack via `useRef`.
 
-5. **Single-page app**: All functionality on one page with tabs. Reduces complexity and keeps the UX focused.
+5. **Recharts for visualization**: Score charts and Pareto plots use Recharts. Lazy-loaded via `React.lazy` + `Suspense` to keep initial bundle small.
 
-6. **Security headers**: HTTP security headers (HSTS, X-Frame-Options, CSP, etc.) configured in `next.config.ts`.
+6. **Conditional tab rendering**: Only the active tab's component mounts (DecisionBuilder is always-mounted). Inactive tabs render a skeleton `<output>` placeholder. This eliminates thousands of unnecessary DOM nodes.
 
-7. **Dark mode**: System-preference-aware with localStorage persistence. FOUC prevented via inline `<script>` in layout.
+7. **Single-page app**: All functionality on one page with 7 tabs (Builder, Results, Sensitivity, Compare, Monte Carlo, Pareto, Quality). Keyboard shortcuts 1–7 switch tabs.
 
-8. **Inline validation**: `useValidation` hook provides memoized real-time feedback (errors, warnings, infos) without blocking save. Builder shows inline borders/messages; Results tab shows a guard for critical errors and a warning banner for non-blocking issues.
+8. **Security headers**: HTTP security headers (HSTS, X-Frame-Options, CSP, etc.) configured in `next.config.ts`.
 
-9. **Undo/Redo**: 50-entry history stack using `useRef` (avoids unnecessary re-renders). All mutation functions call `pushUndo()` before state update. `clearHistory()` resets on decision switch. Keyboard shortcuts (Ctrl+Z, Ctrl+Shift+Z) work even inside inputs.
+9. **Dark mode**: System-preference-aware with localStorage persistence. FOUC prevented via inline `<script>` in layout.
 
-10. **Templates**: Pre-built decision templates defined statically in `src/lib/templates.ts`. `instantiateTemplate()` generates fresh IDs and zero scores. Template picker modal uses focus trap and accessible dialog pattern.
+10. **Inline validation**: `useValidation` hook provides memoized real-time feedback. Builder shows inline borders/messages; Results tab shows a guard for critical errors.
+
+11. **Templates**: Pre-built decision templates defined statically in `src/lib/templates.ts`. `instantiateTemplate()` generates fresh IDs and zero scores.
+
+12. **Web Worker for Monte Carlo**: Heavy simulation runs off-main-thread via `monte-carlo.worker.ts`. The `useMonteCarloWorker` hook manages the lifecycle with progress tracking and cancellation. Falls back to main thread when Workers are unavailable.
+
+13. **Multi-algorithm consensus**: Beyond WSM, the app runs TOPSIS and Minimax Regret in parallel, then unifies rankings via Borda count. Kendall's W measures concordance across algorithms.
+
+14. **3-tier data enrichment**: The enrichment engine tries live providers first, falls back to bundled datasets, then to estimation via income-group/regional proxies. All enriched scores carry provenance and confidence metadata.
+
+15. **i18n**: React context-based i18n with `useTranslation()` hook. Locale files in `src/lib/i18n/` (en, es, fr). Persisted to localStorage via `LanguageSwitcher`.
 
 ## Data Flow
 
 ```
-User Input → DecisionProvider → Scoring Engine → Results
+User Input → DecisionProvider (useReducer) → decision-reducer.ts
+                    │
+          ┌─────────┼──────────────────────────────────┐
+          ▼         ▼                                  ▼
+    Scoring    TOPSIS/AHP/Regret              Bias Detection
+    Engine     Consensus Engine               Pattern Recognition
+          │         │                                  │
+          └─────────┼──────────────────────────────────┘
+                    ▼
+              ResultsCtx → UI Components
                     │
                     ▼
               localStorage (auto-save, 300ms debounce)
@@ -128,8 +300,14 @@ User Input → DecisionProvider → Scoring Engine → Results
               Supabase Cloud (async, best-effort)
 ```
 
+## Testing
+
+- **Unit tests**: 1502 tests across 84 files (Vitest + React Testing Library)
+- **E2E tests**: 43 tests across 5 specs (Playwright — smoke, accessibility, visual, workflows, features)
+- **Coverage**: V8 provider with enforced thresholds per `vitest.config.ts`
+
 ## Future Architecture
 
-- **Web Workers**: Move scoring to a worker for large decisions
 - **Real-time collaboration**: Supabase Realtime for live multi-user editing
 - **Team workspaces**: Shared decision collections with role-based access
+- **Shareable decision links**: Server-stored decisions for persistent sharing


### PR DESCRIPTION
## Summary
Comprehensive update of both primary documentation files to reflect the v1.0.0 codebase state.

## ARCHITECTURE.md Changes
- **+21 lib modules**: ahp, bias-detection, completeness, composite-confidence, consensus, decision-quality, decision-reducer, journal, outcome-tracking, pareto, patterns, provenance, rate-limiter, regret, sanitize, topsis, + data enrichment subsystem (engine, estimation, provider, registry, datasets, providers)
- **+31 components**: AHPWizard, BiasWarnings, CoachmarkOverlay, CompletionRing, CompositeConfidenceIndicator, ConfidenceDot, ConfidenceIndicator, ConfidenceStrategySelector, CriterionTooltip, EnrichmentSuggest, FrameworkComparison, HybridResults, KeyboardShortcutsModal, LanguageSwitcher, MobileOverflowMenu, MobileScoreCards, OutcomeTracker, ParetoChart, PatternInsights, QualityBar, ReasoningPopover, RetrospectiveView, ScoreProvenanceIndicator, ScoreSlider, ScoringPrompt, ServiceWorkerRegistrar, SortableItem, TabErrorFallback, WeightDistributionBar, WeightSlider, WhatIfPanel
- **+3 hooks**: useBiasDetection, useMonteCarloWorker, useOnboarding
- **+1 worker**: monte-carlo.worker.ts
- **+1 directory**: i18n locale files
- Updated high-level diagram for focused contexts, reducer, and Web Worker
- Updated design decisions (15 items reflecting v1.0.0 patterns)
- Updated test section (1502 unit tests, 43 E2E, 84 test files)

## copilot-instructions.md Changes
- Updated project overview to mention all features
- Updated tech stack (React 19, @dnd-kit)
- Complete project structure listing all 50 components, 6 hooks, 37 lib modules
- Updated state management rule for focused contexts + useReducer
- Added 3 new rules: i18n (#14), MCDA algorithms (#15), data enrichment (#16)
- Fixed duplicate checklist items
- Updated test counts (281 → 1502+)

## Stats
435 insertions, 143 deletions across 2 files.

Closes #206