### PR TITLE
test: add tests for TemplatePicker, MigrationBanner, SyncStatus, SortableItem (#218)

### DIFF
--- a/src/__tests__/components/MigrationBanner.test.tsx
+++ b/src/__tests__/components/MigrationBanner.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * Tests for MigrationBanner component.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MigrationBanner } from "@/components/MigrationBanner";
+
+/* ---------- mocks ---------- */
+const mockIsCloudEnabled = vi.fn(() => true);
+const mockHasMigrated = vi.fn(() => false);
+const mockGetDecisions = vi.fn(() => [
+  { id: "d1", title: "Decision A", options: [], criteria: [], scores: {} },
+  { id: "d2", title: "Decision B", options: [], criteria: [], scores: {} },
+]);
+const mockCloudSaveAll = vi.fn(async () => true);
+
+vi.mock("@/lib/supabase", () => ({
+  isCloudEnabled: () => mockIsCloudEnabled(),
+}));
+
+vi.mock("@/lib/sync", () => ({
+  hasMigrated: () => mockHasMigrated(),
+}));
+
+vi.mock("@/lib/storage", () => ({
+  getDecisions: () => mockGetDecisions(),
+}));
+
+vi.mock("@/lib/cloud-storage", () => ({
+  cloudSaveAllDecisions: (...args: unknown[]) => mockCloudSaveAll(...args),
+}));
+
+describe("MigrationBanner", () => {
+  const onComplete = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsCloudEnabled.mockReturnValue(true);
+    mockHasMigrated.mockReturnValue(false);
+    mockGetDecisions.mockReturnValue([
+      { id: "d1", title: "A", options: [], criteria: [], scores: {} },
+      { id: "d2", title: "B", options: [], criteria: [], scores: {} },
+    ]);
+    mockCloudSaveAll.mockResolvedValue(true);
+    localStorage.clear();
+  });
+
+  it("returns null when cloud is not enabled", () => {
+    mockIsCloudEnabled.mockReturnValue(false);
+    const { container } = render(
+      <MigrationBanner isAuthenticated={true} onComplete={onComplete} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("returns null when user is not authenticated", () => {
+    const { container } = render(
+      <MigrationBanner isAuthenticated={false} onComplete={onComplete} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("returns null when already migrated", () => {
+    mockHasMigrated.mockReturnValue(true);
+    const { container } = render(
+      <MigrationBanner isAuthenticated={true} onComplete={onComplete} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("returns null when no local decisions exist", () => {
+    mockGetDecisions.mockReturnValue([]);
+    const { container } = render(
+      <MigrationBanner isAuthenticated={true} onComplete={onComplete} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("shows the banner with local decision count", () => {
+    render(<MigrationBanner isAuthenticated={true} onComplete={onComplete} />);
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText(/decisions saved locally/i)).toBeInTheDocument();
+    expect(screen.getByText("Upload Now")).toBeInTheDocument();
+  });
+
+  it("calls cloudSaveAllDecisions and onComplete on upload", async () => {
+    const user = userEvent.setup();
+    render(<MigrationBanner isAuthenticated={true} onComplete={onComplete} />);
+    await user.click(screen.getByText("Upload Now"));
+
+    await waitFor(() => {
+      expect(mockCloudSaveAll).toHaveBeenCalled();
+      expect(onComplete).toHaveBeenCalled();
+    });
+  });
+
+  it("shows error message when migration fails", async () => {
+    mockCloudSaveAll.mockResolvedValue(false);
+    const user = userEvent.setup();
+    render(<MigrationBanner isAuthenticated={true} onComplete={onComplete} />);
+    await user.click(screen.getByText("Upload Now"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Migration failed. Please try again.")).toBeInTheDocument();
+    });
+  });
+
+  it("shows error message on exception", async () => {
+    mockCloudSaveAll.mockRejectedValue(new Error("network"));
+    const user = userEvent.setup();
+    render(<MigrationBanner isAuthenticated={true} onComplete={onComplete} />);
+    await user.click(screen.getByText("Upload Now"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Migration failed. Please try again.")).toBeInTheDocument();
+    });
+  });
+
+  it("dismisses the banner when X button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<MigrationBanner isAuthenticated={true} onComplete={onComplete} />);
+    expect(screen.getByText("Upload Now")).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Dismiss migration banner"));
+    expect(screen.queryByText("Upload Now")).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/SortableItem.test.tsx
+++ b/src/__tests__/components/SortableItem.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Tests for SortableItem component.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SortableItem } from "@/components/SortableItem";
+
+/* ---------- mocks ---------- */
+const mockUseSortable = vi.fn();
+
+vi.mock("@dnd-kit/sortable", () => ({
+  useSortable: (...args: unknown[]) => mockUseSortable(...args),
+}));
+
+vi.mock("@dnd-kit/utilities", () => ({
+  CSS: {
+    Transform: {
+      toString: (t: unknown) => (t ? `translate(${(t as { x: number }).x}px, ${(t as { y: number }).y}px)` : undefined),
+    },
+  },
+}));
+
+function defaultSortable(overrides = {}) {
+  return {
+    attributes: { role: "button", tabIndex: 0 },
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+    ...overrides,
+  };
+}
+
+describe("SortableItem", () => {
+  beforeEach(() => {
+    mockUseSortable.mockReturnValue(defaultSortable());
+  });
+
+  it("renders children inside the wrapper", () => {
+    render(
+      <SortableItem id="item-1">
+        <span>Test child</span>
+      </SortableItem>,
+    );
+    expect(screen.getByText("Test child")).toBeInTheDocument();
+  });
+
+  it("renders drag handle with default aria-label", () => {
+    render(
+      <SortableItem id="item-1">
+        <span>Content</span>
+      </SortableItem>,
+    );
+    expect(screen.getByLabelText("Drag to reorder")).toBeInTheDocument();
+  });
+
+  it("accepts a custom dragLabel", () => {
+    render(
+      <SortableItem id="item-1" dragLabel="Move criterion">
+        <span>Content</span>
+      </SortableItem>,
+    );
+    expect(screen.getByLabelText("Move criterion")).toBeInTheDocument();
+  });
+
+  it("has aria-roledescription sortable on the handle", () => {
+    render(
+      <SortableItem id="item-1">
+        <span>Content</span>
+      </SortableItem>,
+    );
+    const handle = screen.getByLabelText("Drag to reorder");
+    expect(handle).toHaveAttribute("aria-roledescription", "sortable");
+  });
+
+  it("passes the id to useSortable", () => {
+    render(
+      <SortableItem id="criterion-42">
+        <span>X</span>
+      </SortableItem>,
+    );
+    expect(mockUseSortable).toHaveBeenCalledWith({ id: "criterion-42" });
+  });
+
+  it("applies isDragging visual classes when dragging", () => {
+    mockUseSortable.mockReturnValue(defaultSortable({ isDragging: true }));
+    const { container } = render(
+      <SortableItem id="item-1">
+        <span>Dragging</span>
+      </SortableItem>,
+    );
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.className).toContain("z-10");
+    expect(wrapper.className).toContain("opacity-60");
+    expect(wrapper.className).toContain("shadow-lg");
+  });
+
+  it("does not apply isDragging classes when not dragging", () => {
+    const { container } = render(
+      <SortableItem id="item-1">
+        <span>Static</span>
+      </SortableItem>,
+    );
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.className).not.toContain("opacity-60");
+  });
+});

--- a/src/__tests__/components/SyncStatus.test.tsx
+++ b/src/__tests__/components/SyncStatus.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * Tests for SyncStatus component.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SyncStatus } from "@/components/SyncStatus";
+import type { UseSyncReturn } from "@/hooks/useSync";
+
+/* ---------- mocks ---------- */
+const mockIsCloudEnabled = vi.fn(() => true);
+vi.mock("@/lib/supabase", () => ({
+  isCloudEnabled: () => mockIsCloudEnabled(),
+}));
+
+function makeSyncProp(overrides: Partial<UseSyncReturn> = {}): UseSyncReturn {
+  return {
+    status: "idle",
+    lastResult: null,
+    triggerSync: vi.fn(),
+    isSyncing: false,
+    ...overrides,
+  };
+}
+
+describe("SyncStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsCloudEnabled.mockReturnValue(true);
+  });
+
+  it("returns null when cloud is not enabled", () => {
+    mockIsCloudEnabled.mockReturnValue(false);
+    const { container } = render(
+      <SyncStatus sync={makeSyncProp()} isAuthenticated={true} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("returns null when not authenticated", () => {
+    const { container } = render(
+      <SyncStatus sync={makeSyncProp()} isAuthenticated={false} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("shows idle status label", () => {
+    render(<SyncStatus sync={makeSyncProp({ status: "idle" })} isAuthenticated={true} />);
+    expect(screen.getByLabelText("Cloud sync ready")).toBeInTheDocument();
+  });
+
+  it("shows syncing state", () => {
+    render(
+      <SyncStatus
+        sync={makeSyncProp({ status: "syncing", isSyncing: true })}
+        isAuthenticated={true}
+      />,
+    );
+    expect(screen.getByLabelText("Syncing…")).toBeInTheDocument();
+  });
+
+  it("shows done status", () => {
+    render(
+      <SyncStatus
+        sync={makeSyncProp({
+          status: "done",
+          lastResult: { uploaded: 2, downloaded: 1, error: null },
+        })}
+        isAuthenticated={true}
+      />,
+    );
+    expect(screen.getByText("Synced")).toBeInTheDocument();
+  });
+
+  it("shows error with retry button", () => {
+    render(
+      <SyncStatus
+        sync={makeSyncProp({ status: "error" })}
+        isAuthenticated={true}
+      />,
+    );
+    expect(screen.getByLabelText("Retry sync")).toBeInTheDocument();
+    expect(screen.getByLabelText("Sync error")).toBeInTheDocument();
+  });
+
+  it("calls triggerSync on button click", async () => {
+    const triggerSync = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <SyncStatus
+        sync={makeSyncProp({ status: "idle", triggerSync })}
+        isAuthenticated={true}
+      />,
+    );
+    await user.click(screen.getByLabelText("Cloud sync ready"));
+    expect(triggerSync).toHaveBeenCalled();
+  });
+
+  it("shows tooltip with upload/download counts when lastResult exists", () => {
+    render(
+      <SyncStatus
+        sync={makeSyncProp({
+          status: "done",
+          lastResult: { uploaded: 3, downloaded: 5, error: null },
+        })}
+        isAuthenticated={true}
+      />,
+    );
+    const btn = screen.getByLabelText(/Synced — ↑3 ↓5/);
+    expect(btn).toBeInTheDocument();
+  });
+
+  it("shows offline status", () => {
+    render(
+      <SyncStatus
+        sync={makeSyncProp({ status: "offline" })}
+        isAuthenticated={true}
+      />,
+    );
+    expect(screen.getByLabelText("Offline")).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/TemplatePicker.test.tsx
+++ b/src/__tests__/components/TemplatePicker.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * Tests for TemplatePicker modal component.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TemplatePicker } from "@/components/TemplatePicker";
+import { TEMPLATES } from "@/lib/templates";
+
+describe("TemplatePicker", () => {
+  const onSelect = vi.fn();
+  const onClose = vi.fn();
+
+  function renderPicker() {
+    return render(<TemplatePicker onSelect={onSelect} onClose={onClose} />);
+  }
+
+  it("renders as a dialog with proper ARIA attributes", () => {
+    renderPicker();
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAttribute("aria-label", "Choose a decision template");
+  });
+
+  it("renders the heading", () => {
+    renderPicker();
+    expect(screen.getByText("Start from Template")).toBeInTheDocument();
+  });
+
+  it("renders a card for each template in TEMPLATES", () => {
+    renderPicker();
+    for (const t of TEMPLATES) {
+      expect(screen.getByText(t.name)).toBeInTheDocument();
+    }
+  });
+
+  it("shows template description text", () => {
+    renderPicker();
+    for (const t of TEMPLATES) {
+      expect(screen.getByText(t.description)).toBeInTheDocument();
+    }
+  });
+
+  it("shows criteria and options count for each template", () => {
+    renderPicker();
+    // Multiple templates may share the same count string, so use getAllByText
+    const countTexts = TEMPLATES.map(
+      (t) => `${t.criteria.length} criteria · ${t.options.length} options`,
+    );
+    const unique = [...new Set(countTexts)];
+    for (const label of unique) {
+      const expected = countTexts.filter((c) => c === label).length;
+      expect(screen.getAllByText(label)).toHaveLength(expected);
+    }
+  });
+
+  it("calls onSelect when a template card is clicked", async () => {
+    renderPicker();
+    const user = userEvent.setup();
+    const firstCard = screen.getByText(TEMPLATES[0].name);
+    await user.click(firstCard);
+    expect(onSelect).toHaveBeenCalledWith(TEMPLATES[0]);
+  });
+
+  it("calls onClose when close button is clicked", async () => {
+    renderPicker();
+    const user = userEvent.setup();
+    const closeBtn = screen.getByLabelText("Close template picker");
+    await user.click(closeBtn);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("calls onClose when backdrop is clicked", () => {
+    renderPicker();
+    const backdrop = screen.getByRole("dialog");
+    fireEvent.click(backdrop);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("does not call onClose when content area is clicked", () => {
+    renderPicker();
+    onClose.mockClear();
+    const heading = screen.getByText("Start from Template");
+    fireEvent.click(heading);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("calls onClose on Escape key", () => {
+    renderPicker();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds comprehensive unit tests for 4 previously untested components, closing the largest remaining coverage gaps.

### New test files (35 tests total)

| Component | Tests | Coverage highlights |
|---|---|---|
| **TemplatePicker** | 10 | Dialog ARIA, template grid rendering, onSelect, close/backdrop/Escape |
| **MigrationBanner** | 9 | Guard conditions (cloud/auth/migrated/empty), upload flow, error + exception handling, dismiss |
| **SyncStatus** | 9 | Cloud guards, all 5 status states (idle/syncing/done/error/offline), triggerSync, tooltip with counts |
| **SortableItem** | 7 | Children rendering, drag handle ARIA, custom dragLabel, isDragging visual classes |

### Verification

- **95/95** test files pass
- **1618/1618** tests pass (up from 1583)
- No regressions

Closes #218