### PR TITLE
chore: fix test TypeScript errors + raise sub-88% branch coverage (#240)

### DIFF
--- a/src/__tests__/components/CompositeConfidence.test.tsx
+++ b/src/__tests__/components/CompositeConfidence.test.tsx
@@ -260,7 +260,7 @@ describe("computeCompositeConfidence", () => {
   it("produces low level with weak signals", () => {
     const d = lowConfidenceDecision();
     // Force very low algorithm agreement and structural quality
-    const weakConsensus = { overallAgreement: 0, rankings: {}, pairwise: [] };
+    const weakConsensus = { overallAgreement: 0, rankings: [], algorithmResults: [], divergentOptions: [], pairwiseCorrelations: [], algorithmCount: 0 };
     const weakQuality = { overallScore: 0, indicators: [], suggestions: [] };
     const result = computeCompositeConfidence(
       d,

--- a/src/__tests__/components/MigrationBanner.test.tsx
+++ b/src/__tests__/components/MigrationBanner.test.tsx
@@ -29,7 +29,7 @@ vi.mock("@/lib/storage", () => ({
 }));
 
 vi.mock("@/lib/cloud-storage", () => ({
-  cloudSaveAllDecisions: (...args: unknown[]) => mockCloudSaveAll(...args),
+  cloudSaveAllDecisions: () => mockCloudSaveAll(),
 }));
 
 describe("MigrationBanner", () => {

--- a/src/__tests__/components/ParetoChart.test.tsx
+++ b/src/__tests__/components/ParetoChart.test.tsx
@@ -62,6 +62,7 @@ function makeDecision(criteriaCount: number, optionCount: number): Decision {
 
 function makeResults(optionCount: number): DecisionResults {
   return {
+    decisionId: "test",
     optionResults: Array.from({ length: optionCount }, (_, i) => ({
       optionId: `o${i}`,
       optionName: `Option ${i}`,
@@ -70,7 +71,7 @@ function makeResults(optionCount: number): DecisionResults {
       rank: i + 1,
       criterionScores: [],
     })),
-    bestOptionId: "o0",
+    topDrivers: [],
   };
 }
 

--- a/src/__tests__/components/SortableItem.test.tsx
+++ b/src/__tests__/components/SortableItem.test.tsx
@@ -2,7 +2,7 @@
  * Tests for SortableItem component.
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { SortableItem } from "@/components/SortableItem";
 

--- a/src/__tests__/components/SyncStatus.test.tsx
+++ b/src/__tests__/components/SyncStatus.test.tsx
@@ -65,7 +65,7 @@ describe("SyncStatus", () => {
       <SyncStatus
         sync={makeSyncProp({
           status: "done",
-          lastResult: { uploaded: 2, downloaded: 1, error: null },
+          lastResult: { status: "done" as const, uploaded: 2, downloaded: 1, merged: 0 },
         })}
         isAuthenticated={true}
       />,
@@ -102,7 +102,7 @@ describe("SyncStatus", () => {
       <SyncStatus
         sync={makeSyncProp({
           status: "done",
-          lastResult: { uploaded: 3, downloaded: 5, error: null },
+          lastResult: { status: "done" as const, uploaded: 3, downloaded: 5, merged: 0 },
         })}
         isAuthenticated={true}
       />,

--- a/src/__tests__/i18n.test.tsx
+++ b/src/__tests__/i18n.test.tsx
@@ -111,6 +111,46 @@ describe("detectLocale", () => {
       configurable: true,
     });
   });
+
+  it("falls back to en when window is undefined (SSR)", () => {
+    const origWindow = globalThis.window;
+    // Simulate SSR by removing window
+    Object.defineProperty(globalThis, "window", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+    expect(detectLocale()).toBe("en");
+    // Restore
+    Object.defineProperty(globalThis, "window", {
+      value: origWindow,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("falls back to navigator.language when navigator.languages is undefined", () => {
+    globalThis.localStorage.clear();
+    const origLanguages = globalThis.navigator.languages;
+    const origLanguage = globalThis.navigator.language;
+    Object.defineProperty(globalThis.navigator, "languages", {
+      value: undefined,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis.navigator, "language", {
+      value: "es-MX",
+      configurable: true,
+    });
+    expect(detectLocale()).toBe("es");
+    Object.defineProperty(globalThis.navigator, "languages", {
+      value: origLanguages,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis.navigator, "language", {
+      value: origLanguage,
+      configurable: true,
+    });
+  });
 });
 
 // ── Translation file structure ─────────────────────────────────────
@@ -187,6 +227,11 @@ describe("useTf hook", () => {
       </Wrapper>,
     );
     expect(screen.getByTestId("tf-result").textContent).toBeTruthy();
+  });
+
+  it("returns the key itself when used outside I18nProvider", () => {
+    render(<TfConsumer translationKey="app.title" />);
+    expect(screen.getByTestId("tf-result").textContent).toBe("app.title");
   });
 });
 

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for utility functions.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { generateId, safeJsonParse, formatRelativeTime } from "@/lib/utils";
 
 describe("generateId", () => {
@@ -15,6 +15,14 @@ describe("generateId", () => {
   it("returns unique values on successive calls", () => {
     const ids = new Set(Array.from({ length: 50 }, () => generateId()));
     expect(ids.size).toBe(50);
+  });
+
+  it("falls back to timestamp+random when crypto.randomUUID is unavailable", () => {
+    const origRandomUUID = crypto.randomUUID;
+    vi.stubGlobal("crypto", { ...crypto, randomUUID: undefined });
+    const id = generateId();
+    expect(id).toMatch(/^\d+-[a-z0-9]+$/);
+    vi.stubGlobal("crypto", { ...crypto, randomUUID: origRandomUUID });
   });
 });
 


### PR DESCRIPTION
## Summary

Fix all TypeScript errors in test files and raise remaining sub-88% branch coverage files above threshold.

Closes #240

## TypeScript Fixes (6 errors → 0)

| File | Error | Fix |
|------|-------|-----|
| CompositeConfidence.test.tsx | `as ConsensusResult` missing properties | Added `algorithmResults`, `divergentOptions`, `pairwiseCorrelations`, `algorithmCount` |
| MigrationBanner.test.tsx | Spread into non-rest parameter | Changed `(...args) => fn(...args)` → `() => fn()` |
| ParetoChart.test.tsx | Stale `bestOptionId` property | Replaced with `decisionId` + `topDrivers` |
| SortableItem.test.tsx | Missing `beforeEach` import | Added to vitest imports |
| SyncStatus.test.tsx (×2) | `null` for `string \| undefined` | Used proper `SyncResult` shape with `status`, `merged` fields; removed `error: null` |

## Branch Coverage Tests (+4 tests)

- **i18n.test.tsx** (+2): SSR `window === undefined` fallback in `detectLocale`, `navigator.languages` undefined fallback to `navigator.language`
- **utils.test.ts** (+1): `generateId` fallback when `crypto.randomUUID` unavailable
- **i18n.test.tsx** (+1): `useTf` outside I18nProvider returns key as-is (context default)

## Coverage Impact

| File | Branch Before | Branch After |
|------|:---:|:---:|
| i18n.tsx | 83.33% | **91.66%** |
| utils.ts | 85.71% | **92.85%** |
| **Overall** | **92.40%** | **92.63%** |

## Results
- `npx tsc --noEmit` — **0 errors** (was 6)
- **1659 tests passing** across 97 files
- Overall: 98.07% stmts / 92.63% branches / 99.79% funcs / 99.59% lines