### PR TITLE
chore: fix React act() warnings + cover formatRelativeTime branches (#242)

### DIFF
--- a/src/__tests__/components/CriterionTooltip.test.tsx
+++ b/src/__tests__/components/CriterionTooltip.test.tsx
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { CriterionTooltip } from "@/components/CriterionTooltip";
 
@@ -45,9 +45,10 @@ describe("CriterionTooltip", () => {
     await user.tab(); // focus
     expect(screen.getByRole("tooltip")).not.toHaveClass("invisible");
     await user.tab(); // blur away
-    // Wait for hide timeout
-    await new Promise((r) => setTimeout(r, 200));
-    expect(screen.getByRole("tooltip", { hidden: true })).toHaveClass("invisible");
+    // Wait for hide timeout (150ms in component) to settle inside act()
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip", { hidden: true })).toHaveClass("invisible");
+    });
   });
 
   it("hides tooltip on Escape key", async () => {

--- a/src/__tests__/components/DecisionProvider.test.tsx
+++ b/src/__tests__/components/DecisionProvider.test.tsx
@@ -196,8 +196,8 @@ describe("DecisionProvider", () => {
 
     // First burst
     act(() => result.current.updateTitle("First"));
-    // Advance time past the coalesce window
-    vi.advanceTimersByTime(600);
+    // Advance time past the coalesce window (wrapped in act to flush timers)
+    act(() => vi.advanceTimersByTime(600));
     // Second burst
     act(() => result.current.updateTitle("Second"));
 

--- a/src/__tests__/hooks/useAuth.test.ts
+++ b/src/__tests__/hooks/useAuth.test.ts
@@ -80,14 +80,20 @@ describe("useAuth", () => {
     expect(mockSignOut).not.toHaveBeenCalled();
   });
 
-  it("sets loading=true initially when cloud is enabled", () => {
+  it("sets loading=true initially when cloud is enabled", async () => {
     vi.mocked(isCloudEnabled).mockReturnValue(true);
     vi.mocked(getSupabase).mockReturnValue(mockSupabaseClient as never);
 
-    const { result } = renderHook(() => useAuth());
+    const { result, unmount } = renderHook(() => useAuth());
 
     expect(result.current.cloudEnabled).toBe(true);
     expect(result.current.loading).toBe(true);
+
+    // Wait for async getSession effect to settle, then unmount to avoid act() warning
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    unmount();
   });
 
   it("fetches session on mount when cloud is enabled", async () => {

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -60,4 +60,17 @@ describe("formatRelativeTime", () => {
     const fiveDaysAgo = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
     expect(formatRelativeTime(fiveDaysAgo)).toBe("5d ago");
   });
+
+  it("returns Xs ago for seconds-old timestamps (10-59s)", () => {
+    const thirtySecAgo = new Date(Date.now() - 30 * 1000).toISOString();
+    expect(formatRelativeTime(thirtySecAgo)).toBe("30s ago");
+  });
+
+  it("returns absolute date for timestamps older than 30 days", () => {
+    const fortyFiveDaysAgo = new Date(Date.now() - 45 * 24 * 60 * 60 * 1000);
+    const result = formatRelativeTime(fortyFiveDaysAgo.toISOString());
+    // Should be a locale-formatted date string (e.g. "May 1, 2025"), not "Xd ago"
+    expect(result).not.toContain("d ago");
+    expect(result).toMatch(/\d{4}/); // contains a 4-digit year
+  });
 });


### PR DESCRIPTION
## Summary

Closes #242

### React `act()` warnings fixed (3)

| Test file | Fix |
|---|---|
| `CriterionTooltip.test.tsx` | Replaced raw `setTimeout(200)` with `waitFor()` for blur hide timeout |
| `DecisionProvider.test.tsx` | Wrapped `vi.advanceTimersByTime(600)` in `act()` |
| `useAuth.test.ts` | Awaited async `getSession` effect with `waitFor` + `unmount` cleanup |

### Coverage gaps closed (2 tests)

| Branch | Test |
|---|---|
| `formatRelativeTime` seconds-ago (10-59s) | `30s ago` assertion |
| `formatRelativeTime` >30d absolute date | Verifies locale-formatted date with year |

### Results

- **1661 tests** (was 1659), all passing
- **utils.ts**: 100% branch coverage (was 92.85%)
- **Overall branches**: 92.70% (was 92.63%)
- `tsc --noEmit`: 0 errors
- Zero React `act()` warnings in test output