### PR TITLE
a11y: focus trap, focus restore, touch target (N1/N2/N4)

### DIFF
--- a/docs/A11Y_AUDIT.md
+++ b/docs/A11Y_AUDIT.md
@@ -208,13 +208,13 @@ This universally disables all CSS animations and transitions when the user's sys
 
 ## Noted Items (Future Improvements)
 
-| # | Item | Severity | WCAG |
-|---|------|----------|------|
-| N1 | WhatIfPanel missing focus trap | Low | 2.4.3 |
-| N2 | ImportModal/TemplatePicker missing focus restore | Low | 2.4.3 |
-| N3 | Option/criterion inputs missing `aria-invalid` | Low | 3.3.1 |
-| N4 | ConfidenceDot touch target below 24px | Low | 2.5.8 |
-| N5 | Remaining `text-gray-400` on decorative elements | Info | 1.4.11 |
+| # | Item | Severity | WCAG | Status |
+|---|------|----------|------|--------|
+| N1 | WhatIfPanel missing focus trap | Low | 2.4.3 | ✅ Fixed — Tab trapping + panel focus on mount |
+| N2 | ImportModal/TemplatePicker missing focus restore | Low | 2.4.3 | ✅ Fixed — focus restored to trigger element on close |
+| N3 | Option/criterion inputs missing `aria-invalid` | Low | 3.3.1 | ✅ Fixed — `aria-invalid` on option and criterion name inputs |
+| N4 | ConfidenceDot touch target below 24px | Low | 2.5.8 | ✅ Fixed — min-w-6 min-h-6 (24px) touch target with inner dot |
+| N5 | Remaining `text-gray-400` on decorative elements | Info | 1.4.11 | Acceptable (decorative/non-text per WCAG 1.4.11) |
 
 ---
 

--- a/src/components/ConfidenceDot.tsx
+++ b/src/components/ConfidenceDot.tsx
@@ -42,9 +42,11 @@ export function ConfidenceDot({ confidence, onChange, size = "sm" }: ConfidenceD
     <button
       type="button"
       onClick={() => onChange(next)}
-      className={`inline-flex items-center justify-center rounded-full ${dotSize} ${CONF_COLORS[confidence]} ring-1 ring-inset ring-black/10 dark:ring-white/20 cursor-pointer hover:scale-125 transition-transform focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1`}
+      className="inline-flex items-center justify-center rounded-full min-w-6 min-h-6 cursor-pointer hover:scale-125 transition-transform focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1"
       aria-label={`${CONF_LABELS[confidence]} — click to change to ${CONF_LABELS[next].toLowerCase()}`}
       title={CONF_LABELS[confidence]}
-    />
+    >
+      <span className={`block rounded-full ${dotSize} ${CONF_COLORS[confidence]} ring-1 ring-inset ring-black/10 dark:ring-white/20`} />
+    </button>
   );
 }

--- a/src/components/ImportModal.tsx
+++ b/src/components/ImportModal.tsx
@@ -42,15 +42,23 @@ export const ImportModal = memo(function ImportModal({ onClose }: ImportModalPro
   const fileInputRef = useRef<HTMLInputElement>(null);
   const modalRef = useRef<HTMLDivElement>(null);
   const dragCounter = useRef(0);
+  const triggerRef = useRef<Element | null>(null);
 
   // Focus trap & Escape key
   useEffect(() => {
+    triggerRef.current = document.activeElement;
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
     };
     document.addEventListener("keydown", handleKeyDown);
     modalRef.current?.focus();
-    return () => document.removeEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      // Restore focus to the element that opened the modal
+      if (triggerRef.current instanceof HTMLElement) {
+        triggerRef.current.focus();
+      }
+    };
   }, [onClose]);
 
   const processFile = useCallback(

--- a/src/components/TemplatePicker.tsx
+++ b/src/components/TemplatePicker.tsx
@@ -21,9 +21,11 @@ interface TemplatePickerProps {
 
 export function TemplatePicker({ onSelect, onClose }: TemplatePickerProps) {
   const modalRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<Element | null>(null);
 
   // Focus trap and Escape handling
   useEffect(() => {
+    triggerRef.current = document.activeElement;
     const modal = modalRef.current;
     if (!modal) return;
 
@@ -55,7 +57,13 @@ export function TemplatePicker({ onSelect, onClose }: TemplatePickerProps) {
     };
 
     document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      // Restore focus to the element that opened the modal
+      if (triggerRef.current instanceof HTMLElement) {
+        triggerRef.current.focus();
+      }
+    };
   }, [onClose]);
 
   return (

--- a/src/components/WhatIfPanel.tsx
+++ b/src/components/WhatIfPanel.tsx
@@ -146,12 +146,33 @@ export function WhatIfPanel({ decision, originalResults, onApply, onClose }: Wha
     return map;
   }, [originalResults]);
 
-  // ── Keyboard: Escape closes ─────────────────────────────
+  // ── Keyboard: Escape closes + focus trap ─────────────
   useEffect(() => {
+    const panel = panelRef.current;
     function handleKey(e: KeyboardEvent) {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (e.key === "Tab" && panel) {
+        const focusable = panel.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        );
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
     }
     document.addEventListener("keydown", handleKey);
+    // Focus the panel on mount
+    panel?.focus();
     return () => document.removeEventListener("keydown", handleKey);
   }, [onClose]);
 
@@ -193,7 +214,8 @@ export function WhatIfPanel({ decision, originalResults, onApply, onClose }: Wha
     >
       <div
         ref={panelRef}
-        className="bg-white dark:bg-gray-800 rounded-lg shadow-xl border border-gray-200 dark:border-gray-700 max-w-4xl w-full mx-4 max-h-[85vh] flex flex-col"
+        tabIndex={-1}
+        className="bg-white dark:bg-gray-800 rounded-lg shadow-xl border border-gray-200 dark:border-gray-700 max-w-4xl w-full mx-4 max-h-[85vh] flex flex-col outline-none"
         onClick={(e) => e.stopPropagation()}
       >
         {/* ── Header ─────────────────────────────────────── */}


### PR DESCRIPTION
## Summary
Resolves all 4 actionable items from the A11Y audit (N1–N4). N3 was already fixed in a prior PR; N5 is Info-level and acceptable per WCAG 1.4.11.

## Changes

### N1: WhatIfPanel focus trap (WCAG 2.4.3)
- Added Tab key trapping that cycles focus within the panel
- Panel receives focus on mount via `tabIndex={-1}` + `panel.focus()`
- Escape key handler preserved

### N2: Focus restore on modal close (WCAG 2.4.3)
- **ImportModal**: Captures `document.activeElement` on mount, restores focus to it in useEffect cleanup
- **TemplatePicker**: Same pattern — saves trigger element on mount, restores on unmount

### N4: ConfidenceDot touch target (WCAG 2.5.8)
- Button now has `min-w-6 min-h-6` (24px) touch target
- Visual dot rendered as inner `<span>` to maintain small appearance
- Touch target meets WCAG 2.5.8 minimum of 24×24px

### Audit doc update
- A11Y_AUDIT.md: All 5 noted items now have a Status column; N1–N4 marked ✅ Fixed

## Verification
- ✅ 1502/1502 unit tests pass

Closes #208