### PR TITLE
test: add tests for AuthButton and ParetoChart (#220)

### DIFF
--- a/src/__tests__/components/AuthButton.test.tsx
+++ b/src/__tests__/components/AuthButton.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * Tests for AuthButton component.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AuthButton } from "@/components/AuthButton";
+import type { AuthState } from "@/hooks/useAuth";
+import type { User } from "@supabase/supabase-js";
+
+function makeAuth(overrides: Partial<AuthState> = {}): AuthState {
+  return {
+    user: null,
+    session: null,
+    loading: false,
+    cloudEnabled: true,
+    error: null,
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: "u1",
+    email: "alice@example.com",
+    app_metadata: {},
+    user_metadata: { full_name: "Alice Smith", avatar_url: "https://example.com/avatar.png" },
+    aud: "authenticated",
+    created_at: new Date().toISOString(),
+    ...overrides,
+  } as User;
+}
+
+describe("AuthButton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /* ── Guard: local-only mode ─────────────────────────── */
+  it("renders nothing when cloudEnabled is false", () => {
+    const { container } = render(<AuthButton auth={makeAuth({ cloudEnabled: false })} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  /* ── Loading state ──────────────────────────────────── */
+  it("shows loading skeleton when loading", () => {
+    const { container } = render(<AuthButton auth={makeAuth({ loading: true })} />);
+    const skeleton = container.querySelector(".animate-pulse");
+    expect(skeleton).toBeInTheDocument();
+  });
+
+  /* ── Signed-in state ────────────────────────────────── */
+  it("shows user display name and avatar when signed in", () => {
+    render(<AuthButton auth={makeAuth({ user: makeUser() })} />);
+    expect(screen.getByText("Alice Smith")).toBeInTheDocument();
+    // alt="" gives the img role="presentation", so query by presentation role
+    const avatar = screen.getByRole("presentation");
+    expect(avatar).toHaveAttribute("src", "https://example.com/avatar.png");
+  });
+
+  it("shows initial letter fallback when no avatar_url", () => {
+    const user = makeUser({ user_metadata: { full_name: "Bob" } });
+    render(<AuthButton auth={makeAuth({ user })} />);
+    expect(screen.getByText("B")).toBeInTheDocument();
+  });
+
+  it("falls back to email prefix when no full_name", () => {
+    const user = makeUser({ user_metadata: {}, email: "charlie@example.com" });
+    render(<AuthButton auth={makeAuth({ user })} />);
+    expect(screen.getByText("charlie")).toBeInTheDocument();
+  });
+
+  it("calls signOut when Sign Out is clicked", async () => {
+    const signOut = vi.fn();
+    const user = userEvent.setup();
+    render(<AuthButton auth={makeAuth({ user: makeUser(), signOut })} />);
+    await user.click(screen.getByLabelText("Sign out"));
+    expect(signOut).toHaveBeenCalled();
+  });
+
+  /* ── Signed-out state (dropdown) ────────────────────── */
+  it("shows Sign In button when signed out", () => {
+    render(<AuthButton auth={makeAuth()} />);
+    expect(screen.getByLabelText("Sign in")).toBeInTheDocument();
+  });
+
+  it("opens dropdown with auth providers on click", async () => {
+    const user = userEvent.setup();
+    render(<AuthButton auth={makeAuth()} />);
+    await user.click(screen.getByLabelText("Sign in"));
+    expect(screen.getByText("Continue with GitHub")).toBeInTheDocument();
+    expect(screen.getByText("Continue with Google")).toBeInTheDocument();
+  });
+
+  it("calls signIn('github') when GitHub option is clicked", async () => {
+    const signIn = vi.fn();
+    const user = userEvent.setup();
+    render(<AuthButton auth={makeAuth({ signIn })} />);
+    await user.click(screen.getByLabelText("Sign in"));
+    await user.click(screen.getByText("Continue with GitHub"));
+    expect(signIn).toHaveBeenCalledWith("github");
+  });
+
+  it("calls signIn('google') when Google option is clicked", async () => {
+    const signIn = vi.fn();
+    const user = userEvent.setup();
+    render(<AuthButton auth={makeAuth({ signIn })} />);
+    await user.click(screen.getByLabelText("Sign in"));
+    await user.click(screen.getByText("Continue with Google"));
+    expect(signIn).toHaveBeenCalledWith("google");
+  });
+
+  it("closes dropdown on Escape key", async () => {
+    const user = userEvent.setup();
+    render(<AuthButton auth={makeAuth()} />);
+    await user.click(screen.getByLabelText("Sign in"));
+    expect(screen.getByText("Continue with GitHub")).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByText("Continue with GitHub")).not.toBeInTheDocument();
+    });
+  });
+
+  it("closes dropdown on outside click", async () => {
+    const user = userEvent.setup();
+    render(
+      <div>
+        <div data-testid="outside">Outside</div>
+        <AuthButton auth={makeAuth()} />
+      </div>,
+    );
+    await user.click(screen.getByLabelText("Sign in"));
+    expect(screen.getByText("Continue with GitHub")).toBeInTheDocument();
+    fireEvent.mouseDown(screen.getByTestId("outside"));
+    await waitFor(() => {
+      expect(screen.queryByText("Continue with GitHub")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows error message in dropdown when error is set", async () => {
+    const user = userEvent.setup();
+    render(<AuthButton auth={makeAuth({ error: "Auth failed" })} />);
+    await user.click(screen.getByLabelText("Sign in"));
+    expect(screen.getByText("Auth failed")).toBeInTheDocument();
+  });
+
+  it("sets aria-expanded correctly on Sign In button", async () => {
+    const user = userEvent.setup();
+    render(<AuthButton auth={makeAuth()} />);
+    const btn = screen.getByLabelText("Sign in");
+    expect(btn).toHaveAttribute("aria-expanded", "false");
+    await user.click(btn);
+    expect(btn).toHaveAttribute("aria-expanded", "true");
+  });
+});

--- a/src/__tests__/components/ParetoChart.test.tsx
+++ b/src/__tests__/components/ParetoChart.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * Tests for ParetoChart component.
+ *
+ * Recharts components are mocked to avoid SVG rendering complexity in jsdom.
+ * Tests focus on logic: guard states, axis selectors, same-axis warning,
+ * legend text, and dominated-option insights.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { Decision, DecisionResults } from "@/lib/types";
+import type { ParetoResult } from "@/lib/pareto";
+
+/* ---------- mocks ---------- */
+const mockComputePareto = vi.fn<() => ParetoResult>();
+const mockDefaultAxes = vi.fn<() => [string, string] | null>();
+
+vi.mock("@/lib/pareto", () => ({
+  computeParetoFrontier: (...args: unknown[]) => mockComputePareto(...(args as [])),
+  defaultAxes: (...args: unknown[]) => mockDefaultAxes(...(args as [])),
+}));
+
+// Mock Recharts — render children as plain divs
+vi.mock("recharts", () => {
+  const passthrough = ({ children }: { children?: React.ReactNode }) => <div>{children}</div>;
+  return {
+    ResponsiveContainer: passthrough,
+    ComposedChart: passthrough,
+    Scatter: () => <div data-testid="scatter" />,
+    XAxis: () => null,
+    YAxis: () => null,
+    CartesianGrid: () => null,
+    Tooltip: () => null,
+    Line: () => null,
+    Cell: () => null,
+  };
+});
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+// Must import AFTER mocks are set up
+const { ParetoChart } = await import("@/components/ParetoChart");
+
+/* ---------- helpers ---------- */
+function makeDecision(
+  criteriaCount: number,
+  optionCount: number,
+): Decision {
+  return {
+    id: "d1",
+    title: "Test",
+    options: Array.from({ length: optionCount }, (_, i) => ({
+      id: `o${i}`,
+      name: `Option ${i}`,
+    })),
+    criteria: Array.from({ length: criteriaCount }, (_, i) => ({
+      id: `c${i}`,
+      name: `Criterion ${i}`,
+      weight: 5,
+      type: "benefit" as const,
+    })),
+    scores: {},
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function makeResults(optionCount: number): DecisionResults {
+  return {
+    optionResults: Array.from({ length: optionCount }, (_, i) => ({
+      optionId: `o${i}`,
+      optionName: `Option ${i}`,
+      totalScore: 8 - i,
+      normalizedScore: 1 - i * 0.1,
+      rank: i + 1,
+      criterionScores: [],
+    })),
+    bestOptionId: "o0",
+  };
+}
+
+function defaultPareto(): ParetoResult {
+  return {
+    points: [
+      { optionId: "o0", optionName: "Option 0", x: 8, y: 7, isPareto: true, dominatedBy: [] },
+      { optionId: "o1", optionName: "Option 1", x: 5, y: 4, isPareto: false, dominatedBy: ["o0"] },
+    ],
+    frontier: ["o0"],
+    dominated: ["o1"],
+    dominanceMap: { o1: ["o0"] },
+    xLabel: "Criterion 0",
+    yLabel: "Criterion 1",
+  };
+}
+
+describe("ParetoChart", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDefaultAxes.mockReturnValue(["c0", "c1"]);
+    mockComputePareto.mockReturnValue(defaultPareto());
+  });
+
+  /* ── Guards ─────────────────────────────────────────── */
+  it("shows message when fewer than 2 criteria", () => {
+    render(<ParetoChart decision={makeDecision(1, 3)} results={makeResults(3)} />);
+    expect(screen.getByText(/at least 2 criteria/i)).toBeInTheDocument();
+  });
+
+  it("shows message when fewer than 2 options", () => {
+    render(<ParetoChart decision={makeDecision(3, 1)} results={makeResults(1)} />);
+    expect(screen.getByText(/at least 2 options/i)).toBeInTheDocument();
+  });
+
+  /* ── Axis selectors ─────────────────────────────────── */
+  it("renders axis selector dropdowns with criteria names", () => {
+    render(<ParetoChart decision={makeDecision(3, 3)} results={makeResults(3)} />);
+    expect(screen.getByText("X Axis:")).toBeInTheDocument();
+    expect(screen.getByText("Y Axis:")).toBeInTheDocument();
+    // All criteria should appear in each dropdown (2 selects × 3 options)
+    const allOptions = screen.getAllByRole("option");
+    expect(allOptions.length).toBe(6); // 3 criteria × 2 selects
+  });
+
+  it("changes X axis via dropdown", () => {
+    const decision = makeDecision(3, 3);
+    render(<ParetoChart decision={decision} results={makeResults(3)} />);
+    const selects = screen.getAllByRole("combobox");
+    fireEvent.change(selects[0], { target: { value: "c2" } });
+    expect(mockComputePareto).toHaveBeenCalled();
+  });
+
+  /* ── Same axis warning ──────────────────────────────── */
+  it("shows warning when X and Y axes are the same", () => {
+    mockDefaultAxes.mockReturnValue(["c0", "c0"]);
+    render(<ParetoChart decision={makeDecision(3, 3)} results={makeResults(3)} />);
+    expect(screen.getByText(/different criteria for X and Y/i)).toBeInTheDocument();
+  });
+
+  /* ── Legend ─────────────────────────────────────────── */
+  it("renders legend with Pareto-optimal and dominated counts", () => {
+    render(<ParetoChart decision={makeDecision(3, 3)} results={makeResults(3)} />);
+    expect(screen.getByText(/Pareto-optimal \(1\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Dominated \(1\)/)).toBeInTheDocument();
+  });
+
+  /* ── Dominated insights ─────────────────────────────── */
+  it("shows dominated option insight text", () => {
+    render(<ParetoChart decision={makeDecision(3, 3)} results={makeResults(3)} />);
+    // "Option 0" appears multiple times (as dominator name, in score text, etc.)
+    expect(screen.getByText(/is dominated by/i)).toBeInTheDocument();
+    // Verify the full insight sentence is present
+    expect(screen.getByText(/scores higher on both/i)).toBeInTheDocument();
+  });
+
+  /* ── No dominated options ───────────────────────────── */
+  it("does not show dominated insights when all are Pareto-optimal", () => {
+    mockComputePareto.mockReturnValue({
+      ...defaultPareto(),
+      dominated: [],
+      dominanceMap: {},
+      points: [
+        { optionId: "o0", optionName: "Option 0", x: 8, y: 7, isPareto: true, dominatedBy: [] },
+        { optionId: "o1", optionName: "Option 1", x: 7, y: 8, isPareto: true, dominatedBy: [] },
+      ],
+      frontier: ["o0", "o1"],
+    });
+    render(<ParetoChart decision={makeDecision(3, 2)} results={makeResults(2)} />);
+    expect(screen.queryByText(/dominated by/i)).not.toBeInTheDocument();
+  });
+
+  /* ── Chart ARIA ──────────────────────────────────────── */
+  it("renders chart container with proper aria-label", () => {
+    render(<ParetoChart decision={makeDecision(3, 3)} results={makeResults(3)} />);
+    const chart = screen.getByRole("img");
+    expect(chart.getAttribute("aria-label")).toMatch(/Trade-off scatter plot/);
+    expect(chart.getAttribute("aria-label")).toMatch(/1 Pareto-optimal/);
+    expect(chart.getAttribute("aria-label")).toMatch(/1 dominated/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds comprehensive unit tests for the last 2 previously untested components, achieving **100% component test coverage** (all 50+ components now have tests).

### New test files (23 tests total)

| Component | Tests | Coverage highlights |
|---|---|---|
| **AuthButton** | 14 | Cloud guard, loading skeleton, signed-in state (avatar + initials fallback + email fallback), signed-out dropdown, GitHub/Google provider sign-in, Escape/outside-click close, error display, aria-expanded |
| **ParetoChart** | 9 | < 2 criteria/options guards, axis selector dropdowns, same-axis warning, Pareto/dominated legend with counts, dominated insights text, all-optimal case, chart ARIA label |

### Verification

- **97/97** test files pass
- **1641/1641** tests pass (up from 1618)
- No regressions

Closes #220